### PR TITLE
58 create payload factory

### DIFF
--- a/spec/factories/event_payloads.rb
+++ b/spec/factories/event_payloads.rb
@@ -1,0 +1,107 @@
+FactoryBot.define do
+  factory :user_payload, class: Hash do
+    id      { 1 }
+    node_id { 'MDQ6NlcjE4' }
+    login   { 'heptacat' }
+    type    { 'User' }
+
+    initialize_with do
+      {
+          id: id,
+          node_id: node_id,
+          login: login,
+          type: type
+        }.deep_stringify_keys
+    end
+  end
+
+  factory :repository_payload, class: Hash do
+    id        { 186853002 }
+    node_id   { 'MDEwOlJlcG9zaXRvcnkxODY4NTMwMDI=' }
+    name      { 'Pull Hello-World' }
+    full_name { 'Codertocat/Hello-World' }
+
+    association :pull_request_owner, factory: :user_payload,
+      id: 21031067, node_id: 'MDQ6VXNlcjIxMDMxMDY3', login: 'Codertocat'
+
+    initialize_with do
+      {
+          id: id,
+          node_id: node_id,
+          name: name,
+          full_name: full_name,
+          owner: pull_request_owner
+        }.deep_stringify_keys
+    end
+  end
+
+  factory :pull_request_payload, class: Hash do
+    id      { 1001 }
+    number  { 2 }
+    state   { 'open' }
+    node_id { 'MDExOlB1bGxSZXF1ZXN0Mjc5MTQ3NDM3' }
+    title   { 'Pull Request 2' }
+    locked  { false }
+    merged  { false }
+    draft   { false }
+
+    association :pull_request_owner, factory: :user_payload,
+      id: 21031067, node_id: 'MDQ6VXNlcjIxMDMxMDY3', login: 'Codertocat'
+
+    association :repository, factory: :repository_payload
+
+    initialize_with do
+      {
+          id: id,
+          number: number,
+          state: state,
+          node_id: node_id,
+          title: title,
+          locked: locked,
+          merged: merged,
+          draft: draft,
+          user: pull_request_owner,
+          repository: repository
+        }.deep_stringify_keys
+    end
+  end
+
+  factory :pull_request_review_payload, class: Hash do
+    action { 'submitted' }
+    id { 237895671 }
+    node_id { 'MDE3OlB1bGxSZXF1ZXN0UmV2aWV3MjM3ODk1Njcx' }
+    state { 'commented' }
+
+    association :review_owner, factory: :user_payload,
+      id: 21031067, node_id: 'MDQ6VXNlcjIxMDMxMDY3', login: 'Codertocat'
+
+    association :pull_request, factory: :pull_request_payload
+
+    association :repository, factory: :repository_payload
+
+    trait :submitted do
+        action { 'submitted' }
+    end
+    trait :edited do
+        action { 'edited' }
+    end
+    trait :dismissed do
+        action { 'dismissed' }
+    end
+
+    initialize_with do
+      {
+        action: action,
+        state: state,
+        review: {
+          id: id,
+          node_id: node_id,
+          user: review_owner
+        },
+        pull_request: pull_request,
+        repository: repository,
+        requested_reviewer: requested_reviewer
+      }.deep_stringify_keys
+    end
+  end
+end

--- a/spec/factories/event_payloads.rb
+++ b/spec/factories/event_payloads.rb
@@ -72,6 +72,29 @@ FactoryBot.define do
     end
   end
 
+  factory :pull_request_review_comment_payload, class: Hash do
+    id { 1001 }
+    node_id { 'MDExOlB1bGxSZXF1ZXN0Mjc5MTQ3NDM3' }
+    pull_request_review_id { 1002 }
+    body { 'You might need to fix this.' }
+
+    association :comment_owner,
+                factory: :user_payload,
+                id: 21_031_067,
+                node_id: 'MDQ6VXNlcjIxMDMxMDY3',
+                login: 'Codertocat'
+
+    initialize_with do
+      {
+        id: id,
+        node_id: node_id,
+        pull_request_review_id: pull_request_review_id,
+        user: comment_owner,
+        body: body
+      }.deep_stringify_keys
+    end
+  end
+
   factory :repository_event_payload, class: Hash do
     action { 'created' }
 
@@ -143,6 +166,25 @@ FactoryBot.define do
         },
         pull_request: pull_request,
         repository: repository
+      }.deep_stringify_keys
+    end
+  end
+
+  factory :pull_request_review_comment_event_payload, class: Hash do
+    action { 'created' }
+
+    association :comment, factory: :pull_request_review_comment_payload
+
+    association :pull_request, factory: :pull_request_payload
+
+    changes { { body: 'Please fix this.' } }
+
+    initialize_with do
+      {
+        action: action,
+        comment: comment,
+        pull_request: pull_request,
+        changes: changes
       }.deep_stringify_keys
     end
   end

--- a/spec/factories/event_payloads.rb
+++ b/spec/factories/event_payloads.rb
@@ -66,7 +66,26 @@ FactoryBot.define do
     end
   end
 
-  factory :pull_request_review_payload, class: Hash do
+  factory :pull_request_event_payload, class: Hash do
+    action { 'opened' }
+    number { 2 }
+
+    requested_reviewer { nil }
+
+    association :pull_request, factory: :pull_request_payload
+
+    initialize_with do
+      {
+        action: action,
+        number: number,
+        pull_request: pull_request,
+      }.tap do |payload|
+        payload['requested_reviewer'] = requested_reviewer unless requested_reviewer.nil?
+      end.deep_stringify_keys
+    end
+  end
+
+  factory :pull_request_review_event_payload, class: Hash do
     action { 'submitted' }
     id { 237895671 }
     node_id { 'MDE3OlB1bGxSZXF1ZXN0UmV2aWV3MjM3ODk1Njcx' }
@@ -82,9 +101,11 @@ FactoryBot.define do
     trait :submitted do
         action { 'submitted' }
     end
+
     trait :edited do
         action { 'edited' }
     end
+
     trait :dismissed do
         action { 'dismissed' }
     end
@@ -100,7 +121,6 @@ FactoryBot.define do
         },
         pull_request: pull_request,
         repository: repository,
-        requested_reviewer: requested_reviewer
       }.deep_stringify_keys
     end
   end

--- a/spec/factories/event_payloads.rb
+++ b/spec/factories/event_payloads.rb
@@ -1,37 +1,40 @@
 FactoryBot.define do
   factory :user_payload, class: Hash do
-    id      { 1 }
+    id { 1 }
     node_id { 'MDQ6NlcjE4' }
-    login   { 'heptacat' }
-    type    { 'User' }
+    login { 'heptacat' }
+    type { 'User' }
 
     initialize_with do
       {
-          id: id,
-          node_id: node_id,
-          login: login,
-          type: type
-        }.deep_stringify_keys
+        id: id,
+        node_id: node_id,
+        login: login,
+        type: type
+      }.deep_stringify_keys
     end
   end
 
   factory :repository_payload, class: Hash do
-    id        { 186853002 }
-    node_id   { 'MDEwOlJlcG9zaXRvcnkxODY4NTMwMDI=' }
-    name      { 'Pull Hello-World' }
+    id { 186_853_002 }
+    node_id { 'MDEwOlJlcG9zaXRvcnkxODY4NTMwMDI=' }
+    name { 'Pull Hello-World' }
     full_name { 'Codertocat/Hello-World' }
 
-    association :pull_request_owner, factory: :user_payload,
-      id: 21031067, node_id: 'MDQ6VXNlcjIxMDMxMDY3', login: 'Codertocat'
+    association :pull_request_owner,
+                factory: :user_payload,
+                id: 21_031_067,
+                node_id: 'MDQ6VXNlcjIxMDMxMDY3',
+                login: 'Codertocat'
 
     initialize_with do
       {
-          id: id,
-          node_id: node_id,
-          name: name,
-          full_name: full_name,
-          owner: pull_request_owner
-        }.deep_stringify_keys
+        id: id,
+        node_id: node_id,
+        name: name,
+        full_name: full_name,
+        owner: pull_request_owner
+      }.deep_stringify_keys
     end
   end
 
@@ -45,24 +48,40 @@ FactoryBot.define do
     merged  { false }
     draft   { false }
 
-    association :pull_request_owner, factory: :user_payload,
-      id: 21031067, node_id: 'MDQ6VXNlcjIxMDMxMDY3', login: 'Codertocat'
+    association :pull_request_owner,
+                factory: :user_payload,
+                id: 21_031_067,
+                node_id: 'MDQ6VXNlcjIxMDMxMDY3',
+                login: 'Codertocat'
 
     association :repository, factory: :repository_payload
 
     initialize_with do
       {
-          id: id,
-          number: number,
-          state: state,
-          node_id: node_id,
-          title: title,
-          locked: locked,
-          merged: merged,
-          draft: draft,
-          user: pull_request_owner,
-          repository: repository
-        }.deep_stringify_keys
+        id: id,
+        number: number,
+        state: state,
+        node_id: node_id,
+        title: title,
+        locked: locked,
+        merged: merged,
+        draft: draft,
+        user: pull_request_owner,
+        repository: repository
+      }.deep_stringify_keys
+    end
+  end
+
+  factory :repository_event_payload, class: Hash do
+    action { 'created' }
+
+    association :repository, factory: :repository_payload
+
+    initialize_with do
+      {
+        action: action,
+        repository: repository
+      }.deep_stringify_keys
     end
   end
 
@@ -78,36 +97,39 @@ FactoryBot.define do
       {
         action: action,
         number: number,
-        pull_request: pull_request,
-      }.tap do |payload|
+        pull_request: pull_request
+      }.tap { |payload|
         payload['requested_reviewer'] = requested_reviewer unless requested_reviewer.nil?
-      end.deep_stringify_keys
+      }.deep_stringify_keys
     end
   end
 
   factory :pull_request_review_event_payload, class: Hash do
     action { 'submitted' }
-    id { 237895671 }
+    id { 237_895_671 }
     node_id { 'MDE3OlB1bGxSZXF1ZXN0UmV2aWV3MjM3ODk1Njcx' }
     state { 'commented' }
 
-    association :review_owner, factory: :user_payload,
-      id: 21031067, node_id: 'MDQ6VXNlcjIxMDMxMDY3', login: 'Codertocat'
+    association :review_owner,
+                factory: :user_payload,
+                id: 21_031_067,
+                node_id: 'MDQ6VXNlcjIxMDMxMDY3',
+                login: 'Codertocat'
 
     association :pull_request, factory: :pull_request_payload
 
     association :repository, factory: :repository_payload
 
     trait :submitted do
-        action { 'submitted' }
+      action { 'submitted' }
     end
 
     trait :edited do
-        action { 'edited' }
+      action { 'edited' }
     end
 
     trait :dismissed do
-        action { 'dismissed' }
+      action { 'dismissed' }
     end
 
     initialize_with do
@@ -120,7 +142,7 @@ FactoryBot.define do
           user: review_owner
         },
         pull_request: pull_request,
-        repository: repository,
+        repository: repository
       }.deep_stringify_keys
     end
   end

--- a/spec/models/events/pull_request_spec.rb
+++ b/spec/models/events/pull_request_spec.rb
@@ -27,12 +27,12 @@ require 'rails_helper'
 RSpec.describe Events::PullRequest, type: :model do
   let(:requested_reviewer) do
     build :user_payload,
-      id: 1004, node_id: 'MDExOlB1bGxc5MTQ3NDM3', login: 'octocat'
+          id: 1004,
+          node_id: 'MDExOlB1bGxc5MTQ3NDM3',
+          login: 'octocat'
   end
 
-  let(:raw_payload) do
-    build :pull_request_event_payload, requested_reviewer: requested_reviewer
-  end
+  let(:raw_payload) { build :pull_request_event_payload, requested_reviewer: requested_reviewer }
 
   context 'validations' do
     subject { build :pull_request }

--- a/spec/models/events/pull_request_spec.rb
+++ b/spec/models/events/pull_request_spec.rb
@@ -25,29 +25,13 @@
 require 'rails_helper'
 
 RSpec.describe Events::PullRequest, type: :model do
+  let(:requested_reviewer) do
+    build :user_payload,
+      id: 1004, node_id: 'MDExOlB1bGxc5MTQ3NDM3', login: 'octocat'
+  end
+
   let(:raw_payload) do
-    {
-      pull_request: {
-        id: 1001,
-        number: 2,
-        state: 'open',
-        node_id: 'MDExOlB1bGxSZXF1ZXN0Mjc5MTQ3NDM3',
-        title: 'Pull Request 2',
-        locked: false,
-        merged: false,
-        draft: false,
-        user: {
-          node_id: 'MDQ6NlcjE4',
-          login: 'heptacat',
-          id: 1006
-        }
-      },
-      requested_reviewer: {
-        node_id: 'MDExOlB1bGxc5MTQ3NDM3',
-        login: 'octocat',
-        id: 1004
-      }
-    }.deep_stringify_keys
+    build :pull_request_event_payload, requested_reviewer: requested_reviewer
   end
 
   context 'validations' do

--- a/spec/models/events/review_comment_spec.rb
+++ b/spec/models/events/review_comment_spec.rb
@@ -32,30 +32,11 @@ RSpec.describe Events::ReviewComment, type: :model do
   describe 'actions' do
     subject { create :review_comment, payload: payload }
 
-    let(:payload) do
-      {
-        action: 'created',
-        comment: {
-          pull_request_review_id: 237_895_671,
-          id: 284_312_630,
-          user: {
-            login: 'Codertocat',
-            id: 21_031_067,
-            node_id: 'MDQ6VXNlcjIxMDMxMDY3'
-          },
-          body: 'You might need to fix this.'
-        },
-        pull_request: {
-          id: 279_147_437
-        },
-        changes: {
-          body: 'Please fix this.'
-        }
-      }.deep_stringify_keys
-    end
+    let(:payload) { build :pull_request_review_comment_event_payload }
 
     describe '#find_or_create_review_comment' do
       subject { build :review_comment }
+
       before { create :pull_request, github_id: payload['pull_request']['id'] }
 
       it 'creates a review comment' do

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -31,7 +31,8 @@ RSpec.describe Project, type: :model do
   end
 
   context '#resolve' do
-    let(:payload) { { repository: { name: 'rs-code-review-metrics', id: 1 } }.deep_stringify_keys }
+    let(:repository_payload) { build :repository_payload, name: 'rs-code-review-metrics', id: 1 }
+    let(:payload) { build :repository_event_payload, repository: repository_payload }
 
     it 'creates a project' do
       allow_any_instance_of(Event).to receive(:resolve)


### PR DESCRIPTION
## What does this PR do?

Implement task [58-Create a spec/factory to create GitHub event payloads](https://github.com/rootstrap/rs-code-review-metrics/issues/58)

### Details

This PR creates a factory to generate the Github Webhooks payloads templates for the tests.

These payloads are json objects and the tests of the process that generates metrics will likely create and use several these payload templates during its tests.