### PR TITLE
Implement the Rake task to process the ReviewTurnaround metrics

### DIFF
--- a/app/jobs/process_metrics_job.rb
+++ b/app/jobs/process_metrics_job.rb
@@ -13,6 +13,7 @@ class ProcessMetricsJob < ApplicationJob
   #
   # It takes care of processing only the metrics that are pending to be
   # processed.
-  def perform()
+  def perform
+    # todo
   end
 end

--- a/app/jobs/process_metrics_job.rb
+++ b/app/jobs/process_metrics_job.rb
@@ -1,0 +1,18 @@
+##
+# This job processes the Github events previously stored, generates the
+# metrics and leaves them in a ready to use state.
+#
+# Implementation note: this PR just creates the job placeholder. The job is
+# be implemented in a different PR.
+class ProcessMetricsJob < ApplicationJob
+  queue_as :default
+
+  ##
+  # Does the processing of the Github events previously stored and leaves them
+  # generated metrics in the metrics table.
+  #
+  # It takes care of processing only the metrics that are pending to be
+  # processed.
+  def perform()
+  end
+end

--- a/lib/tasks/metrics.rake
+++ b/lib/tasks/metrics.rake
@@ -1,0 +1,12 @@
+##
+# The namespace used by the tasks that handles the Github event metrics.
+#
+# Call the task from the command line with
+#
+#       rake metrics:process
+namespace :metrics do
+  desc 'Processes the stored events and generates the all the metrics'
+  task process: :environment do
+    ProcessMetricsJob.new.perform
+  end
+end

--- a/spec/lib/metrics_process_spec.rb
+++ b/spec/lib/metrics_process_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+require 'rake'
+
+RSpec.describe 'running the rake task metrics:process' do
+  before do
+    Rake.application.rake_require 'tasks/metrics'
+    Rake::Task.define_task(:environment)
+  end
+
+  it 'creates a ProcessMetricsJob and invokes it' do
+    expect {
+      Rake.application.invoke_task 'metrics:process'
+    } .to satisfy proc {
+      expect_any_instance_of(ProcessMetricsJob).to receive(:perform).once
+    }
+  end
+end


### PR DESCRIPTION
## What does this PR do?

Implements the Rake task

`rake metrics:process`

that creates a ProcessMetricsJob and evaluates it.

This PR does not implement the ProcessMetricsJob, it only implements the Rake task.

The implementation of the ProcessMetricsJob is to be done in a different PR.