### PR TITLE
Changed organization to @rootstrap/ruby-on-rails

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-@Rootstrap/hdamico @Rootstrap/santiagovidal @Rootstrap/santib @Rootstrap/mrubi-rootstrap @Rootstrap/horacio
+@rootstrap/ruby-on-rails/hdamico @rootstrap/ruby-on-rails/santiagovidal @rootstrap/ruby-on-rails/santib @rootstrap/ruby-on-rails/mrubi-rootstrap @rootstrap/ruby-on-rails/horacio

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-@rootstrap/ruby-on-rails/hdamico @rootstrap/ruby-on-rails/santiagovidal @rootstrap/ruby-on-rails/santib @rootstrap/ruby-on-rails/mrubi-rootstrap @rootstrap/ruby-on-rails/horacio
+* @rootstrap/ruby-on-rails/hdamico @rootstrap/ruby-on-rails/santiagovidal @rootstrap/ruby-on-rails/santib @rootstrap/ruby-on-rails/mrubi-rootstrap @rootstrap/ruby-on-rails/horacio


### PR DESCRIPTION
## What does this PR do?

Changes the file CODEOWNERS to the users organisation team @rootstrap/ruby-on-rails.