### PR TITLE
Delete team from CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @rootstrap/ruby-on-rails/hdamico @rootstrap/ruby-on-rails/santiagovidal @rootstrap/ruby-on-rails/santib @rootstrap/ruby-on-rails/mrubi-rootstrap @rootstrap/ruby-on-rails/horacio
+* @rootstrap/hdamico @rootstrap/santiagovidal @rootstrap/santib @rootstrap/mrubi-rootstrap @rootstrap/horacio

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,6 @@
-* @rootstrap/hdamico @rootstrap/santiagovidal @rootstrap/santib @rootstrap/mrubi-rootstrap @rootstrap/horacio
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @global-owner1 and @global-owner2 will be requested for
+# review when someone opens a pull request.
+
+* @hdamico @santiagovidal @santib @mrubi-rootstrap @horacio


### PR DESCRIPTION
## What does this PR do?

Deletes the team from CODEOWNERS.
After reading the documentation I realize that the only way to make it work with team you have to add this repository to the team and give read access to it, otherwise this won't work, so I kept only the user, in this way there are no permission problems.

