### PR TITLE
Fix flaky tests

### DIFF
--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -19,6 +19,8 @@
 #
 
 FactoryBot.define do
+  sequence(:body) { |n| "Please change line #{n}" }
+
   factory :event do
     name { %w[pull_request review review_comment].sample }
     data { Faker::Json.shallow_json(width: 3) }

--- a/spec/factories/events/pull_requests.rb
+++ b/spec/factories/events/pull_requests.rb
@@ -23,8 +23,10 @@
 #
 
 FactoryBot.define do
+  sequence(:pull_request_id, 100)
+
   factory :pull_request, class: Events::PullRequest do
-    github_id { Faker::Number.unique.number(digits: 4) }
+    github_id { generate(:pull_request_id) }
     number { Faker::Number.number(digits: 1) }
     title { "Pull Request-#{Faker::Number.number(digits: 1)}" }
     node_id { "#{Faker::Alphanumeric.alphanumeric}=" }

--- a/spec/factories/events/review_comments.rb
+++ b/spec/factories/events/review_comments.rb
@@ -23,9 +23,11 @@
 #
 
 FactoryBot.define do
+  sequence(:review_comment_id, 100)
+
   factory :review_comment, class: Events::ReviewComment do
-    github_id { Faker::Number.unique.number(digits: 4) }
-    body { Faker::Quote.singular_siegler }
+    github_id { generate(:review_comment_id) }
+    body { generate(:body) }
 
     association :pull_request, strategy: :build
     association :owner, factory: :user, strategy: :build

--- a/spec/factories/events/review_comments.rb
+++ b/spec/factories/events/review_comments.rb
@@ -27,7 +27,7 @@ FactoryBot.define do
 
   factory :review_comment, class: Events::ReviewComment do
     github_id { generate(:review_comment_id) }
-    body { generate(:body) }
+    body
 
     association :pull_request, strategy: :build
     association :owner, factory: :user, strategy: :build

--- a/spec/factories/events/reviews.rb
+++ b/spec/factories/events/reviews.rb
@@ -23,8 +23,10 @@
 #
 
 FactoryBot.define do
+  sequence(:review_id, 100)
+
   factory :review, class: Events::Review do
-    github_id { Faker::Number.unique.number(digits: 4) }
+    github_id { generate(:review_id) }
 
     association :pull_request, strategy: :build
     association :owner, factory: :user, strategy: :build

--- a/spec/factories/events/reviews.rb
+++ b/spec/factories/events/reviews.rb
@@ -30,7 +30,6 @@ FactoryBot.define do
     github_id { generate(:review_id) }
     state { %w[approved commented changes_requested].sample }
 
-
     association :pull_request, strategy: :build
     association :owner, factory: :user, strategy: :build
   end

--- a/spec/factories/events/reviews.rb
+++ b/spec/factories/events/reviews.rb
@@ -25,7 +25,7 @@
 
 FactoryBot.define do
   sequence(:review_id, 100)
-  sequence(:review_state) { |n| Events::Review.states.values[n%2] }
+  sequence(:review_state) { |n| Events::Review.states.values[n % 2] }
 
   factory :review, class: Events::Review do
     github_id { generate(:review_id) }

--- a/spec/factories/events/reviews.rb
+++ b/spec/factories/events/reviews.rb
@@ -25,10 +25,11 @@
 
 FactoryBot.define do
   sequence(:review_id, 100)
+  sequence(:review_state) { |n| Events::Review.states.values[n%2] }
 
   factory :review, class: Events::Review do
     github_id { generate(:review_id) }
-    state { %w[approved commented changes_requested].sample }
+    state { generate(:review_state) }
 
     association :pull_request, strategy: :build
     association :owner, factory: :user, strategy: :build

--- a/spec/factories/payloads/pull_request.rb
+++ b/spec/factories/payloads/pull_request.rb
@@ -3,20 +3,22 @@ FactoryBot.define do
     skip_create
     pull_request do
       {
-        id: Faker::Number.unique.number(digits: 4),
+        id: generate(:pull_request_id),
         number: Faker::Number.number(digits: 1),
         title: "Pull Request-#{Faker::Number.number(digits: 1)}",
         node_id: "#{Faker::Alphanumeric.alphanumeric}=",
         state: 'open',
         locked: 'false',
         draft: 'false',
-        user: (attributes_for :user, id: Faker::Number.unique.number(digits: 2)).as_json
+        user: (attributes_for :user, id: generate(:user_id)).as_json
       }
     end
-    requested_reviewer { (attributes_for :review_request, id: Faker::Number.unique.number).as_json }
+    requested_reviewer do
+      (attributes_for :review_request, id: generate(:review_request_id)).as_json
+    end
     initialize_with { attributes.deep_stringify_keys }
 
-    factory :pull_request_payload_with_repository do
+    factory :full_pull_request_payload do
       after(:create) do |pull_request_payload|
         pull_request_payload.merge!((create :repository_payload))
       end

--- a/spec/factories/payloads/repository.rb
+++ b/spec/factories/payloads/repository.rb
@@ -1,9 +1,10 @@
+# Project payload
 FactoryBot.define do
   factory :repository_payload, class: Hash do
     skip_create
     repository do
       {
-        id: Faker::Number.number(digits: 4),
+        id: generate(:project_id),
         name: Faker::App.name,
         description: ''
       }

--- a/spec/factories/payloads/review.rb
+++ b/spec/factories/payloads/review.rb
@@ -3,14 +3,14 @@ FactoryBot.define do
     skip_create
     review do
       {
-        id: Faker::Number.number(digits: 4),
-        body: Faker::Quote.singular_siegler,
-        user: (attributes_for :user, id: Faker::Number.number).as_json
+        id: generate(:review_id),
+        body: generate(:body),
+        user: (attributes_for :user, id: generate(:user_id)).as_json
       }
     end
     changes do
       {
-        body: Faker::Quote.singular_siegler
+        body: generate(:body)
       }
     end
     initialize_with { attributes.deep_stringify_keys }

--- a/spec/factories/payloads/review.rb
+++ b/spec/factories/payloads/review.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
         id: generate(:review_id),
         body: generate(:body),
         user: (attributes_for :user, id: generate(:user_id)).as_json,
-        state: %w[approved commented changes_requested].sample
+        state: generate(:review_state)
       }
     end
     changes do

--- a/spec/factories/payloads/review_comment.rb
+++ b/spec/factories/payloads/review_comment.rb
@@ -3,14 +3,14 @@ FactoryBot.define do
     skip_create
     comment do
       {
-        id: Faker::Number.number(digits: 4),
-        body: Faker::Quote.singular_siegler,
-        user: (attributes_for :user, id: Faker::Number.number).as_json
+        id: generate(:review_comment_id),
+        body: generate(:body),
+        user: (attributes_for :user, id: generate(:user_id)).as_json
       }
     end
     changes do
       {
-        body: Faker::Quote.singular_siegler
+        body: generate(:body)
       }
     end
     initialize_with { attributes.deep_stringify_keys }

--- a/spec/factories/projects.rb
+++ b/spec/factories/projects.rb
@@ -12,8 +12,10 @@
 #
 
 FactoryBot.define do
+  sequence(:project_id, 100)
+
   factory :project do
-    github_id { Faker::Number.unique.number(digits: 4) }
+    github_id { generate(:project_id) }
     name { Faker::App.name }
     description { Faker::FunnyName.name }
     lang { %w[ruby python nodejs react ios android others unassigned].sample }

--- a/spec/factories/review_request.rb
+++ b/spec/factories/review_request.rb
@@ -1,4 +1,6 @@
 FactoryBot.define do
+  sequence(:review_request_id, 100)
+
   factory :review_request do
     status { %w[active removed].sample }
     login { "octocat#{Faker::Number.number}" }

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -15,8 +15,10 @@
 #
 
 FactoryBot.define do
+  sequence(:user_id, 100)
+
   factory :user do
-    github_id { Faker::Number.unique.number(digits: 4) }
+    github_id { generate(:user_id) }
     login { "octocat#{Faker::Number.number}" }
     node_id { "#{Faker::Alphanumeric.alphanumeric}=" }
   end

--- a/spec/services/github_service_spec.rb
+++ b/spec/services/github_service_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe GithubService do
 
   describe 'events' do
     context 'pull request' do
-      let!(:payload) { (create :pull_request_payload_with_repository) }
+      let!(:payload) { (create :full_pull_request_payload) }
       let!(:event) { 'pull_request' }
       let(:pull_request) { create :pull_request, github_id: payload['pull_request']['id'] }
 


### PR DESCRIPTION
## What does this PR do?

Fixes flaky tests. Currently, we are generating random data on key attributes, for example, `id` and `body`, which are causing random failures, so by adding `sequence` instead of `Faker` we avoid this.

Resolves #85 
