### PR TITLE
[hotfix] Memory Limit in project model

### DIFF
--- a/app/admin/projects.rb
+++ b/app/admin/projects.rb
@@ -1,4 +1,6 @@
 ActiveAdmin.register Project do
+  remove_filter :events
+
   index do
     id_column
     column :name


### PR DESCRIPTION
## What does this PR do?

removes event filter in admin project model because by default active admin does a query for every association that the model requested has.
