### PR TITLE
removes subject column from metrics_definions table

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,7 @@ group :development, :test do
   gem 'factory_bot_rails', '~> 5.1'
   gem 'rspec-collection_matchers', '~> 1.2.0'
   gem 'rspec-rails', '~> 3.9'
+  gem 'faker', '~> 2.10', '>= 2.10.2'
 end
 
 group :development do
@@ -75,7 +76,6 @@ group :test do
   gem 'capybara', '>= 2.15'
   gem 'selenium-webdriver'
   # Easy installation and use of web drivers to run system tests with browsers
-  gem 'faker', '~> 2.10', '>= 2.10.2'
   gem 'shoulda-matchers', '~> 4.2.0', require: false
   gem 'simplecov', require: false
   gem 'webdrivers'

--- a/app/models/metrics_definition.rb
+++ b/app/models/metrics_definition.rb
@@ -6,7 +6,6 @@
 #  last_processed_event_time :datetime
 #  metrics_name              :string           not null
 #  metrics_processor         :string           not null
-#  subject                   :string           not null
 #  time_interval             :string           not null
 #  created_at                :datetime         not null
 #  updated_at                :datetime         not null
@@ -14,14 +13,12 @@
 
 class MetricsDefinition < ApplicationRecord
   enum time_intervals: { all_times: 'all_times', daily: 'daily', weekly: 'weekly' }
-  enum subjects: { projects: 'projects', users: 'users', users_per_project: 'users_per_project' }
   TIME_INTERVALS = { daily: TimeIntervals::DailyInterval }.freeze
 
   has_many :metrics, dependent: :destroy
 
   validates :metrics_name, presence: true, length: { maximum: 255 }
   validates :time_interval, presence: true, inclusion: { in: time_intervals.keys }
-  validates :subject, presence: true, inclusion: { in: subjects.keys }
   validates :metrics_processor, presence: true
 
   ##

--- a/db/migrate/20200401200520_remove_subjects_from_metrics_definition.rb
+++ b/db/migrate/20200401200520_remove_subjects_from_metrics_definition.rb
@@ -1,0 +1,6 @@
+class RemoveSubjectsFromMetricsDefinition < ActiveRecord::Migration[6.0]
+  def change
+
+    remove_column :metrics_definitions, :subject, :string
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -215,7 +215,6 @@ CREATE TABLE public.metrics_definitions (
     id bigint NOT NULL,
     metrics_name character varying NOT NULL,
     time_interval character varying NOT NULL,
-    subject character varying NOT NULL,
     metrics_processor character varying NOT NULL,
     last_processed_event_time timestamp without time zone,
     created_at timestamp(6) without time zone NOT NULL,
@@ -952,6 +951,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20200312161141'),
 ('20200318125243'),
 ('20200318160321'),
-('20200318171820');
+('20200318171820'),
+('20200401200520');
 
 

--- a/spec/factories/metrics.rb
+++ b/spec/factories/metrics.rb
@@ -22,8 +22,8 @@
 
 FactoryBot.define do
   factory :metric do
-    entity_key { Faker::Name.unique }
-    metric_key { Faker::Name.unique }
+    entity_key { Faker::Name.unique.name }
+    metric_key { Faker::Name.unique.name }
     value { Faker::Number.number(digits: 4) }
     value_timestamp { Faker::Date.backward(days: 30) }
     association :metrics_definition

--- a/spec/factories/metrics_definitions.rb
+++ b/spec/factories/metrics_definitions.rb
@@ -6,7 +6,6 @@
 #  last_processed_event_time :datetime
 #  metrics_name              :string           not null
 #  metrics_processor         :string           not null
-#  subject                   :string           not null
 #  time_interval             :string           not null
 #  created_at                :datetime         not null
 #  updated_at                :datetime         not null
@@ -16,7 +15,6 @@ FactoryBot.define do
   factory :metrics_definition do
     metrics_name { Faker::IndustrySegments.unique }
     time_interval { MetricsDefinition.time_intervals.keys.sample }
-    subject { MetricsDefinition.subjects.keys.sample }
     metrics_processor { Metrics::NullProcessor }
     last_processed_event_time { nil }
   end

--- a/spec/models/metrics_definition_spec.rb
+++ b/spec/models/metrics_definition_spec.rb
@@ -6,7 +6,6 @@
 #  last_processed_event_time :datetime
 #  metrics_name              :string           not null
 #  metrics_processor         :string           not null
-#  subject                   :string           not null
 #  time_interval             :string           not null
 #  created_at                :datetime         not null
 #  updated_at                :datetime         not null
@@ -24,12 +23,6 @@ RSpec.describe MetricsDefinition, type: :model do
 
     it 'has a time_interval field' do
       expect(subject).to have_db_column(:time_interval)
-        .of_type(:string)
-        .with_options(null: false)
-    end
-
-    it 'has a subject field' do
-      expect(subject).to have_db_column(:subject)
         .of_type(:string)
         .with_options(null: false)
     end
@@ -53,9 +46,6 @@ RSpec.describe MetricsDefinition, type: :model do
 
     it { should validate_presence_of(:time_interval) }
     it { should validate_inclusion_of(:time_interval) .in_array(%w[all_times daily weekly]) }
-
-    it { should validate_presence_of(:subject) }
-    it { should validate_inclusion_of(:subject) .in_array(%w[projects users users_per_project]) }
 
     it { should validate_presence_of(:metrics_processor) }
   end

--- a/spec/services/metrics/metric_definition_time_intervals_processor_spec.rb
+++ b/spec/services/metrics/metric_definition_time_intervals_processor_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe Metrics::MetricDefinitionTimeIntervalsProcessor do
       create :metrics_definition,
              metrics_name: 'review_turnaround',
              time_interval: :daily,
-             subject: :projects,
              metrics_processor: Metrics::NullProcessor.name
 
       create :event_pull_request, occurred_at: Time.zone.now

--- a/spec/services/metrics/metrics_definition_processor_spec.rb
+++ b/spec/services/metrics/metrics_definition_processor_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe Metrics::MetricsDefinitionProcessor do
       create :metrics_definition,
              metrics_name: 'review_turnaround',
              time_interval: :daily,
-             subject: :projects,
              metrics_processor: Metrics::NullProcessor.name
     end
 

--- a/spec/services/metrics/time_intervals/daily_metrics_spec.rb
+++ b/spec/services/metrics/time_intervals/daily_metrics_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe Metrics::MetricDefinitionTimeIntervalsProcessor do
       create :metrics_definition,
              metrics_name: 'review_turnaround',
              time_interval: :daily,
-             subject: :projects,
              metrics_processor: Metrics::NullProcessor.name
 
       create :event_pull_request, occurred_at: Time.zone.now - 2.days


### PR DESCRIPTION
## What does this PR do?

* Removes the subject column from metrics_definitions table.
* Changes faker gem to develop group so it can be used to created dummy data in local
