### PR TITLE
Backfill technologies

### DIFF
--- a/app/models/technology.rb
+++ b/app/models/technology.rb
@@ -11,6 +11,8 @@
 class Technology < ApplicationRecord
   has_many :blog_posts, dependent: :nullify
 
+  validates :name, uniqueness: true
+
   def keywords
     keyword_string.split(',')
   end

--- a/app/services/processors/technologies_backfiller.rb
+++ b/app/services/processors/technologies_backfiller.rb
@@ -1,0 +1,25 @@
+module Processors
+  class TechnologiesBackfiller < BaseService
+    def call
+      init_attributes.each do |tech_attributes|
+        technology = Technology.find_or_initialize_by(name: tech_attributes[:name])
+        technology.keyword_string = tech_attributes[:keyword_string]
+        technology.save!
+      end
+    end
+
+    private
+
+    def init_attributes
+      [
+        { name: 'ruby', keyword_string: 'ruby,rails' },
+        { name: 'python', keyword_string: 'python,django' },
+        { name: 'ios', keyword_string: 'ios' },
+        { name: 'android', keyword_string: 'android' },
+        { name: 'react', keyword_string: 'react' },
+        { name: 'machine learning', keyword_string: 'machine learning' },
+        { name: 'other', keyword_string: '' }
+      ]
+    end
+  end
+end

--- a/lib/tasks/technologies.rake
+++ b/lib/tasks/technologies.rake
@@ -1,0 +1,12 @@
+##
+# The namespace used by the tasks that handles the Technologies for the blog metrics
+#
+# Call the task from the command line with
+#
+#       rake technologies:backfill
+namespace :technologies do
+  desc 'Backfills the DB with all the technologies needed'
+  task backfill: :environment do
+    Processors::TechnologiesBackfiller.call
+  end
+end

--- a/spec/lib/technologies_backfill_spec.rb
+++ b/spec/lib/technologies_backfill_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+require 'rake'
+
+RSpec.describe 'running the rake task technologies:backfill' do
+  let(:load_rake_technologies) do
+    Rake.application.rake_require 'tasks/technologies'
+    Rake::Task.define_task(:environment)
+  end
+
+  let(:rake_backfill_technologies) do
+    Rake.application.invoke_task 'technologies:backfill'
+  end
+
+  before do
+    load_rake_technologies
+  end
+
+  it 'calls the TechnologiesBackfiller processor' do
+    expect(Processors::TechnologiesBackfiller).to receive(:call)
+
+    rake_backfill_technologies
+  end
+end

--- a/spec/services/processors/technologies_backfiller_spec.rb
+++ b/spec/services/processors/technologies_backfiller_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+RSpec.describe Processors::TechnologiesBackfiller do
+  describe '.call' do
+    it 'creates all the needed technologies' do
+      described_class.call
+
+      all_technologies = Technology.pluck(:name)
+      expect(all_technologies).to include('ruby')
+      expect(all_technologies).to include('python')
+      expect(all_technologies).to include('ios')
+      expect(all_technologies).to include('android')
+      expect(all_technologies).to include('react')
+      expect(all_technologies).to include('machine learning')
+      expect(all_technologies).to include('other')
+    end
+
+    context 'when it has already been run' do
+      before { described_class.call }
+
+      it 'does not create new records' do
+        expect { described_class.call }.not_to change(Technology, :count)
+      end
+    end
+
+    context 'when the records in the DB have to be updated' do
+      before do
+        Technology.create!(name: 'ruby', keyword_string: 'an old keyword string')
+      end
+
+      it 'updates the outdated technologies' do
+        described_class.call
+
+        expect(Technology.find_by(name: 'ruby').keyword_string).to eq 'ruby,rails'
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What does this PR do?
It creates a rake task and an associated processor to backfill all the technologies we're gonna need.
- `TechnologiesBackfiller` is the processor in charge of backfilling all the required records in the technologies table
- `technologies.rake` is the new file where the task `technologies:backfill` has been added
