### PR TITLE
Fix requested reviewers creation flow

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -110,7 +110,10 @@ detectors:
     accept: []
   UncommunicativeVariableName:
     enabled: true
-    exclude: ['EventsProcessor#process']
+    exclude: [
+      'EventsProcessor#process',
+      'ActionHandlers::PullRequest#review_requested'
+    ]
     reject:
       - "/^.$/"
       - "/[0-9]$/"

--- a/app/models/review_request.rb
+++ b/app/models/review_request.rb
@@ -24,7 +24,7 @@
 #  fk_rails_...  (reviewer_id => users.id)
 #
 class ReviewRequest < ApplicationRecord
-  enum state: { active: 'active', removed: 'removed' }
+  enum state: { active: 'active', removed: 'removed', reviewed: 'reviewed' }
 
   belongs_to :owner, class_name: 'User',
                      foreign_key: :owner_id,
@@ -39,5 +39,5 @@ class ReviewRequest < ApplicationRecord
                      dependent: :destroy
 
   validates :state, inclusion: { in: states.keys }
-  validates :pull_request_id, uniqueness: { scope: %i[owner_id reviewer_id] }
+  validates :pull_request_id, uniqueness: { scope: %i[owner_id reviewer_id state] }
 end

--- a/app/models/review_request.rb
+++ b/app/models/review_request.rb
@@ -39,4 +39,5 @@ class ReviewRequest < ApplicationRecord
                      dependent: :destroy
 
   validates :state, inclusion: { in: states.keys }
+  validates :pull_request_id, uniqueness: { scope: %i[owner_id reviewer_id] }
 end

--- a/app/services/action_handlers/pull_request.rb
+++ b/app/services/action_handlers/pull_request.rb
@@ -34,8 +34,12 @@ module ActionHandlers
     def review_requested
       pr_data = @payload['pull_request']
       owner = find_or_create_user(pr_data['user'])
-      reviewer = find_or_create_user(pr_data['requested_reviewers'].first)
-      @entity.review_requests.create!(owner: owner, reviewer: reviewer)
+      pr_data['requested_reviewers'].each do |raw_reviewer|
+        reviewer = find_or_create_user(raw_reviewer)
+        @entity.review_requests.create!(owner: owner, reviewer: reviewer)
+      end
+    rescue ActiveRecord::RecordInvalid => e
+      raise unless e.message == 'Validation failed: Pull request has already been taken'
     end
   end
 end

--- a/app/services/action_handlers/pull_request.rb
+++ b/app/services/action_handlers/pull_request.rb
@@ -48,7 +48,6 @@ module ActionHandlers
       @entity.review_requests
              .includes(:owner)
              .where.not(reviewer: User.where(github_id: reviewers))
-             .where(owner: owner)
              .each(&:removed!)
     end
   end

--- a/app/services/action_handlers/pull_request.rb
+++ b/app/services/action_handlers/pull_request.rb
@@ -29,8 +29,7 @@ module ActionHandlers
       pr_data = @payload['pull_request']
       reviewers_github_id = pr_data['requested_reviewers'].map { |reviewer| reviewer['id'] }
       owner_github_id = pr_data['user']['id']
-      owner = User.find_by!(github_id: owner_github_id).id
-      remove_review_requests(owner, reviewers_github_id)
+      remove_review_requests(reviewers_github_id)
     end
 
     def review_requested
@@ -44,7 +43,7 @@ module ActionHandlers
       end
     end
 
-    def remove_review_requests(owner, reviewers)
+    def remove_review_requests(reviewers)
       @entity.review_requests
              .includes(:owner)
              .where.not(reviewer: User.where(github_id: reviewers))

--- a/app/services/action_handlers/pull_request.rb
+++ b/app/services/action_handlers/pull_request.rb
@@ -28,7 +28,6 @@ module ActionHandlers
     def review_request_removed
       pr_data = @payload['pull_request']
       reviewers_github_id = pr_data['requested_reviewers'].map { |reviewer| reviewer['id'] }
-      owner_github_id = pr_data['user']['id']
       remove_review_requests(reviewers_github_id)
     end
 

--- a/app/services/action_handlers/review.rb
+++ b/app/services/action_handlers/review.rb
@@ -11,6 +11,7 @@ module ActionHandlers
 
     # Sets state depending on the state that we receive from the payload
     def submitted
+      @entity.review_request.reviewed!
       @state = @payload['review']['state']
       return unless valid_state?
 

--- a/app/services/event_builder.rb
+++ b/app/services/event_builder.rb
@@ -13,15 +13,8 @@ class EventBuilder < BaseService
     Events::PullRequest.find_by!(github_id: @payload['pull_request']['id'])
   end
 
-  def find_or_create_review_request(pull_request, reviewer_id)
-    review_requests = pull_request.review_requests.where(reviewer_id: reviewer_id)
-    if review_requests.empty?
-      ReviewRequest.create!(owner: pull_request.owner,
-                            reviewer_id: reviewer_id,
-                            pull_request: pull_request)
-    else
-      review_requests.order(:created_at).first
-    end
+  def find_first_review_request(pull_request, reviewer_id)
+    pull_request.review_requests.where(reviewer_id: reviewer_id).order(:created_at).first
   end
 
   def find_or_create_user_project(project_id, user_id)

--- a/app/services/event_builders/review.rb
+++ b/app/services/event_builders/review.rb
@@ -17,7 +17,7 @@ module EventBuilders
     def assign_attrs(review, review_data)
       review.owner = find_or_create_user(review_data['user'])
       review.pull_request = find_pull_request
-      review.review_request = find_or_create_review_request(review.pull_request, review.owner.id)
+      review.review_request = find_first_review_request(review.pull_request, review.owner.id)
       review.project = Projects::Builder.call(@payload['repository'])
     end
   end

--- a/db/migrate/20200305171608_change_review_comments_status.rb
+++ b/db/migrate/20200305171608_change_review_comments_status.rb
@@ -11,7 +11,7 @@ class ChangeReviewCommentsStatus < ActiveRecord::Migration[6.0]
     remove_index :review_comments, :state
     remove_column :review_comments, :state
     execute <<-SQL
-      DROP TYPE review_request_state;
+      DROP TYPE review_comment_state;
     SQL
   end
 end

--- a/db/migrate/20200511180927_add_reviewed_state_review_requests.rb
+++ b/db/migrate/20200511180927_add_reviewed_state_review_requests.rb
@@ -1,0 +1,16 @@
+class AddReviewedStateReviewRequests < ActiveRecord::Migration[6.0]
+  def up
+    execute <<-SQL
+      ALTER TYPE review_request_state ADD VALUE 'reviewed';
+    SQL
+  end
+
+  def down
+    execute <<-SQL
+      ALTER TYPE review_request_state RENAME TO review_request_state_old;
+      CREATE TYPE review_request_state AS ENUM ('active', 'removed');
+      ALTER TABLE review_requests ALTER COLUMN name TYPE review_request_state USING name::text::review_request_state;
+      DROP TYPE review_request_state_old;
+    SQL
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -73,7 +73,8 @@ CREATE TYPE public.review_comment_state AS ENUM (
 
 CREATE TYPE public.review_request_state AS ENUM (
     'active',
-    'removed'
+    'removed',
+    'reviewed'
 );
 
 
@@ -1129,6 +1130,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20200423185715'),
 ('20200424155835'),
 ('20200504143532'),
-('20200507135524');
+('20200507135524'),
+('20200511180927');
 
 

--- a/lib/events_processor.rb
+++ b/lib/events_processor.rb
@@ -62,15 +62,8 @@ class EventsProcessor
       Events::PullRequest.find_by!(github_id: payload['pull_request']['id'])
     end
 
-    def find_or_create_review_request(pull_request, reviewer_id)
-      review_requests = pull_request.review_requests.where(reviewer_id: reviewer_id)
-      if review_requests.empty?
-        ReviewRequest.create!(owner: pull_request.owner,
-                              reviewer_id: reviewer_id,
-                              pull_request: pull_request)
-      else
-        review_requests.order(:created_at).first
-      end
+    def find_first_review_request(pull_request, reviewer_id)
+      pull_request.review_requests.where(reviewer_id: reviewer_id).order(:created_at).first
     end
 
     def find_or_create_user_project(project_id, user_id)

--- a/spec/factories/review_request.rb
+++ b/spec/factories/review_request.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   sequence(:review_request_id, 100)
 
   factory :review_request do
-    state { %w[active removed].sample }
+    state { 'active' }
 
     association :pull_request
     association :reviewer, factory: :user

--- a/spec/services/github_service_spec.rb
+++ b/spec/services/github_service_spec.rb
@@ -39,9 +39,23 @@ RSpec.describe GithubService do
         let!(:reviewer) do
           create :user, github_id: payload['pull_request']['requested_reviewers'].first['id']
         end
+        let!(:second_reviewer) do
+          create :user
+        end
+        let!(:owner) do
+          create :user, github_id: payload['pull_request']['user']['id']
+        end
         let!(:review_request) do
           create :review_request,
+                 owner: owner,
                  reviewer: reviewer,
+                 pull_request: pull_request
+        end
+
+        before do
+          create :review_request,
+                 owner: owner,
+                 reviewer: second_reviewer,
                  pull_request: pull_request
         end
 
@@ -92,7 +106,7 @@ RSpec.describe GithubService do
                changes: { body: 'new body contents' }
       end
       let(:event) { 'review' }
-      let(:review) { create :review, github_id: payload['review']['id'], state: 'commented' }
+      let(:review) { create :review, github_id: payload['review']['id'], state: 'approved' }
       let!(:user) { create :user, github_id: payload['review']['user']['id'] }
       let!(:pull_request) { create :pull_request, github_id: payload['pull_request']['id'] }
       let!(:review_request) do
@@ -101,12 +115,25 @@ RSpec.describe GithubService do
                reviewer_id: user.id
       end
 
-      it 'creates a review' do
-        expect { subject }.to change(Events::Review, :count).by(1)
-      end
+      context 'when submit a review' do
+        before { change_action_to('submitted') }
 
-      it 'sets state to commented' do
-        expect(review.state).to eq('commented')
+        it 'creates a review' do
+          expect { subject }.to change(Events::Review, :count).by(1)
+        end
+
+        it 'sets state to commented' do
+          payload_state = payload['review']['state']
+          expect {
+            subject
+          }.to change { review.reload.state }.from(review.state).to(payload_state)
+        end
+
+        it 'sets review state to reviewed' do
+          expect {
+            subject
+          }.to change { review_request.reload.state }.from(review_request.state).to('reviewed')
+        end
       end
 
       it 'edits body' do


### PR DESCRIPTION
## What does this PR do?

Fixes how requested reviewers are created. Now GitHub sends you all the reviewers at once and also, if there are CODEOWNERS repeats the payload on every code owner. So, this PR adds a validation in `ReviewRequest` where it can't be more than one `ReviewRequest` with the same `pull_request_id`, `owner_id` and `reviewer_id`, and also at the creation (`ActionHandlers::PullRequest#review_requested`) an iteration of every reviewer in the payload.

