### PR TITLE
[Weekly-metrics-v2]

### DIFF
--- a/app/jobs/weekly_metrics_job.rb
+++ b/app/jobs/weekly_metrics_job.rb
@@ -1,0 +1,7 @@
+class WeeklyMetricsJob < ApplicationJob
+  queue_as :weekly_metrics
+
+  def perform
+    Metrics::Weekly::AllMetrics.call
+  end
+end

--- a/app/models/metric.rb
+++ b/app/models/metric.rb
@@ -25,4 +25,8 @@ class Metric < ApplicationRecord
 
   validates :interval, inclusion: { in: intervals.keys }
   validates :name, inclusion: { in: names.keys }
+
+  scope :today_daily_metrics, lambda {
+    where(value_timestamp: Time.zone.today.all_day, interval: :daily)
+  }
 end

--- a/app/services/metrics/weekly/all_metrics.rb
+++ b/app/services/metrics/weekly/all_metrics.rb
@@ -1,0 +1,50 @@
+module Metrics
+  module Weekly
+    class AllMetrics < BaseService
+      def call
+        process
+      end
+
+      private
+
+      def process
+        Metric.today_daily_metrics.find_each do |daily_metric|
+          create_or_update(daily_metric)
+        end
+      end
+
+      def create_or_update(daily_metric)
+        metric = Metric.find_or_initialize_by(
+          ownable: daily_metric.ownable,
+          value_timestamp: week_range,
+          interval: :weekly,
+          name: daily_metric.name
+        )
+
+        value = metric_avg(daily_metric)
+        return metric.update!(value: value) if metric.persisted?
+
+        metric.value = value
+        metric.value_timestamp = current_time
+        metric.save!
+      end
+
+      def metric_avg(daily_metric)
+        Metric.where(
+          value_timestamp: week_range,
+          ownable: daily_metric.ownable,
+          interval: :daily,
+          name: daily_metric.name
+        ).average(:value)
+      end
+
+      def week_range
+        @week_range ||= current_time.beginning_of_week..current_time.end_of_week
+      end
+
+      def current_time
+        @current_time = Time.zone.now
+      end
+    end
+  end
+end

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -1,3 +1,7 @@
 metrics_generator:
   cron: '*/30 23 * * *'
   class: 'ProcessReviewTurnaroundMetricsJob'
+
+weekly_metrics:
+  cron: '50 23 * * 1-5'
+  class: 'WeeklyMetricsJob'

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -4,3 +4,4 @@ production:
   :concurrency: 10
 :queues:
   - default
+  - weekly_metrics

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -46,6 +46,7 @@ RSpec.configure do |config|
   # examples within a transaction, remove the following line or assign false
   # instead of true.
   config.use_transactional_fixtures = true
+  config.include ActiveSupport::Testing::TimeHelpers
 
   # RSpec Rails can automatically mix in different behaviours to your tests
   # based on their file location, for example enabling you to call `get` and

--- a/spec/services/metrics/weekly/all_metrics_spec.rb
+++ b/spec/services/metrics/weekly/all_metrics_spec.rb
@@ -1,0 +1,81 @@
+require 'rails_helper'
+
+RSpec.describe Metrics::Weekly::AllMetrics do
+  describe '.call' do
+    let(:user_project) { create(:users_project) }
+
+    before do
+      travel_to Time.zone.parse('2020-05-07')
+    end
+
+    let!(:current_time) { Time.zone.now }
+
+    context 'when processing diferent types of metrics' do
+      context 'and the last weekly metric is of a diferent type' do
+        let!(:daily_metric) do
+          create(:metric,
+                 interval: :daily,
+                 name: :blog_visits,
+                 ownable: user_project,
+                 value_timestamp: current_time)
+        end
+
+        before do
+          create(:metric,
+                 interval: :weekly,
+                 name: :review_turnaround,
+                 ownable: user_project,
+                 value_timestamp: current_time - 1.day)
+
+          create(:metric,
+                 interval: :daily,
+                 name: :review_turnaround,
+                 ownable: user_project,
+                 value_timestamp: current_time)
+        end
+
+        let(:metric) { Metric.last }
+
+        it 'creates a new metric with the respective daily metric type' do
+          described_class.call
+          expect(metric.name).to eq('blog_visits')
+        end
+
+        it 'changes the number of metrics created' do
+          expect { described_class.call }.to change { Metric.count }.from(3).to(4)
+        end
+
+        it 'creates a metric for the correct entity' do
+          described_class.call
+          expect(metric.ownable.id).to eq(daily_metric.ownable.id)
+        end
+      end
+
+      context 'and the last weekly metric is the same type' do
+        let!(:previous_metric) do
+          create(:metric,
+                 interval: :weekly,
+                 name: :review_turnaround,
+                 ownable: user_project,
+                 value_timestamp: current_time - 1.day)
+        end
+
+        before do
+          create(:metric,
+                 interval: :daily,
+                 name: :review_turnaround,
+                 ownable: user_project,
+                 value_timestamp: current_time)
+        end
+
+        it 'updates the previous metric' do
+          expect { described_class.call }.to change { previous_metric.reload.value }
+        end
+
+        it 'does not create a new one' do
+          expect { described_class.call }.not_to change { Metric.count }
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What does this PR do?

* process all daily metrics at the end of the day to create a weekly metric, this metric is being updated if a new daily metric for the same type is created.
* process all daily metrics independently of the entity and the type (name) of metric.
