### PR TITLE
Create helper to stub Wordpress API requests

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -33,7 +33,7 @@ detectors:
     exclude: []
   LongParameterList:
     enabled: true
-    exclude: ['WordpressApiHelper#stub_single_blog_post_response']
+    exclude: ['WordpressApiMocker#stub_single_blog_post_response']
     max_params: 4
     overrides:
       initialize:

--- a/.reek.yml
+++ b/.reek.yml
@@ -33,7 +33,7 @@ detectors:
     exclude: []
   LongParameterList:
     enabled: true
-    exclude: []
+    exclude: ['WordpressApiHelper#stub_single_blog_post_response']
     max_params: 4
     overrides:
       initialize:

--- a/spec/factories/blog_posts.rb
+++ b/spec/factories/blog_posts.rb
@@ -22,7 +22,7 @@
 #
 FactoryBot.define do
   factory :blog_post do
-    blog_id { 1111 }
+    blog_id { Faker::Number.number(digits: 4) }
     slug { 'ruby-is-awesome' }
     url { 'https://www.rotstrap.com/blog/ruby_is_awesome' }
     status { BlogPost.statuses[:publish] }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -79,4 +79,6 @@ RSpec.configure do |config|
   config.include Devise::Test::ControllerHelpers, type: :helper
   config.include Devise::Test::IntegrationHelpers, type: :request
   config.include Devise::Test::IntegrationHelpers, type: :feature
+
+  config.include WordpressApiHelper
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -80,5 +80,5 @@ RSpec.configure do |config|
   config.include Devise::Test::IntegrationHelpers, type: :request
   config.include Devise::Test::IntegrationHelpers, type: :feature
 
-  config.include WordpressApiHelper
+  config.include WordpressApiMocker
 end

--- a/spec/services/processors/blog_post_views_updater_spec.rb
+++ b/spec/services/processors/blog_post_views_updater_spec.rb
@@ -10,14 +10,9 @@ describe Processors::BlogPostViewsUpdater do
     let(:current_month_views) do
       blog_post_views_payload['years'][publish_date.year.to_s]['months'][publish_date.month.to_s]
     end
-    let(:api_service) { instance_double(WordpressService) }
 
     before do
-      allow_any_instance_of(described_class).to receive(:wordpress_service).and_return(api_service)
-      allow(api_service)
-        .to receive(:blog_post_views)
-        .with(blog_post.blog_id)
-        .and_return(blog_post_views_payload)
+      stub_blog_post_views_response(blog_post.blog_id, blog_post_views_payload)
     end
 
     it 'creates views metrics for the blog post' do

--- a/spec/services/processors/blog_posts_updater_spec.rb
+++ b/spec/services/processors/blog_posts_updater_spec.rb
@@ -2,15 +2,11 @@ require 'rails_helper'
 
 RSpec.describe Processors::BlogPostsUpdater do
   describe '.call' do
-    let(:api_service) { instance_double(WordpressService) }
-    let(:blog_post_payload) { [create(:blog_post_payload).with_indifferent_access] }
-
     subject { Processors::BlogPostsFullUpdater.call }
 
     before do
-      allow_any_instance_of(described_class).to receive(:wordpress_service).and_return(api_service)
-      allow(api_service).to receive(:blog_posts).and_return(blog_post_payload)
       create(:technology, name: 'other')
+      stub_blog_posts_response
     end
 
     it 'saves all blog posts in the db' do

--- a/spec/services/wordpress_service_spec.rb
+++ b/spec/services/wordpress_service_spec.rb
@@ -2,36 +2,15 @@ require 'rails_helper'
 
 RSpec.describe WordpressService do
   describe '#access_token' do
-    let(:client_id) { '11111' }
-    let(:client_secret) { 'qwerty' }
-    let(:username) { 'rootstrap@rootstrap.com' }
-    let(:password) { 'rootstrap' }
-    let(:request_params) do
-      {
-        client_id: ENV['WORDPRESS_CLIENT_ID'],
-        client_secret: ENV['WORDPRESS_CLIENT_SECRET'],
-        grant_type: 'password',
-        username: ENV['WORDPRESS_USERNAME'],
-        password: ENV['WORDPRESS_PASSWORD']
-      }
-    end
-
     subject { described_class.new.send(:access_token) }
 
     before do
-      stub_env('WORDPRESS_CLIENT_ID', client_id)
-      stub_env('WORDPRESS_CLIENT_SECRET', client_secret)
-      stub_env('WORDPRESS_USERNAME', username)
-      stub_env('WORDPRESS_PASSWORD', password)
-
-      stub_request(:post, 'https://public-api.wordpress.com/oauth2/token')
-        .with(body: request_params)
-        .to_return(body: token_response, status: response_status)
+      stub_access_token_response(response_body: token_response, response_status: response_status)
     end
 
     context 'when the request is successful' do
       let(:access_token) { 'asdf' }
-      let(:token_response) { JSON.generate(access_token: access_token) }
+      let(:token_response) { { access_token: access_token } }
       let(:response_status) { 200 }
 
       it 'returns the access token' do
@@ -40,14 +19,12 @@ RSpec.describe WordpressService do
     end
 
     context 'when the API fails to return an access token' do
-      let(:password) { 'invalid_password' }
-      let(:error_body) do
+      let(:token_response) do
         {
           'error': 'invalid_request',
           'error_description': 'Incorrect username or password.'
         }
       end
-      let(:token_response) { JSON.generate(error_body) }
       let(:response_status) { 400 }
 
       it 'raises an exception' do
@@ -57,27 +34,10 @@ RSpec.describe WordpressService do
   end
 
   describe '#blog_posts' do
-    let(:access_token) { 'asdf' }
-    let(:authorization_header) { { 'Authorization': "Bearer #{access_token}" } }
     let(:blog_post) { create(:blog_post_payload) }
-    let(:blog_posts_response) do
-      JSON.generate(
-        'posts': [blog_post],
-        'found': 1
-      )
-    end
-    let(:request_params) do
-      {
-        status: BlogPost.statuses[:publish],
-        after: nil
-      }
-    end
 
     before do
-      subject.instance_variable_set(:@access_token, access_token)
-      stub_request(:get, 'https://public-api.wordpress.com/rest/v1.1/me/posts')
-        .with(query: request_params.merge(page_handle: nil), headers: authorization_header)
-        .to_return(body: blog_posts_response, status: 200)
+      stub_blog_posts_response(blog_post_payloads: [blog_post])
     end
 
     it 'returns the published blog posts of the site' do
@@ -85,36 +45,14 @@ RSpec.describe WordpressService do
     end
 
     context 'when there is more than 1 page of results' do
-      let(:next_page_token) { 'value=1564437351&blog=166779230&post=715' }
       let(:blog_post_2) { create(:blog_post_payload) }
-      let(:blog_posts_response) do
-        JSON.generate(
-          'posts': [blog_post],
-          'found': 2,
-          'meta': {
-            'next_page': next_page_token
-          }
-        )
-      end
-      let(:blog_posts_response_2) do
-        JSON.generate(
-          'posts': [blog_post_2],
-          'found': 1
-        )
-      end
 
       before do
-        stub_request(:get, 'https://public-api.wordpress.com/rest/v1.1/me/posts')
-          .with(
-            query: request_params.merge(page_handle: next_page_token),
-            headers: authorization_header
-          )
-          .to_return(body: blog_posts_response_2, status: 200)
+        stub_blog_posts_response(blog_post_payloads: [blog_post, blog_post_2], page_size: 1)
       end
 
       it 'returns all the published blog posts of the site' do
-        expect(subject.blog_posts)
-          .to match_array([blog_post, blog_post_2].map(&:deep_symbolize_keys))
+        expect(subject.blog_posts).to contain_exactly(blog_post, blog_post_2)
       end
     end
 
@@ -122,11 +60,12 @@ RSpec.describe WordpressService do
       let(:starting_date) { 30.days.ago }
       let(:blog_post_date) { Faker::Time.between(from: starting_date, to: Time.zone.today) }
       let(:blog_post) { create(:blog_post_payload, date: blog_post_date.iso8601) }
-      let(:request_params) do
-        {
-          status: BlogPost.statuses[:publish],
-          after: starting_date.iso8601
-        }
+
+      before do
+        stub_blog_posts_response(
+          request_params: { after: starting_date.iso8601 },
+          blog_post_payloads: [blog_post]
+        )
       end
 
       it 'returns the published blog posts created since the given date' do
@@ -137,25 +76,14 @@ RSpec.describe WordpressService do
   end
 
   describe '#blog_post_views' do
-    let(:access_token) { 'asdf' }
-    let(:authorization_header) { { 'Authorization': "Bearer #{access_token}" } }
-    let(:blog_site_id) { 11_111 }
-    let(:url) do
-      "https://public-api.wordpress.com/rest/v1.1/sites/#{blog_site_id}/stats/post/#{blog_post_id}"
-    end
     let(:blog_post) { create(:blog_post) }
     let(:blog_post_id) { blog_post.blog_id }
     let(:blog_post_views_payload) do
       create(:blog_post_views_payload, publish_datetime: blog_post.published_at)
     end
-    let(:blog_post_views_response) { JSON.generate(blog_post_views_payload) }
 
     before do
-      stub_env('WORDPRESS_SITE_ID', blog_site_id)
-      subject.instance_variable_set(:@access_token, access_token)
-      stub_request(:get, url)
-        .with(headers: authorization_header)
-        .to_return(body: blog_post_views_response, status: 200)
+      stub_blog_post_views_response(blog_post_id, blog_post_views_payload)
     end
 
     it 'returns the views hash for the requested post' do

--- a/spec/support/helpers/wordpress_api_helper.rb
+++ b/spec/support/helpers/wordpress_api_helper.rb
@@ -1,0 +1,132 @@
+module WordpressApiHelper
+  def stub_blog_post_views_response(
+    blog_post_id,
+    blog_post_views_payload = create(:blog_post_views_payload)
+  )
+    stub_access_token_response
+    stub_env('WORDPRESS_SITE_ID', blog_site_id)
+
+    url = 'https://public-api.wordpress.com/rest/v1.1/sites/' \
+          "#{blog_site_id}/stats/post/#{blog_post_id}"
+    stub_request(:get, url)
+      .with(headers: authorization_header)
+      .to_return(body: JSON.generate(blog_post_views_payload), status: 200)
+  end
+
+  def stub_blog_posts_response(
+    request_params: {},
+    blog_post_payloads: [create(:blog_post_payload)],
+    page_size: 20
+  )
+    stub_access_token_response
+
+    request_params = {
+      status: BlogPost.statuses[:publish],
+      after: nil
+    }.merge(request_params)
+
+    found_blog_posts = blog_post_payloads.count
+    groups_of_payloads = blog_post_payloads.in_groups_of(page_size, false)
+
+    groups_of_payloads.each.with_index do |blog_posts_payload, index|
+      stub_single_blog_post_response(
+        blog_posts: blog_posts_payload,
+        request_params: request_params,
+        page_token: request_token_for(index, groups_of_payloads),
+        next_page_token: response_token_for(index, groups_of_payloads),
+        found_blog_posts: found_blog_posts
+      )
+      found_blog_posts -= blog_posts_payload.count
+    end
+  end
+
+  def stub_single_blog_post_response(
+    blog_posts:,
+    request_params:,
+    page_token:,
+    next_page_token:,
+    found_blog_posts:
+  )
+    blog_posts_response = {
+      'posts': blog_posts,
+      'found': found_blog_posts
+    }
+
+    blog_posts_response.merge!('meta': { 'next_page': next_page_token }) if next_page_token.present?
+
+    stub_request(:get, 'https://public-api.wordpress.com/rest/v1.1/me/posts')
+      .with(query: request_params.merge(page_handle: page_token), headers: authorization_header)
+      .to_return(body: JSON.generate(blog_posts_response), status: 200)
+  end
+
+  def stub_access_token_response(
+    response_body: { access_token: access_token },
+    response_status: 200
+  )
+    stub_env_vars_for_access_token_request
+
+    request_params = {
+      client_id: client_id,
+      client_secret: client_secret,
+      grant_type: 'password',
+      username: username,
+      password: password
+    }
+
+    stub_request(:post, 'https://public-api.wordpress.com/oauth2/token')
+      .with(body: request_params)
+      .to_return(body: JSON.generate(response_body), status: response_status)
+  end
+
+  def stub_env_vars_for_access_token_request
+    stub_env('WORDPRESS_CLIENT_ID', client_id)
+    stub_env('WORDPRESS_CLIENT_SECRET', client_secret)
+    stub_env('WORDPRESS_USERNAME', username)
+    stub_env('WORDPRESS_PASSWORD', password)
+  end
+
+  def authorization_header
+    { 'Authorization': "Bearer #{access_token}" }
+  end
+
+  def request_token_for(payload_index, group_of_payloads)
+    return if payload_index == 0
+
+    generate_next_page_token(group_of_payloads[payload_index - 1])
+  end
+
+  def response_token_for(payload_index, group_of_payloads)
+    return if group_of_payloads[payload_index + 1].blank?
+
+    generate_next_page_token(group_of_payloads[payload_index])
+  end
+
+  def generate_next_page_token(blog_posts_payload)
+    last_blog_post = blog_posts_payload.last
+    "value=11111&blog=#{last_blog_post['site_ID']}&post=#{last_blog_post['ID']}"
+  end
+
+  def access_token
+    'asdf'
+  end
+
+  def blog_site_id
+    11_111
+  end
+
+  def client_id
+    '11111'
+  end
+
+  def client_secret
+    'qwerty'
+  end
+
+  def username
+    'rootstrap@rootstrap.com'
+  end
+
+  def password
+    'rootstrap'
+  end
+end

--- a/spec/support/helpers/wordpress_api_mocker.rb
+++ b/spec/support/helpers/wordpress_api_mocker.rb
@@ -1,4 +1,4 @@
-module WordpressApiHelper
+module WordpressApiMocker
   def stub_blog_post_views_response(
     blog_post_id,
     blog_post_views_payload = create(:blog_post_views_payload)


### PR DESCRIPTION
## What does this PR do?
It adds the `WordpressApiMocker` to make stubbing the Wordpress API much easier when testing.