### PR TITLE
Add processor to update blog visits metrics

### DIFF
--- a/app/services/processors/blog_metrics_updater.rb
+++ b/app/services/processors/blog_metrics_updater.rb
@@ -8,7 +8,7 @@ module Processors
     private
 
     def update_blog_post_visits_metrics
-      BlogPost.find_each(batch_size: 50) do |blog_post|
+      BlogPost.find_each(batch_size: 50).lazy.each do |blog_post|
         BlogPostViewsUpdater.call(blog_post.blog_id)
       end
     end

--- a/app/services/processors/blog_metrics_updater.rb
+++ b/app/services/processors/blog_metrics_updater.rb
@@ -1,0 +1,52 @@
+module Processors
+  class BlogMetricsUpdater < BaseService
+    def call
+      update_blog_post_visits_metrics
+      update_technologies_visits_metrics
+    end
+
+    private
+
+    def update_blog_post_visits_metrics
+      BlogPost.find_each(batch_size: 50) do |blog_post|
+        BlogPostViewsUpdater.call(blog_post.blog_id)
+      end
+    end
+
+    def update_technologies_visits_metrics
+      blog_views_by_technology_and_month.each do |pair_group, visits|
+        timestamp, technology_id = pair_group
+        update_technology_visits_metric(technology_id, visits, timestamp)
+      end
+    end
+
+    def blog_views_by_technology_and_month
+      Metric.where(name: Metric.names[:blog_visits], ownable_type: BlogPost.to_s)
+            .where('value_timestamp >= ?', latest_technology_metrics_updated_at)
+            .joins('JOIN blog_posts on metrics.ownable_id = blog_posts.id')
+            .group(:value_timestamp, :technology_id)
+            .sum(:value)
+    end
+
+    def latest_technology_metrics_updated_at
+      latest_visits_metrics_by_technology =
+        Metric.where(name: Metric.names[:blog_visits], ownable_type: Technology.to_s)
+              .group(:ownable_id)
+              .maximum(:value_timestamp)
+
+      latest_visits_metrics_by_technology.values.min || Time.zone.at(0)
+    end
+
+    def update_technology_visits_metric(technology_id, visits, timestamp)
+      metric = Metric.find_or_initialize_by(
+        ownable_id: technology_id,
+        ownable_type: Technology.to_s,
+        name: Metric.names[:blog_visits],
+        interval: Metric.intervals[:monthly],
+        value_timestamp: timestamp
+      )
+      metric.value = visits
+      metric.save!
+    end
+  end
+end

--- a/app/services/processors/blog_metrics_updater.rb
+++ b/app/services/processors/blog_metrics_updater.rb
@@ -14,39 +14,7 @@ module Processors
     end
 
     def update_technologies_visits_metrics
-      blog_views_by_technology_and_month.each do |pair_group, visits|
-        timestamp, technology_id = pair_group
-        update_technology_visits_metric(technology_id, visits, timestamp)
-      end
-    end
-
-    def blog_views_by_technology_and_month
-      Metric.where(name: Metric.names[:blog_visits], ownable_type: BlogPost.to_s)
-            .where('value_timestamp >= ?', latest_technology_metrics_updated_at)
-            .joins('JOIN blog_posts on metrics.ownable_id = blog_posts.id')
-            .group(:value_timestamp, :technology_id)
-            .sum(:value)
-    end
-
-    def latest_technology_metrics_updated_at
-      latest_visits_metrics_by_technology =
-        Metric.where(name: Metric.names[:blog_visits], ownable_type: Technology.to_s)
-              .group(:ownable_id)
-              .maximum(:value_timestamp)
-
-      latest_visits_metrics_by_technology.values.min || Time.zone.at(0)
-    end
-
-    def update_technology_visits_metric(technology_id, visits, timestamp)
-      metric = Metric.find_or_initialize_by(
-        ownable_id: technology_id,
-        ownable_type: Technology.to_s,
-        name: Metric.names[:blog_visits],
-        interval: Metric.intervals[:monthly],
-        value_timestamp: timestamp
-      )
-      metric.value = visits
-      metric.save!
+      BlogTechnologyViewsUpdater.call
     end
   end
 end

--- a/app/services/processors/blog_technology_views_updater.rb
+++ b/app/services/processors/blog_technology_views_updater.rb
@@ -1,0 +1,41 @@
+module Processors
+  class BlogTechnologyViewsUpdater < BaseService
+    def call
+      blog_views_by_technology_and_month.each do |pair_group, visits|
+        timestamp, technology_id = pair_group
+        update_technology_visits_metric(technology_id, visits, timestamp)
+      end
+    end
+
+    private
+
+    def blog_views_by_technology_and_month
+      Metric.where(name: Metric.names[:blog_visits], ownable_type: BlogPost.to_s)
+            .where('value_timestamp >= ?', latest_technology_metrics_updated_at)
+            .joins('JOIN blog_posts on metrics.ownable_id = blog_posts.id')
+            .group(:value_timestamp, :technology_id)
+            .sum(:value)
+    end
+
+    def latest_technology_metrics_updated_at
+      latest_visits_metrics_by_technology =
+        Metric.where(name: Metric.names[:blog_visits], ownable_type: Technology.to_s)
+              .group(:ownable_id)
+              .maximum(:value_timestamp)
+
+      latest_visits_metrics_by_technology.values.min || Time.zone.at(0)
+    end
+
+    def update_technology_visits_metric(technology_id, visits, timestamp)
+      metric = Metric.find_or_initialize_by(
+        ownable_id: technology_id,
+        ownable_type: Technology.to_s,
+        name: Metric.names[:blog_visits],
+        interval: Metric.intervals[:monthly],
+        value_timestamp: timestamp
+      )
+      metric.value = visits
+      metric.save!
+    end
+  end
+end

--- a/spec/factories/technologies.rb
+++ b/spec/factories/technologies.rb
@@ -10,7 +10,7 @@
 #
 FactoryBot.define do
   factory :technology do
-    name { 'Ruby' }
-    keyword_string { 'ruby,rails' }
+    name { Faker::Lorem.word }
+    keyword_string { Faker::Lorem.word }
   end
 end

--- a/spec/services/processors/blog_metrics_updater_spec.rb
+++ b/spec/services/processors/blog_metrics_updater_spec.rb
@@ -2,175 +2,38 @@ require 'rails_helper'
 
 describe Processors::BlogMetricsUpdater do
   describe '.call' do
-    let(:technology) { create(:technology) }
-    let!(:blog_post) { create(:blog_post, technology: technology) }
-    let(:blog_post_views_payload) { create(:blog_post_views_payload) }
-
-    before do
-      stub_blog_post_views_response(blog_post.blog_id, blog_post_views_payload)
-    end
-
-    it 'updates blog post visits metrics' do
-      described_class.call
-
-      metric = Metric.find_by!(
-        ownable: blog_post,
-        interval: Metric.intervals[:monthly],
-        name: Metric.names[:blog_visits]
-      )
-
-      expect(metric).to be_present
-    end
-
-    it 'updates technologies visits metrics' do
-      described_class.call
-
-      metric = Metric.find_by!(
-        ownable: technology,
-        interval: Metric.intervals[:monthly],
-        name: Metric.names[:blog_visits]
-      )
-
-      expect(metric).to be_present
-    end
-  end
-
-  describe '#update_blog_post_visits_metrics' do
-    let!(:blog_post_1) { create(:blog_post) }
-    let!(:blog_post_2) { create(:blog_post) }
+    let!(:technology) { create(:technology) }
+    let(:blog_post_1) { create(:blog_post, technology: technology) }
+    let(:blog_post_2) { create(:blog_post, technology: technology) }
     let(:blog_post_views_payload_1) { create(:blog_post_views_payload) }
     let(:blog_post_views_payload_2) { create(:blog_post_views_payload) }
-    let(:total_metrics_generated) do
-      months_count_for(blog_post_views_payload_1) + months_count_for(blog_post_views_payload_2)
-    end
-
-    subject { described_class.send(:new).send(:update_blog_post_visits_metrics) }
+    let(:blog_post_1_month_count) { months_count_for(blog_post_views_payload_1) }
+    let(:blog_post_2_month_count) { months_count_for(blog_post_views_payload_2) }
 
     before do
       stub_blog_post_views_response(blog_post_1.blog_id, blog_post_views_payload_1)
       stub_blog_post_views_response(blog_post_2.blog_id, blog_post_views_payload_2)
     end
 
-    it 'updates visits metrics for all blog posts' do
-      expect { subject }.to change(Metric, :count).by total_metrics_generated
-    end
-  end
+    describe '#update_blog_post_visits_metrics' do
+      let(:total_metrics_generated) { blog_post_1_month_count + blog_post_2_month_count }
 
-  describe '#update_technologies_visits_metrics' do
-    let!(:technology) { create(:technology) }
-    let(:metric_timestamp) { Time.zone.now.end_of_month }
-    let(:blog_post_1) { create(:blog_post, technology: technology) }
-    let!(:blog_post_1_views_metric) do
-      create(
-        :metric,
-        name: Metric.names[:blog_visits],
-        interval: Metric.intervals[:monthly],
-        value_timestamp: metric_timestamp,
-        ownable: blog_post_1
-      )
-    end
-    let(:blog_post_2) { create(:blog_post, technology: technology) }
-    let!(:blog_post_2_views_metric) do
-      create(
-        :metric,
-        name: Metric.names[:blog_visits],
-        interval: Metric.intervals[:monthly],
-        value_timestamp: metric_timestamp,
-        ownable: blog_post_2
-      )
-    end
-    let(:technology_visits) { blog_post_1_views_metric.value + blog_post_2_views_metric.value }
-
-    subject { described_class.send(:new).send(:update_technologies_visits_metrics) }
-
-    it 'creates the technologies visits metric' do
-      subject
-
-      metric = Metric.find_by!(
-        ownable: technology,
-        name: Metric.names[:blog_visits],
-        interval: Metric.intervals[:monthly]
-      )
-      expect(metric.value).to eq technology_visits
-      expect(metric.value_timestamp.to_s).to eq blog_post_1_views_metric.value_timestamp.to_s
-    end
-
-    context 'when the metric is already present' do
-      let!(:technology_visits_metric) do
-        create(
-          :metric,
-          name: Metric.names[:blog_visits],
-          interval: Metric.intervals[:monthly],
-          value_timestamp: metric_timestamp,
-          ownable: technology,
-          value: technology_visits - 10
-        )
-      end
-
-      it 'updates it with the latest info' do
-        expect { subject }.to change { technology_visits_metric.reload.value }.to technology_visits
+      it 'updates visits metrics for all blog posts' do
+        expect { described_class.call }
+          .to change(Metric.where(ownable_type: BlogPost.to_s), :count)
+          .by total_metrics_generated
       end
     end
 
-    context 'when there is more than one technology' do
-      let!(:technology_2) { create(:technology) }
-      let(:blog_post_for_tech_2) { create(:blog_post, technology: technology_2) }
-      let!(:blog_post_for_tech_2_views_metric) do
-        create(
-          :metric,
-          name: Metric.names[:blog_visits],
-          interval: Metric.intervals[:monthly],
-          value_timestamp: metric_timestamp,
-          ownable: blog_post_for_tech_2
-        )
+    describe '#update_technologies_visits_metrics' do
+      let(:total_months_with_blog_post_visits) do
+        [blog_post_1_month_count, blog_post_2_month_count].max
       end
 
-      it 'creates metrics for all of them' do
-        expect { subject }.to change { Metric.count }.by 2
-      end
-    end
-
-    context 'when there are blog post views metrics for more than 1 month' do
-      let!(:last_month_blog_post_1_views_metric) do
-        create(
-          :metric,
-          name: Metric.names[:blog_visits],
-          interval: Metric.intervals[:monthly],
-          value_timestamp: metric_timestamp.last_month,
-          ownable: blog_post_1
-        )
-      end
-
-      it 'creates a technology metric for each one of those months' do
-        expect { subject }.to change { Metric.count }.by 2
-      end
-
-      context 'but technologies visits metrics have already been registered' do
-        before do
-          create(
-            :metric,
-            name: Metric.names[:blog_visits],
-            interval: Metric.intervals[:monthly],
-            value: last_month_blog_post_1_views_metric.value,
-            value_timestamp: metric_timestamp.last_month,
-            ownable: technology
-          )
-
-          create(
-            :metric,
-            name: Metric.names[:blog_visits],
-            interval: Metric.intervals[:monthly],
-            value: technology_visits,
-            value_timestamp: metric_timestamp,
-            ownable: technology
-          )
-        end
-
-        it 'just tries to update the last of them' do
-          expect(Metric).to receive(:find_or_initialize_by).once.and_call_original
-
-          subject
-        end
+      it 'creates as much technology visits metrics as months with blog post visits' do
+        expect { described_class.call }
+          .to change(Metric.where(ownable: technology), :count)
+          .by total_months_with_blog_post_visits
       end
     end
   end

--- a/spec/services/processors/blog_metrics_updater_spec.rb
+++ b/spec/services/processors/blog_metrics_updater_spec.rb
@@ -1,0 +1,183 @@
+require 'rails_helper'
+
+describe Processors::BlogMetricsUpdater do
+  describe '.call' do
+    let(:technology) { create(:technology) }
+    let!(:blog_post) { create(:blog_post, technology: technology) }
+    let(:blog_post_views_payload) { create(:blog_post_views_payload) }
+
+    before do
+      stub_blog_post_views_response(blog_post.blog_id, blog_post_views_payload)
+    end
+
+    it 'updates blog post visits metrics' do
+      described_class.call
+
+      metric = Metric.find_by!(
+        ownable: blog_post,
+        interval: Metric.intervals[:monthly],
+        name: Metric.names[:blog_visits]
+      )
+
+      expect(metric).to be_present
+    end
+
+    it 'updates technologies visits metrics' do
+      described_class.call
+
+      metric = Metric.find_by!(
+        ownable: technology,
+        interval: Metric.intervals[:monthly],
+        name: Metric.names[:blog_visits]
+      )
+
+      expect(metric).to be_present
+    end
+  end
+
+  describe '#update_blog_post_visits_metrics' do
+    let!(:blog_post_1) { create(:blog_post) }
+    let!(:blog_post_2) { create(:blog_post) }
+    let(:blog_post_views_payload_1) { create(:blog_post_views_payload) }
+    let(:blog_post_views_payload_2) { create(:blog_post_views_payload) }
+    let(:total_metrics_generated) do
+      months_count_for(blog_post_views_payload_1) + months_count_for(blog_post_views_payload_2)
+    end
+
+    subject { described_class.send(:new).send(:update_blog_post_visits_metrics) }
+
+    before do
+      stub_blog_post_views_response(blog_post_1.blog_id, blog_post_views_payload_1)
+      stub_blog_post_views_response(blog_post_2.blog_id, blog_post_views_payload_2)
+    end
+
+    it 'updates visits metrics for all blog posts' do
+      expect { subject }.to change(Metric, :count).by total_metrics_generated
+    end
+  end
+
+  describe '#update_technologies_visits_metrics' do
+    let!(:technology) { create(:technology) }
+    let(:metric_timestamp) { Time.zone.now.end_of_month }
+    let(:blog_post_1) { create(:blog_post, technology: technology) }
+    let!(:blog_post_1_views_metric) do
+      create(
+        :metric,
+        name: Metric.names[:blog_visits],
+        interval: Metric.intervals[:monthly],
+        value_timestamp: metric_timestamp,
+        ownable: blog_post_1
+      )
+    end
+    let(:blog_post_2) { create(:blog_post, technology: technology) }
+    let!(:blog_post_2_views_metric) do
+      create(
+        :metric,
+        name: Metric.names[:blog_visits],
+        interval: Metric.intervals[:monthly],
+        value_timestamp: metric_timestamp,
+        ownable: blog_post_2
+      )
+    end
+    let(:technology_visits) { blog_post_1_views_metric.value + blog_post_2_views_metric.value }
+
+    subject { described_class.send(:new).send(:update_technologies_visits_metrics) }
+
+    it 'creates the technologies visits metric' do
+      subject
+
+      metric = Metric.find_by!(
+        ownable: technology,
+        name: Metric.names[:blog_visits],
+        interval: Metric.intervals[:monthly]
+      )
+      expect(metric.value).to eq technology_visits
+      expect(metric.value_timestamp.to_s).to eq blog_post_1_views_metric.value_timestamp.to_s
+    end
+
+    context 'when the metric is already present' do
+      let!(:technology_visits_metric) do
+        create(
+          :metric,
+          name: Metric.names[:blog_visits],
+          interval: Metric.intervals[:monthly],
+          value_timestamp: metric_timestamp,
+          ownable: technology,
+          value: technology_visits - 10
+        )
+      end
+
+      it 'updates it with the latest info' do
+        expect { subject }.to change { technology_visits_metric.reload.value }.to technology_visits
+      end
+    end
+
+    context 'when there is more than one technology' do
+      let!(:technology_2) { create(:technology) }
+      let(:blog_post_for_tech_2) { create(:blog_post, technology: technology_2) }
+      let!(:blog_post_for_tech_2_views_metric) do
+        create(
+          :metric,
+          name: Metric.names[:blog_visits],
+          interval: Metric.intervals[:monthly],
+          value_timestamp: metric_timestamp,
+          ownable: blog_post_for_tech_2
+        )
+      end
+
+      it 'creates metrics for all of them' do
+        expect { subject }.to change { Metric.count }.by 2
+      end
+    end
+
+    context 'when there are blog post views metrics for more than 1 month' do
+      let!(:last_month_blog_post_1_views_metric) do
+        create(
+          :metric,
+          name: Metric.names[:blog_visits],
+          interval: Metric.intervals[:monthly],
+          value_timestamp: metric_timestamp.last_month,
+          ownable: blog_post_1
+        )
+      end
+
+      it 'creates a technology metric for each one of those months' do
+        expect { subject }.to change { Metric.count }.by 2
+      end
+
+      context 'but technologies visits metrics have already been registered' do
+        before do
+          create(
+            :metric,
+            name: Metric.names[:blog_visits],
+            interval: Metric.intervals[:monthly],
+            value: last_month_blog_post_1_views_metric.value,
+            value_timestamp: metric_timestamp.last_month,
+            ownable: technology
+          )
+
+          create(
+            :metric,
+            name: Metric.names[:blog_visits],
+            interval: Metric.intervals[:monthly],
+            value: technology_visits,
+            value_timestamp: metric_timestamp,
+            ownable: technology
+          )
+        end
+
+        it 'just tries to update the last of them' do
+          expect(Metric).to receive(:find_or_initialize_by).once.and_call_original
+
+          subject
+        end
+      end
+    end
+  end
+end
+
+def months_count_for(blog_post_views_payload)
+  blog_post_views_payload['years'].sum do |_year, year_hash|
+    year_hash['months'].count
+  end
+end

--- a/spec/services/processors/blog_technology_views_updater_spec.rb
+++ b/spec/services/processors/blog_technology_views_updater_spec.rb
@@ -1,0 +1,122 @@
+require 'rails_helper'
+
+describe Processors::BlogTechnologyViewsUpdater do
+  describe '.call' do
+    let!(:technology) { create(:technology) }
+    let(:metric_timestamp) { Time.zone.now.end_of_month }
+    let(:blog_post_1) { create(:blog_post, technology: technology) }
+    let!(:blog_post_1_views_metric) do
+      create(
+        :metric,
+        name: Metric.names[:blog_visits],
+        interval: Metric.intervals[:monthly],
+        value_timestamp: metric_timestamp,
+        ownable: blog_post_1
+      )
+    end
+    let(:blog_post_2) { create(:blog_post, technology: technology) }
+    let!(:blog_post_2_views_metric) do
+      create(
+        :metric,
+        name: Metric.names[:blog_visits],
+        interval: Metric.intervals[:monthly],
+        value_timestamp: metric_timestamp,
+        ownable: blog_post_2
+      )
+    end
+    let(:technology_visits) { blog_post_1_views_metric.value + blog_post_2_views_metric.value }
+
+    it 'creates the technologies visits metric' do
+      described_class.call
+
+      metric = Metric.find_by!(
+        ownable: technology,
+        name: Metric.names[:blog_visits],
+        interval: Metric.intervals[:monthly]
+      )
+      expect(metric.value).to eq technology_visits
+      expect(metric.value_timestamp.to_s).to eq blog_post_1_views_metric.value_timestamp.to_s
+    end
+
+    context 'when the metric is already present' do
+      let!(:technology_visits_metric) do
+        create(
+          :metric,
+          name: Metric.names[:blog_visits],
+          interval: Metric.intervals[:monthly],
+          value_timestamp: metric_timestamp,
+          ownable: technology,
+          value: technology_visits - 10
+        )
+      end
+
+      it 'updates it with the latest info' do
+        expect { described_class.call }
+          .to change { technology_visits_metric.reload.value }
+          .to technology_visits
+      end
+    end
+
+    context 'when there is more than one technology' do
+      let!(:technology_2) { create(:technology) }
+      let(:blog_post_for_tech_2) { create(:blog_post, technology: technology_2) }
+      let!(:blog_post_for_tech_2_views_metric) do
+        create(
+          :metric,
+          name: Metric.names[:blog_visits],
+          interval: Metric.intervals[:monthly],
+          value_timestamp: metric_timestamp,
+          ownable: blog_post_for_tech_2
+        )
+      end
+
+      it 'creates metrics for all of them' do
+        expect { described_class.call }.to change { Metric.count }.by 2
+      end
+    end
+
+    context 'when there are blog post views metrics for more than 1 month' do
+      let!(:last_month_blog_post_1_views_metric) do
+        create(
+          :metric,
+          name: Metric.names[:blog_visits],
+          interval: Metric.intervals[:monthly],
+          value_timestamp: metric_timestamp.last_month,
+          ownable: blog_post_1
+        )
+      end
+
+      it 'creates a technology metric for each one of those months' do
+        expect { described_class.call }.to change { Metric.count }.by 2
+      end
+
+      context 'but technologies visits metrics have already been registered' do
+        before do
+          create(
+            :metric,
+            name: Metric.names[:blog_visits],
+            interval: Metric.intervals[:monthly],
+            value: last_month_blog_post_1_views_metric.value,
+            value_timestamp: metric_timestamp.last_month,
+            ownable: technology
+          )
+
+          create(
+            :metric,
+            name: Metric.names[:blog_visits],
+            interval: Metric.intervals[:monthly],
+            value: technology_visits,
+            value_timestamp: metric_timestamp,
+            ownable: technology
+          )
+        end
+
+        it 'just tries to update the last of them' do
+          expect(Metric).to receive(:find_or_initialize_by).once.and_call_original
+
+          described_class.call
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What does this PR do?
Adds a processor called `BlogMetricsUpdater`, which first updates all the visits metrics of each blog post and then calculates those visits per technology.
As visits from previous months remain unchanged, it only iterates through the metrics of the current month (or since the month lastly updated).
