### PR TITLE
Fix blog posts request to Wordpress API

### DIFF
--- a/app/services/wordpress_service.rb
+++ b/app/services/wordpress_service.rb
@@ -1,5 +1,5 @@
 class WordpressService
-  def blog_posts(since: nil, posts: [], next_page_token: nil)
+  def blog_posts(since: Time.zone.at(0), posts: [], next_page_token: nil)
     request_params = {
       status: BlogPost.statuses[:publish],
       after: since&.iso8601,

--- a/spec/support/helpers/wordpress_api_mocker.rb
+++ b/spec/support/helpers/wordpress_api_mocker.rb
@@ -22,7 +22,7 @@ module WordpressApiMocker
 
     request_params = {
       status: BlogPost.statuses[:publish],
-      after: nil
+      after: default_starting_time.iso8601
     }.merge(request_params)
 
     found_blog_posts = blog_post_payloads.count
@@ -128,5 +128,9 @@ module WordpressApiMocker
 
   def password
     'rootstrap'
+  end
+
+  def default_starting_time
+    Time.zone.at(0)
   end
 end


### PR DESCRIPTION
## What does this PR do?
When requesting blog posts to the Wordpress API, if the `after` param is sent blank, no posts will be returned (presumably because of how they handle that param on their end).

We need to change our default value for that param from `nil` to an actual date. I chose `Time.zone.at(0)` because as a default we want all posts.
