### PR TITLE
Fix for print.css not found

### DIFF
--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -86,7 +86,7 @@ production:
   compile: false
 
   # Extract and emit a css file
-  extract_css: true
+  extract_css: false
 
   # Cache manifest.json for performance
   cache_manifest: true


### PR DESCRIPTION
## Description

Since we are using Asset Pipeline and not webpacker for the assets, we should set this value to false.