### PR TITLE
Add chart for technology visits

### DIFF
--- a/app/controllers/tech_blog_controller.rb
+++ b/app/controllers/tech_blog_controller.rb
@@ -1,0 +1,11 @@
+class TechBlogController < ApplicationController
+  def index
+    @visits_per_technology = visits_per_technology
+  end
+
+  private
+
+  def visits_per_technology
+    BlogMetricChartBuilder.new.technology_visits
+  end
+end

--- a/app/models/technology.rb
+++ b/app/models/technology.rb
@@ -10,6 +10,7 @@
 #
 class Technology < ApplicationRecord
   has_many :blog_posts, dependent: :nullify
+  has_many :metrics, as: :ownable, dependent: :destroy
 
   validates :name, uniqueness: true
 

--- a/app/services/blog_metric_chart_builder.rb
+++ b/app/services/blog_metric_chart_builder.rb
@@ -1,0 +1,18 @@
+class BlogMetricChartBuilder
+  def technology_visits
+    Technology.all.map do |technology|
+      {
+        name: technology.name.titlecase,
+        data: metrics_data_for(technology)
+      }
+    end
+  end
+
+  private
+
+  def metrics_data_for(technology)
+    technology.metrics.order(:value_timestamp).each.inject({}) do |hash, metric|
+      hash.merge!(metric.value_timestamp.strftime('%B') => metric.value)
+    end
+  end
+end

--- a/app/views/tech_blog/index.erb
+++ b/app/views/tech_blog/index.erb
@@ -1,0 +1,3 @@
+<div class='col-md-10 p-3'>
+  <%= line_chart @visits_per_technology, ytitle: "Visits" %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,4 +14,5 @@ Rails.application.routes.draw do
       get 'review_turnaround', controller: :projects
     end
   end
+  get 'tech_blog', to: 'tech_blog#index'
 end

--- a/spec/services/blog_metric_chart_builder_spec.rb
+++ b/spec/services/blog_metric_chart_builder_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+describe BlogMetricChartBuilder do
+  describe '#technology_visits' do
+    let(:technology) { create(:technology) }
+    let!(:last_month_metric) do
+      create(
+        :metric,
+        ownable: technology,
+        interval: Metric.intervals[:monthly],
+        name: Metric.names[:blog_visits],
+        value: 10,
+        value_timestamp: Time.zone.now.last_month.end_of_month
+      )
+    end
+    let!(:this_month_metric) do
+      create(
+        :metric,
+        ownable: technology,
+        interval: Metric.intervals[:monthly],
+        name: Metric.names[:blog_visits],
+        value: 5,
+        value_timestamp: Time.zone.now.end_of_month
+      )
+    end
+    let(:technology_metrics_hash) do
+      {
+        name: technology.name.titlecase,
+        data: {
+          last_month_metric.value_timestamp.strftime('%B') => last_month_metric.value,
+          this_month_metric.value_timestamp.strftime('%B') => this_month_metric.value
+        }
+      }
+    end
+
+    it 'returns the technology visits formatted by technology and month' do
+      expect(subject.technology_visits).to contain_exactly(technology_metrics_hash)
+    end
+  end
+end


### PR DESCRIPTION
## What does this PR do?
It creates a chart for blog visits by technology metrics. The chart looks like this:

![image](https://user-images.githubusercontent.com/7276679/83057098-d291d800-a02c-11ea-8491-baa8c1624618.png)

It's worth noting that technologies stats can be viewed separately by turning off the ones that are not needed (and the scale of the chart resizes accordingly):

![image](https://user-images.githubusercontent.com/7276679/83057297-1e448180-a02d-11ea-9ce5-bc82773e199c.png)
