### PR TITLE
Review turnaround query fix

### DIFF
--- a/app/services/metrics/review_turnaround/per_user_project.rb
+++ b/app/services/metrics/review_turnaround/per_user_project.rb
@@ -39,7 +39,7 @@ module Metrics
       def filtered_reviews_ids
         Events::Review.joins(:review_request)
                       .where(opened_at: metric_interval)
-                      .order(:pull_request_id, :owner_id, opened_at: :desc)
+                      .order(:pull_request_id, :owner_id, :opened_at)
                       .pluck(Arel.sql('DISTINCT ON (reviews.pull_request_id,'\
                                       'reviews.owner_id) reviews.id'))
       end

--- a/app/services/metrics/review_turnaround/per_user_project.rb
+++ b/app/services/metrics/review_turnaround/per_user_project.rb
@@ -39,8 +39,9 @@ module Metrics
       def filtered_reviews_ids
         Events::Review.joins(:review_request)
                       .where(opened_at: metric_interval)
-                      .order(:pull_request_id, :opened_at)
-                      .pluck(Arel.sql('DISTINCT ON (reviews.pull_request_id) reviews.id'))
+                      .order(:pull_request_id, :owner_id, opened_at: :desc)
+                      .pluck(Arel.sql('DISTINCT ON (reviews.pull_request_id,'\
+                                      'reviews.owner_id) reviews.id'))
       end
 
       def calculate_turnaround(review)

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -7,5 +7,5 @@ weekly_metrics:
   class: 'WeeklyMetricsJob'
 
 merge_time_generator:
-  cron: '* 23 * * *'
+  cron: '00 23 * * *'
   class: 'ProcessMergeTimeMetricsJob'


### PR DESCRIPTION
## What does this PR do?

Fixes review turnaround query which gets all the reviews. Currently we were getting the first duplicated record in base of pull request which it was returning just the first review from the pull request and not the first review from the pull request of every user, so we also need to add owner to the distinct.
Also I fixed merge time execution, it was being execute every minute of the hour (23:00).