### PR TITLE
[EM-43] Allow blog metrics to be fully updated

### DIFF
--- a/app/services/processors/blog_metrics_full_updater.rb
+++ b/app/services/processors/blog_metrics_full_updater.rb
@@ -1,0 +1,9 @@
+module Processors
+  class BlogMetricsFullUpdater < BlogMetricsUpdater
+    private
+
+    def technology_views_updater
+      BlogTechnologyViewsFullUpdater
+    end
+  end
+end

--- a/app/services/processors/blog_metrics_partial_updater.rb
+++ b/app/services/processors/blog_metrics_partial_updater.rb
@@ -1,0 +1,9 @@
+module Processors
+  class BlogMetricsPartialUpdater < BlogMetricsUpdater
+    private
+
+    def technology_views_updater
+      BlogTechnologyViewsPartialUpdater
+    end
+  end
+end

--- a/app/services/processors/blog_metrics_updater.rb
+++ b/app/services/processors/blog_metrics_updater.rb
@@ -14,7 +14,7 @@ module Processors
     end
 
     def update_technologies_visits_metrics
-      BlogTechnologyViewsUpdater.call
+      technology_views_updater.call
     end
   end
 end

--- a/app/services/processors/blog_technology_views_full_updater.rb
+++ b/app/services/processors/blog_technology_views_full_updater.rb
@@ -3,7 +3,7 @@ module Processors
     private
 
     def metrics_by_timestamp
-      Metric
+      Metric.all
     end
   end
 end

--- a/app/services/processors/blog_technology_views_full_updater.rb
+++ b/app/services/processors/blog_technology_views_full_updater.rb
@@ -1,0 +1,9 @@
+module Processors
+  class BlogTechnologyViewsFullUpdater < BlogTechnologyViewsUpdater
+    private
+
+    def metrics_by_timestamp
+      Metric
+    end
+  end
+end

--- a/app/services/processors/blog_technology_views_partial_updater.rb
+++ b/app/services/processors/blog_technology_views_partial_updater.rb
@@ -1,0 +1,9 @@
+module Processors
+  class BlogTechnologyViewsPartialUpdater < BlogTechnologyViewsUpdater
+    private
+
+    def metrics_by_timestamp
+      Metric.where('value_timestamp >= ?', latest_technology_metrics_updated_at)
+    end
+  end
+end

--- a/app/services/processors/blog_technology_views_updater.rb
+++ b/app/services/processors/blog_technology_views_updater.rb
@@ -10,11 +10,11 @@ module Processors
     private
 
     def blog_views_by_technology_and_month
-      Metric.where(name: Metric.names[:blog_visits], ownable_type: BlogPost.to_s)
-            .where('value_timestamp >= ?', latest_technology_metrics_updated_at)
-            .joins('JOIN blog_posts on metrics.ownable_id = blog_posts.id')
-            .group(:value_timestamp, :technology_id)
-            .sum(:value)
+      metrics_by_timestamp
+        .where(name: Metric.names[:blog_visits], ownable_type: BlogPost.to_s)
+        .joins('JOIN blog_posts on metrics.ownable_id = blog_posts.id')
+        .group(:value_timestamp, :technology_id)
+        .sum(:value)
     end
 
     def latest_technology_metrics_updated_at

--- a/spec/services/processors/blog_metrics_updater_spec.rb
+++ b/spec/services/processors/blog_metrics_updater_spec.rb
@@ -15,11 +15,13 @@ describe Processors::BlogMetricsUpdater do
       stub_blog_post_views_response(blog_post_2.blog_id, blog_post_views_payload_2)
     end
 
+    subject(:updater) { Processors::BlogMetricsPartialUpdater }
+
     describe '#update_blog_post_visits_metrics' do
       let(:total_metrics_generated) { blog_post_1_month_count + blog_post_2_month_count }
 
       it 'updates visits metrics for all blog posts' do
-        expect { described_class.call }
+        expect { updater.call }
           .to change(Metric.where(ownable_type: BlogPost.to_s), :count)
           .by total_metrics_generated
       end
@@ -31,7 +33,7 @@ describe Processors::BlogMetricsUpdater do
       end
 
       it 'creates as much technology visits metrics as months with blog post visits' do
-        expect { described_class.call }
+        expect { updater.call }
           .to change(Metric.where(ownable: technology), :count)
           .by total_months_with_blog_post_visits
       end

--- a/spec/services/processors/blog_technology_views_full_updater_spec.rb
+++ b/spec/services/processors/blog_technology_views_full_updater_spec.rb
@@ -1,0 +1,55 @@
+require 'rails_helper'
+
+describe Processors::BlogTechnologyViewsFullUpdater do
+  describe '.call' do
+    let!(:technology) { create(:technology) }
+    let(:metric_timestamp) { Time.zone.now.end_of_month }
+    let(:blog_post) { create(:blog_post, technology: technology) }
+    let!(:blog_post_views_metric) do
+      create(
+        :metric,
+        name: Metric.names[:blog_visits],
+        interval: Metric.intervals[:monthly],
+        value_timestamp: metric_timestamp,
+        ownable: blog_post
+      )
+    end
+    let!(:last_month_blog_post_views_metric) do
+      create(
+        :metric,
+        name: Metric.names[:blog_visits],
+        interval: Metric.intervals[:monthly],
+        value_timestamp: metric_timestamp.last_month,
+        ownable: blog_post
+      )
+    end
+
+    context 'when technologies visits metrics have been registered' do
+      before do
+        create(
+          :metric,
+          name: Metric.names[:blog_visits],
+          interval: Metric.intervals[:monthly],
+          value: last_month_blog_post_views_metric.value,
+          value_timestamp: metric_timestamp.last_month,
+          ownable: technology
+        )
+
+        create(
+          :metric,
+          name: Metric.names[:blog_visits],
+          interval: Metric.intervals[:monthly],
+          value: blog_post_views_metric.value,
+          value_timestamp: metric_timestamp,
+          ownable: technology
+        )
+      end
+
+      it 'tries to update all of them' do
+        expect(Metric).to receive(:find_or_initialize_by).twice.and_call_original
+
+        described_class.call
+      end
+    end
+  end
+end

--- a/spec/services/processors/blog_technology_views_partial_updater_spec.rb
+++ b/spec/services/processors/blog_technology_views_partial_updater_spec.rb
@@ -1,0 +1,55 @@
+require 'rails_helper'
+
+RSpec.describe Processors::BlogTechnologyViewsPartialUpdater do
+  describe '.call' do
+    let!(:technology) { create(:technology) }
+    let(:metric_timestamp) { Time.zone.now.end_of_month }
+    let(:blog_post) { create(:blog_post, technology: technology) }
+    let!(:blog_post_views_metric) do
+      create(
+        :metric,
+        name: Metric.names[:blog_visits],
+        interval: Metric.intervals[:monthly],
+        value_timestamp: metric_timestamp,
+        ownable: blog_post
+      )
+    end
+    let!(:last_month_blog_post_views_metric) do
+      create(
+        :metric,
+        name: Metric.names[:blog_visits],
+        interval: Metric.intervals[:monthly],
+        value_timestamp: metric_timestamp.last_month,
+        ownable: blog_post
+      )
+    end
+
+    context 'when technologies visits metrics have been registered' do
+      before do
+        create(
+          :metric,
+          name: Metric.names[:blog_visits],
+          interval: Metric.intervals[:monthly],
+          value: last_month_blog_post_views_metric.value,
+          value_timestamp: metric_timestamp.last_month,
+          ownable: technology
+        )
+
+        create(
+          :metric,
+          name: Metric.names[:blog_visits],
+          interval: Metric.intervals[:monthly],
+          value: blog_post_views_metric.value,
+          value_timestamp: metric_timestamp,
+          ownable: technology
+        )
+      end
+
+      it 'just tries to update the last of them' do
+        expect(Metric).to receive(:find_or_initialize_by).once.and_call_original
+
+        described_class.call
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What does this PR do?
Not all blog metrics need to be updated all the time; in a regular use, we should only update those metrics corresponding to the current month (and maybe the last one as well in some cases). Visits for previous months won't ever change.

But still there are certain circumstances where we do need to update all of them (for example, when a blog post changes its technology).

For those occasions, our `BlogMetricsUpdater` should be able to be run for a _full_ update as well as a _partial_ one.

Story: https://rootstrap.atlassian.net/browse/EM-43
