### PR TITLE
Schedule Blog jobs

### DIFF
--- a/app/jobs/blog_metrics_full_updater_job.rb
+++ b/app/jobs/blog_metrics_full_updater_job.rb
@@ -1,0 +1,7 @@
+class BlogMetricsFullUpdaterJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    Processors::BlogMetricsFullUpdater.call
+  end
+end

--- a/app/jobs/blog_metrics_partial_updater_job.rb
+++ b/app/jobs/blog_metrics_partial_updater_job.rb
@@ -1,0 +1,7 @@
+class BlogMetricsPartialUpdaterJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    Processors::BlogMetricsPartialUpdater.call
+  end
+end

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -9,3 +9,19 @@ weekly_metrics:
 merge_time_generator:
   cron: '00 23 * * *'
   class: 'ProcessMergeTimeMetricsJob'
+
+blog_posts_partial_update:
+  cron: '00 4 * * 3'
+  class: 'BlogPostsPartialUpdaterJob'
+
+blog_posts_full_update:
+  cron: '00 2 1 * *'
+  class: 'BlogPostsFullUpdaterJob'
+
+blog_metrics_partial_update:
+  cron: '30 4 * * *'
+  class: 'BlogMetricsPartialUpdaterJob'
+
+blog_metrics_full_update:
+  cron: '00 3 1 * *'
+  class: 'BlogMetricsFullUpdaterJob'

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -1,27 +1,34 @@
 review_turnaround_generator:
   cron: '30 23 * * *'
   class: 'ProcessReviewTurnaroundMetricsJob'
+  active_job: true
 
 weekly_metrics:
   cron: '50 23 * * 1-5'
   class: 'WeeklyMetricsJob'
+  active_job: true
 
 merge_time_generator:
   cron: '00 23 * * *'
   class: 'ProcessMergeTimeMetricsJob'
+  active_job: true
 
 blog_posts_partial_update:
   cron: '00 4 * * 3'
   class: 'BlogPostsPartialUpdaterJob'
+  active_job: true
 
 blog_posts_full_update:
   cron: '00 2 1 * *'
   class: 'BlogPostsFullUpdaterJob'
+  active_job: true
 
 blog_metrics_partial_update:
   cron: '30 4 * * *'
   class: 'BlogMetricsPartialUpdaterJob'
+  active_job: true
 
 blog_metrics_full_update:
   cron: '00 3 1 * *'
   class: 'BlogMetricsFullUpdaterJob'
+  active_job: true

--- a/spec/jobs/blog_metrics_full_updater_job_spec.rb
+++ b/spec/jobs/blog_metrics_full_updater_job_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+describe BlogMetricsFullUpdaterJob do
+  describe '#perform' do
+    it 'correctly initializes the BlogMetricsFullUpdater processor and calls it' do
+      expect_any_instance_of(Processors::BlogMetricsFullUpdater)
+        .to receive(:call)
+        .once
+
+      described_class.perform_now
+    end
+  end
+end

--- a/spec/jobs/blog_metrics_partial_updater_job_spec.rb
+++ b/spec/jobs/blog_metrics_partial_updater_job_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+describe BlogMetricsPartialUpdaterJob do
+  describe '#perform' do
+    it 'correctly initializes the BlogMetricsPartialUpdater processor and calls it' do
+      expect_any_instance_of(Processors::BlogMetricsPartialUpdater)
+        .to receive(:call)
+        .once
+
+      described_class.perform_now
+    end
+  end
+end


### PR DESCRIPTION
## What does this PR do?
It schedules three main jobs to update the blog metrics:
- `BlogPostsPartialUpdaterJob`: Runs once a week, on Wednesdays early morning. It adds newly published posts to our DB.
- `BlogPostsFullUpdaterJob`: Runs once per month (on the 1st). It updates all blog posts from scratch (looking for updated titles, links, tags or whatever new info that we should be aware of).
- `BlogMetricsPartialUpdaterJob`: Runs every day, early morning. It updates the metrics with the latest info.
- `BlogMetricsFullUpdaterJob`: Runs right after `BlogPostsFullUpdaterJob`. It reflects those possible changes in the blog posts into the metrics.