### PR TITLE
Fix the migration error caused by the use of ALTER TYPE

### DIFF
--- a/db/migrate/20200423185715_add_blog_visits_to_metric_name_type.rb
+++ b/db/migrate/20200423185715_add_blog_visits_to_metric_name_type.rb
@@ -1,4 +1,6 @@
 class AddBlogVisitsToMetricNameType < ActiveRecord::Migration[6.0]
+  disable_ddl_transaction!
+
   def up
     execute <<-SQL
       ALTER TYPE metric_name ADD VALUE 'blog_visits';

--- a/db/migrate/20200506182951_add_value_to_metric_name_enum.rb
+++ b/db/migrate/20200506182951_add_value_to_metric_name_enum.rb
@@ -1,4 +1,6 @@
 class AddValueToMetricNameEnum < ActiveRecord::Migration[6.0]
+  disable_ddl_transaction!
+
   def up
     execute <<-SQL
       ALTER TYPE metric_name ADD VALUE 'merge_time';

--- a/db/migrate/20200511180927_add_reviewed_state_review_requests.rb
+++ b/db/migrate/20200511180927_add_reviewed_state_review_requests.rb
@@ -1,4 +1,6 @@
 class AddReviewedStateReviewRequests < ActiveRecord::Migration[6.0]
+  disable_ddl_transaction!
+
   def up
     execute <<-SQL
       ALTER TYPE review_request_state ADD VALUE 'reviewed';


### PR DESCRIPTION
## What does this PR do?

The migrations containing al ALTER TYPE do not run within a transaction.
This PR disables the use of a transaction in those migrations