### PR TITLE
[EM-42] No chart when no project selected

### DIFF
--- a/app/assets/stylesheets/_user-project-metric.scss
+++ b/app/assets/stylesheets/_user-project-metric.scss
@@ -1,16 +1,6 @@
-.metric-container{
-  display: flex;
-  flex-direction: column;
-}
-
 .period-selection{
   max-width: 15rem;
   display: flex;
   align-items: baseline;
 }
 
-.metric-title{
-  text-align: center;
-  margin-bottom: 2rem;
-  font-size: 20px;
-}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -8,7 +8,7 @@
 @import "layout/navigation";
 
 //shared
-@import "shared/sidebar";
+@import "shared/*";
 
 @import "user-project-metric";
 @import "nav-filter";

--- a/app/assets/stylesheets/shared/_line-chart.scss
+++ b/app/assets/stylesheets/shared/_line-chart.scss
@@ -1,0 +1,10 @@
+.chart-container{
+  display: flex;
+  flex-direction: column;
+}
+
+.metric-title{
+  text-align: center;
+  margin-bottom: 2rem;
+  font-size: 20px;
+}

--- a/app/views/shared/_line-chart.erb
+++ b/app/views/shared/_line-chart.erb
@@ -1,0 +1,7 @@
+<div class='p-3 chart-container'>
+  <span class='metric-title'><%= metric_name %></span>
+  <%= line_chart metric,
+      ytitle: "Time as hours",
+      suffix: "hours",
+      library: { spanGaps: true } %>
+</div>

--- a/app/views/users_projects/metrics.erb
+++ b/app/views/users_projects/metrics.erb
@@ -10,8 +10,7 @@
     %>
   <% end %>
   <%= render partial: 'shared/line-chart',
-              locals: { metric_name: 'Review Turnaround', metric: @review_turnaround } %>
+              locals: { metric_name: 'Review Turnaround', metric: @review_turnaround } if @review_turnaround %>
   <%= render partial: 'shared/line-chart',
-              locals: { metric_name: 'Merge Time', metric: @merge_time } %>
-
+              locals: { metric_name: 'Merge Time', metric: @merge_time } if @merge_time %>
 </div>

--- a/app/views/users_projects/metrics.erb
+++ b/app/views/users_projects/metrics.erb
@@ -9,18 +9,9 @@
       prompt: '- select option -'
     %>
   <% end %>
-  <div class='p-3 metric-container'>
-    <span class='metric-title'>Review Turnaround</span>
-    <%= line_chart @review_turnaround,
-        ytitle: "Time as hours",
-        suffix: " hours",
-        library: { spanGaps: true } %>
-  </div>
-  <div class='p-3 metric-container'>
-    <span class='metric-title'>Merge Time</span>
-    <%= line_chart @merge_time,
-        ytitle: "Time as hours",
-        suffix: " hours",
-        library: { spanGaps: true } %>
-  </div>
+  <%= render partial: 'shared/line-chart',
+              locals: { metric_name: 'Review Turnaround', metric: @review_turnaround } %>
+  <%= render partial: 'shared/line-chart',
+              locals: { metric_name: 'Merge Time', metric: @merge_time } %>
+
 </div>


### PR DESCRIPTION
## What does this PR do?

* shows nothing when a project is not selected 
* chart is moved to a partial

<img width="1440" alt="Screen Shot 2020-06-03 at 3 51 36 PM" src="https://user-images.githubusercontent.com/21251065/83677155-231baf00-a5b2-11ea-9e74-02ef868bb2df.png">


Issue:
[Jira](https://rootstrap.atlassian.net/browse/EM-42)