### PR TITLE
Add keywords to technologies

### DIFF
--- a/app/services/processors/technologies_backfiller.rb
+++ b/app/services/processors/technologies_backfiller.rb
@@ -12,13 +12,20 @@ module Processors
 
     def init_attributes
       [
-        { name: 'ruby', keyword_string: 'ruby,rails' },
-        { name: 'python', keyword_string: 'python,django' },
-        { name: 'ios', keyword_string: 'ios' },
-        { name: 'android', keyword_string: 'android' },
-        { name: 'react', keyword_string: 'react' },
-        { name: 'machine learning', keyword_string: 'machine learning' },
-        { name: 'other', keyword_string: '' }
+        { name: 'ruby',
+          keyword_string: 'ruby,rails' },
+        { name: 'python',
+          keyword_string: 'python,django' },
+        { name: 'ios',
+          keyword_string: 'ios,swift' },
+        { name: 'android',
+          keyword_string: 'android' },
+        { name: 'react',
+          keyword_string: 'react,reactjs' },
+        { name: 'machine learning',
+          keyword_string: 'machine learning,data science,artificial intelligence' },
+        { name: 'other',
+          keyword_string: '' }
       ]
     end
   end


### PR DESCRIPTION
## What does this PR do?
It adds some keywords to the technologies we have in our DB so that blog posts can be better categorized. The changes are:
- Added `swift` as a keyword for `ios` technology
- Added `reactjs` as a keyword for `react` technology
- Added `data science` and `artificial intelligence` as keywords for `machine learning` technology