### PR TITLE
[EM-63] Hide each blog technology metrics by default

### DIFF
--- a/app/services/builders/blog_metric_chart/base.rb
+++ b/app/services/builders/blog_metric_chart/base.rb
@@ -9,13 +9,15 @@ module Builders
         metrics_result = Technology.all.map do |technology|
           generate_results_for(
             entity_name: technology.name.titlecase,
-            metrics: technology.metrics
+            metrics: technology.metrics,
+            hidden: true
           )
         end
 
         metrics_result << generate_results_for(
           entity_name: 'Totals',
-          metrics: Metric.where(ownable_type: Technology.to_s)
+          metrics: Metric.where(ownable_type: Technology.to_s),
+          hidden: false
         )
       end
 
@@ -23,12 +25,13 @@ module Builders
 
       attr_reader :months
 
-      def generate_results_for(entity_name:, metrics:)
+      def generate_results_for(entity_name:, metrics:, hidden:)
         metrics_data = collect_data(metrics)
         processed_data = process_data(metrics_data)
         {
           name: entity_name,
-          data: format_data(processed_data)
+          data: format_data(processed_data),
+          dataset: { hidden: hidden }
         }
       end
 

--- a/spec/services/builders/blog_metric_chart/base_spec.rb
+++ b/spec/services/builders/blog_metric_chart/base_spec.rb
@@ -26,16 +26,43 @@ describe Builders::BlogMetricChart::Base do
         )
       end
       let(:totals_hash) do
-        {
+        a_hash_including(
           name: 'Totals',
           data: a_hash_including(
             Time.zone.now.strftime('%B %Y') => metric_1.value + metric_2.value
           )
-        }
+        )
       end
 
       it 'includes each month totals in the hash response' do
         expect(subject.call).to include(totals_hash)
+      end
+    end
+
+    describe 'hidden results' do
+      let(:technology) { create(:technology) }
+      let!(:metric) do
+        create(
+          :metric,
+          ownable: technology,
+          interval: Metric.intervals[:monthly],
+          name: Metric.names[:blog_post_count],
+          value_timestamp: Time.zone.now.end_of_month
+        )
+      end
+
+      it 'each technology dataset is hidden' do
+        technology_dataset = subject.call.find do |dataset|
+          dataset[:name] == technology.name.titleize
+        end
+
+        expect(technology_dataset[:dataset][:hidden]).to eq true
+      end
+
+      it 'the totals dataset is not hidden' do
+        totals_dataset = subject.call.find { |dataset| dataset[:name] == 'Totals' }
+
+        expect(totals_dataset[:dataset][:hidden]).to eq false
       end
     end
   end

--- a/spec/services/builders/blog_metric_chart/technology_blog_post_count_spec.rb
+++ b/spec/services/builders/blog_metric_chart/technology_blog_post_count_spec.rb
@@ -25,13 +25,13 @@ describe Builders::BlogMetricChart::TechnologyBlogPostCount do
     end
 
     let(:technology_metrics_hash) do
-      {
+      a_hash_including(
         name: technology.name.titlecase,
         data: a_hash_including(
           last_month_metric.value_timestamp.strftime('%B %Y') => last_month_metric.value,
           this_month_metric.value_timestamp.strftime('%B %Y') => this_month_metric.value
         )
-      }
+      )
     end
 
     it 'returns the blog post count per technology formatted by technology and month' do

--- a/spec/services/builders/blog_metric_chart/technology_visits_growth_mom_spec.rb
+++ b/spec/services/builders/blog_metric_chart/technology_visits_growth_mom_spec.rb
@@ -42,12 +42,12 @@ describe Builders::BlogMetricChart::TechnologyVisitsGrowthMom do
     describe 'totals' do
       let(:other_tecnology) { create(:technology) }
       let(:totals_hash) do
-        {
+        a_hash_including(
           name: 'Totals',
           data: a_hash_including(
             Time.zone.now.strftime('%B %Y') => 10
           )
-        }
+        )
       end
 
       before do

--- a/spec/services/builders/blog_metric_chart/technology_visits_spec.rb
+++ b/spec/services/builders/blog_metric_chart/technology_visits_spec.rb
@@ -24,13 +24,13 @@ describe Builders::BlogMetricChart::TechnologyVisits do
       )
     end
     let(:technology_metrics_hash) do
-      {
+      a_hash_including(
         name: technology.name.titlecase,
         data: a_hash_including(
           last_month_metric.value_timestamp.strftime('%B %Y') => last_month_metric.value,
           this_month_metric.value_timestamp.strftime('%B %Y') => this_month_metric.value
         )
-      }
+      )
     end
 
     it 'returns the technology visits formatted by technology and month' do


### PR DESCRIPTION
## What does this PR do?
It shows the blog charts with all the technologies deselected (i.e.: hidden, not shown). The only visible metrics are for the totals

![image](https://user-images.githubusercontent.com/7276679/84825160-6422b300-aff7-11ea-81d5-44c9b4db9f5b.png)

## Link to Story
https://rootstrap.atlassian.net/jira/software/projects/EM/boards/42?selectedIssue=EM-63
