### PR TITLE
[EM-62] Update blog posts with correct tags

### DIFF
--- a/app/services/blog_post_categorizer.rb
+++ b/app/services/blog_post_categorizer.rb
@@ -1,14 +1,20 @@
 class BlogPostCategorizer
   def technology_for(blog_post_payload)
-    Technology.all.detect(default_technology) do |technology|
+    technologies.detect(default_technology) do |technology|
       keywords_for(blog_post_payload).any? do |keyword|
         technology.keywords.include?(keyword)
       end
     end
   end
 
+  private
+
+  def technologies
+    @technologies ||= Technology.all
+  end
+
   def default_technology
-    proc { Technology.other }
+    @default_technology ||= proc { Technology.other }
   end
 
   def keywords_for(blog_post_payload)

--- a/app/services/processors/blog_posts_updater.rb
+++ b/app/services/processors/blog_posts_updater.rb
@@ -2,12 +2,13 @@ module Processors
   class BlogPostsUpdater < BaseService
     def call
       blog_posts.each do |blog_post_payload|
-        blog_post = BlogPost.find_or_initialize_by(blog_id: blog_post_payload[:ID])
+        blog_post_id = blog_post_payload[:ID]
+        blog_post = BlogPost.find_or_initialize_by(blog_id: blog_post_id)
         blog_post.published_at = blog_post_payload[:date]
         blog_post.slug = blog_post_payload[:slug]
         blog_post.status = blog_post_payload[:status]
         blog_post.url = blog_post_payload[:URL]
-        blog_post.technology = categorizer.technology_for(blog_post_payload)
+        blog_post.technology = technology_for(blog_post_id)
 
         blog_post.save!
       end
@@ -21,6 +22,11 @@ module Processors
 
     def categorizer
       @categorizer ||= BlogPostCategorizer.new
+    end
+
+    def technology_for(blog_post_id)
+      blog_post_payload = wordpress_service.blog_post(blog_post_id)
+      categorizer.technology_for(blog_post_payload)
     end
   end
 end

--- a/app/services/wordpress_service.rb
+++ b/app/services/wordpress_service.rb
@@ -32,6 +32,15 @@ class WordpressService
     JSON.parse(response.body).with_indifferent_access
   end
 
+  def blog_post(blog_post_id)
+    response = connection.get(
+      "https://public-api.wordpress.com/rest/v1.1/sites/#{site_id}/posts/#{blog_post_id}",
+      {},
+      Authorization: "Bearer #{access_token}"
+    )
+    JSON.parse(response.body).with_indifferent_access
+  end
+
   private
 
   def access_token

--- a/spec/services/processors/blog_posts_full_updater_spec.rb
+++ b/spec/services/processors/blog_posts_full_updater_spec.rb
@@ -3,7 +3,6 @@ require 'rails_helper'
 describe Processors::BlogPostsFullUpdater do
   describe '.call' do
     context 'when there is already a blog post stored in the DB' do
-      let(:api_service) { instance_double(WordpressService) }
       let(:publish_date) { Faker::Time.backward }
       let!(:stored_blog_post) { create(:blog_post, published_at: publish_date) }
       let(:updated_slug) { 'newly-updated-slug' }
@@ -24,11 +23,10 @@ describe Processors::BlogPostsFullUpdater do
       let(:blog_post_payload) { [stored_blog_post_payload, new_blog_post_payload] }
 
       before do
-        allow_any_instance_of(described_class)
-          .to receive(:wordpress_service)
-          .and_return(api_service)
-        allow(api_service).to receive(:blog_posts).and_return(blog_post_payload)
         create(:technology, name: 'other')
+        stub_blog_posts_response(blog_post_payloads: blog_post_payload)
+        stub_blog_post_response(stored_blog_post_payload)
+        stub_blog_post_response(new_blog_post_payload)
       end
 
       it 'updates the stored blog post' do

--- a/spec/services/processors/blog_posts_partial_updater_spec.rb
+++ b/spec/services/processors/blog_posts_partial_updater_spec.rb
@@ -3,7 +3,6 @@ require 'rails_helper'
 describe Processors::BlogPostsPartialUpdater do
   describe '.call' do
     context 'when there is already a blog post stored in the DB' do
-      let(:api_service) { instance_double(WordpressService) }
       let(:publish_date) { Faker::Time.backward }
       let!(:stored_blog_post) { create(:blog_post, published_at: publish_date) }
       let(:updated_slug) { 'newly-updated-slug' }
@@ -24,14 +23,12 @@ describe Processors::BlogPostsPartialUpdater do
       let(:partial_blog_post_payload) { [new_blog_post_payload] }
 
       before do
-        allow_any_instance_of(described_class)
-          .to receive(:wordpress_service)
-          .and_return(api_service)
-        allow(api_service)
-          .to receive(:blog_posts)
-          .with(since: publish_date)
-          .and_return(partial_blog_post_payload)
         create(:technology, name: 'other')
+        stub_blog_posts_response(
+          request_params: { after: publish_date.utc.iso8601 },
+          blog_post_payloads: partial_blog_post_payload
+        )
+        stub_blog_post_response(new_blog_post_payload)
       end
 
       it 'does not update the stored blog post' do

--- a/spec/services/processors/blog_posts_updater_spec.rb
+++ b/spec/services/processors/blog_posts_updater_spec.rb
@@ -6,7 +6,9 @@ RSpec.describe Processors::BlogPostsUpdater do
 
     before do
       create(:technology, name: 'other')
-      stub_blog_posts_response
+      blog_post_payload = create(:blog_post_payload)
+      stub_blog_posts_response(blog_post_payloads: [blog_post_payload])
+      stub_blog_post_response(blog_post_payload)
     end
 
     it 'saves all blog posts in the db' do

--- a/spec/services/wordpress_service_spec.rb
+++ b/spec/services/wordpress_service_spec.rb
@@ -90,4 +90,17 @@ RSpec.describe WordpressService do
       expect(subject.blog_post_views(blog_post_id)).to eq blog_post_views_payload
     end
   end
+
+  describe '#blog_post' do
+    let(:blog_post_payload) { create(:blog_post_payload) }
+    let(:blog_post_id) { blog_post_payload['ID'] }
+
+    before do
+      stub_blog_post_response(blog_post_payload)
+    end
+
+    it 'returns the payload of the requested post' do
+      expect(subject.blog_post(blog_post_id)).to eq blog_post_payload
+    end
+  end
 end

--- a/spec/support/helpers/wordpress_api_mocker.rb
+++ b/spec/support/helpers/wordpress_api_mocker.rb
@@ -59,6 +59,18 @@ module WordpressApiMocker
       .to_return(body: JSON.generate(blog_posts_response), status: 200)
   end
 
+  def stub_blog_post_response(blog_post_payload = create(:blog_post_payload))
+    stub_access_token_response
+    stub_env('WORDPRESS_SITE_ID', blog_site_id)
+
+    blog_post_id = blog_post_payload['ID']
+    url = 'https://public-api.wordpress.com/rest/v1.1/sites/' \
+          "#{blog_site_id}/posts/#{blog_post_id}"
+    stub_request(:get, url)
+      .with(headers: authorization_header)
+      .to_return(body: JSON.generate(blog_post_payload), status: 200)
+  end
+
   def stub_access_token_response(
     response_body: { access_token: access_token },
     response_status: 200


### PR DESCRIPTION
## What does this PR do?
When requesting blog posts from Wordpress through the `rest/v1.1/me/posts` endpoint, many are returned without tags nor categories, used for categorizing them properly.

To avoid this, we need to make a request to `/rest/v1.1/sites/SITE_ID/posts/BLOG_POST_ID` to get the correct tags and categories and use these ones to categorize the blog post.
