### PR TITLE
Add open issues count to project view

### DIFF
--- a/app/views/shared/_code-climate-summary.erb
+++ b/app/views/shared/_code-climate-summary.erb
@@ -12,6 +12,9 @@
       <div class="col-md-3">
         <span class="code-climate-summary text-danger"><%= code_climate.wont_fix_issues_count %> won't fix issues</span>
       </div>
+      <div class="col-md-3">
+        <span class="code-climate-summary text-danger"><%= code_climate.open_issues_count %> open issues</span>
+      </div>
     <% else -%>
       <div class="col-md-9">
         <span class="code-climate-summary text-danger">No information available</span>


### PR DESCRIPTION
## What does this PR do?

- It adds the CodeClimate number of open issues to a project view

<img width="1151" alt="Screen Shot 2020-06-24 at 17 00 30" src="https://user-images.githubusercontent.com/60940211/85621839-48915b00-b63c-11ea-9d3a-f49ccd2f8c48.png">
