### PR TITLE
[EM-66.3] Create open source visits metrics

### DIFF
--- a/app/jobs/open_source_metrics_updater_job.rb
+++ b/app/jobs/open_source_metrics_updater_job.rb
@@ -1,0 +1,7 @@
+class OpenSourceMetricsUpdaterJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    Processors::OpenSourceMetricsUpdater.call
+  end
+end

--- a/app/models/language.rb
+++ b/app/models/language.rb
@@ -19,4 +19,8 @@ class Language < ApplicationRecord
   belongs_to :department, optional: true
   has_many :projects, dependent: :destroy
   has_many :metrics, as: :ownable, dependent: :destroy
+
+  def self.unassigned
+    find_by(name: 'unassigned')
+  end
 end

--- a/app/models/metric.rb
+++ b/app/models/metric.rb
@@ -22,7 +22,8 @@ class Metric < ApplicationRecord
   enum name: { review_turnaround: 'review_turnaround',
                blog_visits: 'blog_visits',
                merge_time: 'merge_time',
-               blog_post_count: 'blog_post_count' }
+               blog_post_count: 'blog_post_count',
+               open_source_visits: 'open_source_visits' }
 
   belongs_to :ownable, polymorphic: true
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -41,11 +41,19 @@ class Project < ApplicationRecord
 
   before_validation :set_default_language, on: :create
 
+  scope :open_source, lambda {
+    with_language.where(is_private: false)
+  }
+
+  scope :with_language, lambda {
+    joins(:language).where.not(languages: { name: 'unassigned' })
+  }
+
   private
 
   def set_default_language
     return unless language.nil?
 
-    self.language = Language.find_by(name: 'unassigned')
+    self.language = Language.unassigned
   end
 end

--- a/app/services/github_repository_client.rb
+++ b/app/services/github_repository_client.rb
@@ -10,4 +10,12 @@ class GithubRepositoryClient
                            'Accept' => 'application/vnd.github.v3.raw')
     response.success? ? response.body : ''
   end
+
+  def repository_views
+    connection = Faraday.new(url: "#{URL}/#{@project_name}/traffic/views") do |conn|
+      conn.basic_auth(ENV['GITHUB_ADMIN_USER'], ENV['GITHUB_ADMIN_TOKEN'])
+    end
+    response = connection.get
+    JSON.parse(response.body).with_indifferent_access
+  end
 end

--- a/app/services/processors/open_source_metrics_updater.rb
+++ b/app/services/processors/open_source_metrics_updater.rb
@@ -7,7 +7,9 @@ module Processors
     private
 
     def update_open_source_visits
-      OpenSourceProjectViewsUpdater.call
+      Project.open_source.each do |project|
+        OpenSourceProjectViewsUpdater.call(project)
+      end
     end
   end
 end

--- a/app/services/processors/open_source_metrics_updater.rb
+++ b/app/services/processors/open_source_metrics_updater.rb
@@ -1,0 +1,13 @@
+module Processors
+  class OpenSourceMetricsUpdater < BaseService
+    def call
+      update_open_source_visits
+    end
+
+    private
+
+    def update_open_source_visits
+      OpenSourceProjectViewsUpdater.call
+    end
+  end
+end

--- a/app/services/processors/open_source_project_views_updater.rb
+++ b/app/services/processors/open_source_project_views_updater.rb
@@ -1,0 +1,48 @@
+module Processors
+  class OpenSourceProjectViewsUpdater < BaseService
+    def call
+      Project.open_source.each do |project|
+        views_to_update_for(project).each do |project_views_payload|
+          update_views_metric_for_project(
+            project,
+            project_views_payload['timestamp'],
+            project_views_payload['uniques']
+          )
+        end
+      end
+    end
+
+    private
+
+    def views_to_update_for(project)
+      last_updated_timestamp = last_updated_timestamp_for(project)
+
+      views_for_project(project)['views'].select do |views_payload|
+        last_updated_timestamp <= views_payload['timestamp']
+      end
+    end
+
+    def last_updated_timestamp_for(project)
+      Metric.where(
+        name: Metric.names[:open_source_visits],
+        interval: Metric.intervals[:daily],
+        ownable: project
+      ).maximum(:value_timestamp) || Time.zone.at(0)
+    end
+
+    def views_for_project(project)
+      GithubRepositoryClient.new(project.name).repository_views
+    end
+
+    def update_views_metric_for_project(project, timestamp, views)
+      metric = Metric.find_or_initialize_by(
+        ownable: project,
+        name: Metric.names[:open_source_visits],
+        interval: Metric.intervals[:daily],
+        value_timestamp: timestamp
+      )
+      metric.value = views
+      metric.save!
+    end
+  end
+end

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -42,3 +42,8 @@ code_climate_metrics_update:
   cron: '00 * * * *'
   class: 'CodeClimateMetricsUpdaterJob'
   active_job: true
+
+open_source_metrics_update:
+  cron: '00 6 * * *'
+  class: 'OpenSourceMetricsUpdaterJob'
+  active_job: true

--- a/db/migrate/20200630165139_add_open_source_visits_to_metric_name_type.rb
+++ b/db/migrate/20200630165139_add_open_source_visits_to_metric_name_type.rb
@@ -1,0 +1,18 @@
+class AddOpenSourceVisitsToMetricNameType < ActiveRecord::Migration[6.0]
+  disable_ddl_transaction!
+
+  def up
+    execute <<-SQL
+      ALTER TYPE metric_name ADD VALUE 'open_source_visits';
+    SQL
+  end
+
+  def down
+    execute <<-SQL
+      ALTER TYPE metric_name RENAME TO metric_name_old;
+      CREATE TYPE metric_name AS ENUM ('review_turnaround', 'blog_visits', 'merge_time', 'blog_post_count');
+      ALTER TABLE metrics ALTER COLUMN name TYPE metric_name USING name::text::metric_name;
+      DROP TYPE metric_name_old;
+    SQL
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -72,7 +72,8 @@ CREATE TYPE public.metric_name AS ENUM (
     'review_turnaround',
     'blog_visits',
     'merge_time',
-    'blog_post_count'
+    'blog_post_count',
+    'open_source_visits'
 );
 
 
@@ -523,8 +524,8 @@ CREATE TABLE public.projects (
     description character varying,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
-    language_id bigint,
-    is_private boolean
+    is_private boolean,
+    language_id bigint
 );
 
 
@@ -1563,6 +1564,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20200622221335'),
 ('20200622221651'),
 ('20200622221729'),
-('20200625144922');
+('20200625144922'),
+('20200630165139');
 
 

--- a/spec/factories/payloads/repository_views.rb
+++ b/spec/factories/payloads/repository_views.rb
@@ -1,0 +1,22 @@
+FactoryBot.define do
+  factory :repository_views_payload, class: Hash do
+    skip_create
+
+    count { Faker::Number.number(digits: 3) }
+    uniques { Faker::Number.number(digits: 3) }
+
+    views do
+      start_date = 14.days.ago.to_date
+      end_date = Time.zone.today.to_date
+      (start_date..end_date).map(&:beginning_of_day).map do |timestamp|
+        {
+          'timestamp': timestamp.iso8601,
+          'count': Faker::Number.number(digits: 2),
+          'uniques': Faker::Number.number(digits: 2)
+        }
+      end
+    end
+
+    initialize_with { attributes.deep_stringify_keys }
+  end
+end

--- a/spec/factories/projects.rb
+++ b/spec/factories/projects.rb
@@ -21,6 +21,7 @@ FactoryBot.define do
     sequence(:github_id, 1000)
     name { Faker::App.name }
     description { Faker::FunnyName.name }
-    language { Language.find_by(name: 'unassigned') }
+    language { Language.unassigned }
+    is_private { false }
   end
 end

--- a/spec/factories/projects.rb
+++ b/spec/factories/projects.rb
@@ -23,5 +23,10 @@ FactoryBot.define do
     description { Faker::FunnyName.name }
     language { Language.unassigned }
     is_private { false }
+
+    trait :open_source do
+      language { Language.find_by(name: 'ruby') }
+      is_private { false }
+    end
   end
 end

--- a/spec/factories/projects.rb
+++ b/spec/factories/projects.rb
@@ -19,7 +19,7 @@
 FactoryBot.define do
   factory :project do
     sequence(:github_id, 1000)
-    name { Faker::App.name }
+    name { Faker::App.name.gsub(' ', '') }
     description { Faker::FunnyName.name }
     language { Language.unassigned }
     is_private { false }

--- a/spec/jobs/open_source_metrics_updater_job_spec.rb
+++ b/spec/jobs/open_source_metrics_updater_job_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+describe OpenSourceMetricsUpdaterJob do
+  describe '#perform' do
+    it 'correctly initializes the OpenSourceMetricsUpdater processor and calls it' do
+      expect_any_instance_of(Processors::OpenSourceMetricsUpdater)
+        .to receive(:call)
+        .once
+
+      described_class.perform_now
+    end
+  end
+end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -34,4 +34,25 @@ RSpec.describe Project, type: :model do
     it { is_expected.to validate_uniqueness_of(:github_id) }
     it { is_expected.to have_many(:events) }
   end
+
+  describe 'open_source' do
+    let(:language) { Language.find_by(name: 'ruby') }
+    let!(:private_project) { create(:project, is_private: true, language: language) }
+    let!(:unassigned_project) { create(:project, language: Language.unassigned) }
+    let!(:open_source_project) { create(:project, is_private: false, language: language) }
+
+    it 'returns the projects that have an assigned language and are not private' do
+      expect(Project.open_source).to contain_exactly(open_source_project)
+    end
+  end
+
+  describe 'with_language' do
+    let(:language) { Language.find_by(name: 'ruby') }
+    let!(:project_with_language) { create(:project, language: language) }
+    let!(:project_without_language) { create(:project, language: Language.unassigned) }
+
+    it 'returns the projects that have an assigned language' do
+      expect(Project.with_language).to contain_exactly(project_with_language)
+    end
+  end
 end

--- a/spec/services/github_repository_client_spec.rb
+++ b/spec/services/github_repository_client_spec.rb
@@ -18,4 +18,15 @@ RSpec.describe GithubRepositoryClient do
       end
     end
   end
+
+  describe '#repository_views' do
+    let(:project) { create(:project) }
+    let(:repository_views_payload) { create(:repository_views_payload) }
+
+    before { stub_repository_views(project.name, repository_views_payload) }
+
+    it 'returns the views hash of that project on Github' do
+      expect(described_class.new(project.name).repository_views).to eq repository_views_payload
+    end
+  end
 end

--- a/spec/services/processors/open_source_metrics_updater_spec.rb
+++ b/spec/services/processors/open_source_metrics_updater_spec.rb
@@ -2,15 +2,16 @@ require 'rails_helper'
 
 RSpec.describe Processors::OpenSourceMetricsUpdater do
   describe '.call' do
-    let(:project) { create(:project, :open_source) }
-    let(:repository_views_payload) { create(:repository_views_payload) }
-    let(:total_metrics_generated) { repository_views_payload['views'].count }
+    let!(:private_project) { create(:project, is_private: true) }
+    let!(:open_source_project) { create(:project, :open_source) }
+    let(:open_source_repository_views_payload) { create(:repository_views_payload) }
+    let(:total_metrics_generated) { open_source_repository_views_payload['views'].count }
 
     before do
-      stub_repository_views(project.name, repository_views_payload)
+      stub_repository_views(open_source_project.name, open_source_repository_views_payload)
     end
 
-    it 'generates open source visits metrics' do
+    it 'generates visits metrics for all open source projects' do
       expect { described_class.call }
         .to change(Metric.where(ownable_type: Project.to_s), :count)
         .by(total_metrics_generated)

--- a/spec/services/processors/open_source_metrics_updater_spec.rb
+++ b/spec/services/processors/open_source_metrics_updater_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe Processors::OpenSourceMetricsUpdater do
+  describe '.call' do
+    let(:project) { create(:project, :open_source) }
+    let(:repository_views_payload) { create(:repository_views_payload) }
+    let(:total_metrics_generated) { repository_views_payload['views'].count }
+
+    before do
+      stub_repository_views(project.name, repository_views_payload)
+    end
+
+    it 'generates open source visits metrics' do
+      expect { described_class.call }
+        .to change(Metric.where(ownable_type: Project.to_s), :count)
+        .by(total_metrics_generated)
+    end
+  end
+end

--- a/spec/services/processors/open_source_project_views_updater_spec.rb
+++ b/spec/services/processors/open_source_project_views_updater_spec.rb
@@ -2,47 +2,44 @@ require 'rails_helper'
 
 RSpec.describe Processors::OpenSourceProjectViewsUpdater do
   describe '.call' do
-    let!(:open_source_project) { create(:project, :open_source) }
-    let(:open_source_repository_views_payload) { create(:repository_views_payload) }
-    let!(:private_project) { create(:project, is_private: true) }
-    let(:private_repository_views_payload) { create(:repository_views_payload) }
+    let(:project) { create(:project, :open_source) }
+    let(:repository_views_payload) { create(:repository_views_payload) }
 
     before do
-      stub_repository_views(private_project.name, private_repository_views_payload)
-      stub_repository_views(open_source_project.name, open_source_repository_views_payload)
+      stub_repository_views(project.name, repository_views_payload)
     end
 
-    it 'generates visits metrics for all open source projects' do
-      expect { described_class.call }
+    it 'generates visits metrics for the given project' do
+      expect { described_class.call(project) }
         .to change {
           Metric.where(
             name: Metric.names[:open_source_visits],
             interval: Metric.intervals[:daily]
           ).count
         }
-        .by(open_source_repository_views_payload['views'].count)
+        .by(repository_views_payload['views'].count)
     end
 
     context 'when the project has already some views metrics' do
       let(:old_views) { 3 }
-      let(:today_views_payload) { open_source_repository_views_payload['views'].last }
+      let(:today_views_payload) { repository_views_payload['views'].last }
       let(:today_timestamp) { today_views_payload['timestamp'] }
       let(:new_views) { today_views_payload['uniques'] }
       let(:today_metric) do
         Metric.find_by(
           name: Metric.names[:open_source_visits],
           interval: Metric.intervals[:daily],
-          ownable: open_source_project,
+          ownable: project,
           value_timestamp: today_timestamp
         )
       end
 
       before do
-        open_source_repository_views_payload['views'].each do |views_payload|
+        repository_views_payload['views'].each do |views_payload|
           Metric.create(
             name: Metric.names[:open_source_visits],
             interval: Metric.intervals[:daily],
-            ownable: open_source_project,
+            ownable: project,
             value: old_views,
             value_timestamp: views_payload['timestamp']
           )
@@ -50,7 +47,7 @@ RSpec.describe Processors::OpenSourceProjectViewsUpdater do
       end
 
       it 'updates the last metric value' do
-        expect { described_class.call }
+        expect { described_class.call(project) }
           .to change { today_metric.reload.value }
           .from(old_views)
           .to(new_views)
@@ -59,7 +56,7 @@ RSpec.describe Processors::OpenSourceProjectViewsUpdater do
       it 'only tries to update the last metric' do
         expect(Metric).to receive(:find_or_initialize_by).once.and_call_original
 
-        described_class.call
+        described_class.call(project)
       end
     end
   end

--- a/spec/services/processors/open_source_project_views_updater_spec.rb
+++ b/spec/services/processors/open_source_project_views_updater_spec.rb
@@ -1,0 +1,66 @@
+require 'rails_helper'
+
+RSpec.describe Processors::OpenSourceProjectViewsUpdater do
+  describe '.call' do
+    let!(:open_source_project) { create(:project, :open_source) }
+    let(:open_source_repository_views_payload) { create(:repository_views_payload) }
+    let!(:private_project) { create(:project, is_private: true) }
+    let(:private_repository_views_payload) { create(:repository_views_payload) }
+
+    before do
+      stub_repository_views(private_project.name, private_repository_views_payload)
+      stub_repository_views(open_source_project.name, open_source_repository_views_payload)
+    end
+
+    it 'generates visits metrics for all open source projects' do
+      expect { described_class.call }
+        .to change {
+          Metric.where(
+            name: Metric.names[:open_source_visits],
+            interval: Metric.intervals[:daily]
+          ).count
+        }
+        .by(open_source_repository_views_payload['views'].count)
+    end
+
+    context 'when the project has already some views metrics' do
+      let(:old_views) { 3 }
+      let(:today_views_payload) { open_source_repository_views_payload['views'].last }
+      let(:today_timestamp) { today_views_payload['timestamp'] }
+      let(:new_views) { today_views_payload['uniques'] }
+      let(:today_metric) do
+        Metric.find_by(
+          name: Metric.names[:open_source_visits],
+          interval: Metric.intervals[:daily],
+          ownable: open_source_project,
+          value_timestamp: today_timestamp
+        )
+      end
+
+      before do
+        open_source_repository_views_payload['views'].each do |views_payload|
+          Metric.create(
+            name: Metric.names[:open_source_visits],
+            interval: Metric.intervals[:daily],
+            ownable: open_source_project,
+            value: old_views,
+            value_timestamp: views_payload['timestamp']
+          )
+        end
+      end
+
+      it 'updates the last metric value' do
+        expect { described_class.call }
+          .to change { today_metric.reload.value }
+          .from(old_views)
+          .to(new_views)
+      end
+
+      it 'only tries to update the last metric' do
+        expect(Metric).to receive(:find_or_initialize_by).once.and_call_original
+
+        described_class.call
+      end
+    end
+  end
+end

--- a/spec/support/helpers/github_api_mocker.rb
+++ b/spec/support/helpers/github_api_mocker.rb
@@ -12,6 +12,17 @@ module GithubApiMock
       )
   end
 
+  def stub_repository_views(project_name, repository_views_payload)
+    stub_env('GITHUB_ADMIN_USER', github_admin_user)
+    stub_env('GITHUB_ADMIN_TOKEN', github_admin_token)
+
+    url = "#{GithubRepositoryClient::URL}/#{project_name}/traffic/views"
+
+    stub_request(:get, url)
+      .with(basic_auth: [github_admin_user, github_admin_token])
+      .to_return(body: JSON.generate(repository_views_payload), status: 200)
+  end
+
   def not_found_body_from_github
     {
       'message': 'Not Found',
@@ -23,5 +34,13 @@ module GithubApiMock
 
   def base_content_file
     file_fixture('code_owners_file.txt').read
+  end
+
+  def github_admin_user
+    'adminuser'
+  end
+
+  def github_admin_token
+    '1q2w3e4r5t'
   end
 end


### PR DESCRIPTION
## What does this PR do?
It creates the `open_source_visits` metric for projects.
It includes:
- `OpenSourceProjectViewsUpdater` processor to update every project repository views on the `Metrics` table
- Schedule the job to update all Open Source metrics once per day 
