### PR TITLE
[EM-66.5] Make open source visits metrics weekly

### DIFF
--- a/app/services/builders/metric_chart/base.rb
+++ b/app/services/builders/metric_chart/base.rb
@@ -1,12 +1,12 @@
 module Builders
   module MetricChart
     class Base < BaseService
-      def initialize(months = 13)
-        @months = months
+      def initialize(periods = 13)
+        @periods = periods
       end
 
       def call
-        datasets = entity_type.all.map do |entity|
+        datasets = entities.map do |entity|
           generate_results_for(
             entity_name: entity_name(entity),
             metrics: entity_metrics(entity),
@@ -25,7 +25,7 @@ module Builders
 
       private
 
-      attr_reader :months
+      attr_reader :periods
 
       def generate_results_for(entity_name:, metrics:, hidden:)
         metrics_data = collect_data(metrics)
@@ -38,8 +38,8 @@ module Builders
       end
 
       def collect_data(metrics)
-        metrics.where(name: metric_name)
-               .group_by_month(:value_timestamp, last: months)
+        metrics.where(name: metric_name, interval: metric_interval)
+               .group_by_period(grouping_period, :value_timestamp, last: periods)
                .sum(:value)
       end
 
@@ -48,10 +48,10 @@ module Builders
       end
 
       def format_data(metrics_data)
-        metrics_data.transform_keys { |date| date.strftime('%B %Y') }
+        metrics_data.transform_keys { |date| date.strftime(chart_date_format) }
       end
 
-      def entity_type
+      def entities
         raise NoMethodError
       end
 
@@ -68,6 +68,18 @@ module Builders
       end
 
       def metric_name
+        raise NoMethodError
+      end
+
+      def metric_interval
+        raise NoMethodError
+      end
+
+      def chart_date_format
+        raise NoMethodError
+      end
+
+      def grouping_period
         raise NoMethodError
       end
     end

--- a/app/services/builders/metric_chart/blog/base.rb
+++ b/app/services/builders/metric_chart/blog/base.rb
@@ -2,8 +2,10 @@ module Builders
   module MetricChart
     module Blog
       class Base < Builders::MetricChart::Base
-        def entity_type
-          Technology
+        private
+
+        def entities
+          Technology.all
         end
 
         def entity_name(technology)
@@ -15,7 +17,19 @@ module Builders
         end
 
         def metric_ownable_type
-          entity_type
+          Technology
+        end
+
+        def metric_interval
+          :monthly
+        end
+
+        def chart_date_format
+          '%B %Y'
+        end
+
+        def grouping_period
+          :month
         end
       end
     end

--- a/app/services/builders/metric_chart/open_source/base.rb
+++ b/app/services/builders/metric_chart/open_source/base.rb
@@ -2,8 +2,15 @@ module Builders
   module MetricChart
     module OpenSource
       class Base < Builders::MetricChart::Base
-        def entity_type
-          Language
+        def initialize(periods = 24)
+          Groupdate.week_start = :monday
+          super(periods)
+        end
+
+        private
+
+        def entities
+          Language.where.not(name: 'unassigned')
         end
 
         def entity_name(language)
@@ -16,6 +23,18 @@ module Builders
 
         def metric_ownable_type
           ::Project
+        end
+
+        def metric_interval
+          :weekly
+        end
+
+        def chart_date_format
+          '%Y-%m-%d'
+        end
+
+        def grouping_period
+          :week
         end
       end
     end

--- a/app/services/github_repository_client.rb
+++ b/app/services/github_repository_client.rb
@@ -15,7 +15,7 @@ class GithubRepositoryClient
     connection = Faraday.new(url: "#{URL}/#{@project_name}/traffic/views") do |conn|
       conn.basic_auth(ENV['GITHUB_ADMIN_USER'], ENV['GITHUB_ADMIN_TOKEN'])
     end
-    response = connection.get
+    response = connection.get { |request| request.params['per'] = 'week' }
     JSON.parse(response.body).with_indifferent_access
   end
 end

--- a/app/services/processors/open_source_project_views_updater.rb
+++ b/app/services/processors/open_source_project_views_updater.rb
@@ -26,7 +26,7 @@ module Processors
     def last_updated_timestamp
       Metric.where(
         name: Metric.names[:open_source_visits],
-        interval: Metric.intervals[:daily],
+        interval: Metric.intervals[:weekly],
         ownable: project
       ).maximum(:value_timestamp) || Time.zone.at(0)
     end
@@ -39,7 +39,7 @@ module Processors
       metric = Metric.find_or_initialize_by(
         ownable: project,
         name: Metric.names[:open_source_visits],
-        interval: Metric.intervals[:daily],
+        interval: Metric.intervals[:weekly],
         value_timestamp: timestamp
       )
       metric.value = views

--- a/spec/factories/payloads/repository_views.rb
+++ b/spec/factories/payloads/repository_views.rb
@@ -6,9 +6,12 @@ FactoryBot.define do
     uniques { Faker::Number.number(digits: 3) }
 
     views do
-      start_date = 14.days.ago.to_date
-      end_date = Time.zone.today.to_date
-      (start_date..end_date).map(&:beginning_of_day).map do |timestamp|
+      now = Time.zone.now
+      [
+        now - 2.weeks,
+        now.last_week,
+        now
+      ].map(&:beginning_of_week).map do |timestamp|
         {
           'timestamp': timestamp.iso8601,
           'count': Faker::Number.number(digits: 2),

--- a/spec/services/builders/metric_chart/base_spec.rb
+++ b/spec/services/builders/metric_chart/base_spec.rb
@@ -66,8 +66,8 @@ describe Builders::MetricChart::Base do
   describe 'abstract methods' do
     subject { described_class.send(:new) }
 
-    describe '#entity_type' do
-      it_behaves_like 'abstract method', :entity_type, 0
+    describe '#entities' do
+      it_behaves_like 'abstract method', :entities, 0
     end
 
     describe '#entity_name' do
@@ -84,6 +84,18 @@ describe Builders::MetricChart::Base do
 
     describe '#metric_name' do
       it_behaves_like 'abstract method', :metric_name, 0
+    end
+
+    describe '#metric_interval' do
+      it_behaves_like 'abstract method', :metric_interval, 0
+    end
+
+    describe '#chart_date_format' do
+      it_behaves_like 'abstract method', :chart_date_format, 0
+    end
+
+    describe '#grouping_period' do
+      it_behaves_like 'abstract method', :grouping_period, 0
     end
   end
 end

--- a/spec/services/builders/metric_chart/open_source/base_spec.rb
+++ b/spec/services/builders/metric_chart/open_source/base_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe Builders::MetricChart::OpenSource::Base do
+  subject { Builders::MetricChart::OpenSource::LanguageVisits }
+
+  describe 'languages included' do
+    it 'does not include the unassigned language' do
+      expect(subject.call.datasets).not_to include(a_hash_including(name: 'Unassigned'))
+    end
+  end
+end

--- a/spec/services/builders/metric_chart/open_source/language_visits_spec.rb
+++ b/spec/services/builders/metric_chart/open_source/language_visits_spec.rb
@@ -2,45 +2,40 @@ require 'rails_helper'
 
 RSpec.describe Builders::MetricChart::OpenSource::LanguageVisits do
   describe '.call' do
-    let(:language) { project.language }
-    let(:project) { create(:project, :open_source) }
-    let(:last_month_visit_values) { [15, 23, 10, 17, 28] }
-    let(:this_month_visit_values) { [34, 63, 19, 11] }
-    let(:first_day_of_last_month) { first_day_of_month.last_month }
-    let(:first_day_of_month) { Time.zone.now.beginning_of_month.to_date }
-    let(:last_month_timestamps) { first_day_of_last_month..first_day_of_last_month.next_day(4) }
-    let(:this_month_timestamps) { first_day_of_month..first_day_of_month.next_day(3) }
+    let(:language) { project_1.language }
+    let(:project_1) { create(:project, :open_source) }
+    let(:project_2) { create(:project, :open_source, language: language) }
+    let(:last_week_timestamp) { this_week_timestamp.last_week }
+    let(:this_week_timestamp) { Time.zone.now.beginning_of_week }
+    let!(:last_week_metric_1) { create_visits_metric(project_1, 10, last_week_timestamp) }
+    let!(:last_week_metric_2) { create_visits_metric(project_2, 20, last_week_timestamp) }
+    let!(:this_week_metric_1) { create_visits_metric(project_1, 15, this_week_timestamp) }
+    let!(:this_week_metric_2) { create_visits_metric(project_2, 30, this_week_timestamp) }
+    let(:last_week_visits) { last_week_metric_1.value + last_week_metric_2.value }
+    let(:this_week_visits) { this_week_metric_1.value + this_week_metric_2.value }
     let(:language_visits_hash) do
       a_hash_including(
         name: language.name.titlecase,
         data: a_hash_including(
-          first_day_of_last_month.strftime('%B %Y') => last_month_visit_values.sum,
-          first_day_of_month.strftime('%B %Y') => this_month_visit_values.sum
+          last_week_timestamp.strftime('%Y-%m-%d') => last_week_visits,
+          this_week_timestamp.strftime('%Y-%m-%d') => this_week_visits
         )
       )
     end
 
-    before do
-      values_and_timestamps = last_month_visit_values.zip(last_month_timestamps) +
-                              this_month_visit_values.zip(this_month_timestamps)
-      create_visits_metrics(project, values_and_timestamps)
-    end
-
-    it 'returns the monthly visits grouped by language' do
+    it 'returns the weekly visits grouped by language' do
       expect(described_class.call.datasets).to include(language_visits_hash)
     end
   end
 
-  def create_visits_metrics(project, values_and_timestamps)
-    values_and_timestamps.each do |value, timestamp|
-      create(
-        :metric,
-        name: Metric.names[:open_source_visits],
-        interval: Metric.intervals[:daily],
-        ownable: project,
-        value: value,
-        value_timestamp: timestamp
-      )
-    end
+  def create_visits_metric(project, value, timestamp)
+    create(
+      :metric,
+      name: Metric.names[:open_source_visits],
+      interval: Metric.intervals[:weekly],
+      ownable: project,
+      value: value,
+      value_timestamp: timestamp
+    )
   end
 end

--- a/spec/services/processors/open_source_project_views_updater_spec.rb
+++ b/spec/services/processors/open_source_project_views_updater_spec.rb
@@ -14,23 +14,23 @@ RSpec.describe Processors::OpenSourceProjectViewsUpdater do
         .to change {
           Metric.where(
             name: Metric.names[:open_source_visits],
-            interval: Metric.intervals[:daily]
+            interval: Metric.intervals[:weekly]
           ).count
         }
         .by(repository_views_payload['views'].count)
     end
 
-    context 'when the project has already some views metrics' do
+    context 'when the project already has some views metrics' do
       let(:old_views) { 3 }
-      let(:today_views_payload) { repository_views_payload['views'].last }
-      let(:today_timestamp) { today_views_payload['timestamp'] }
-      let(:new_views) { today_views_payload['uniques'] }
-      let(:today_metric) do
+      let(:this_week_views_payload) { repository_views_payload['views'].last }
+      let(:this_week_timestamp) { this_week_views_payload['timestamp'] }
+      let(:new_views) { this_week_views_payload['uniques'] }
+      let(:this_week_metric) do
         Metric.find_by(
           name: Metric.names[:open_source_visits],
-          interval: Metric.intervals[:daily],
+          interval: Metric.intervals[:weekly],
           ownable: project,
-          value_timestamp: today_timestamp
+          value_timestamp: this_week_timestamp
         )
       end
 
@@ -38,7 +38,7 @@ RSpec.describe Processors::OpenSourceProjectViewsUpdater do
         repository_views_payload['views'].each do |views_payload|
           Metric.create(
             name: Metric.names[:open_source_visits],
-            interval: Metric.intervals[:daily],
+            interval: Metric.intervals[:weekly],
             ownable: project,
             value: old_views,
             value_timestamp: views_payload['timestamp']
@@ -48,7 +48,7 @@ RSpec.describe Processors::OpenSourceProjectViewsUpdater do
 
       it 'updates the last metric value' do
         expect { described_class.call(project) }
-          .to change { today_metric.reload.value }
+          .to change { this_week_metric.reload.value }
           .from(old_views)
           .to(new_views)
       end

--- a/spec/support/helpers/github_api_mocker.rb
+++ b/spec/support/helpers/github_api_mocker.rb
@@ -19,7 +19,7 @@ module GithubApiMock
     url = "#{GithubRepositoryClient::URL}/#{project_name}/traffic/views"
 
     stub_request(:get, url)
-      .with(basic_auth: [github_admin_user, github_admin_token])
+      .with(basic_auth: [github_admin_user, github_admin_token], query: { per: 'week' })
       .to_return(body: JSON.generate(repository_views_payload), status: 200)
   end
 


### PR DESCRIPTION
## What does this PR do?
It changes the way we calculate and show Open Source metrics. We used to fetch the daily visits and show them grouped by month. But as we're looking for unique visits, adding each month daily unique visits does not equal to the monthly unique visits.
So given that the biggest period the Github API returns the unique visits is weekly, we'll now get and show them weekly.

![image](https://user-images.githubusercontent.com/7276679/86935948-c6ad3180-c113-11ea-9c81-b6043c70b6ac.png)

