### PR TITLE
[EM-100 & EM-108] Split react and react native technologies and add ruby on rails keyword to ruby

### DIFF
--- a/app/services/processors/technologies_backfiller.rb
+++ b/app/services/processors/technologies_backfiller.rb
@@ -13,7 +13,7 @@ module Processors
     def init_attributes
       [
         { name: 'ruby',
-          keyword_string: 'ruby,rails' },
+          keyword_string: 'ruby,rails,ruby on rails' },
         { name: 'python',
           keyword_string: 'python,django' },
         { name: 'ios',
@@ -22,6 +22,8 @@ module Processors
           keyword_string: 'android' },
         { name: 'react',
           keyword_string: 'react,reactjs' },
+        { name: 'react native',
+          keyword_string: 'react native,react-native' },
         { name: 'machine learning',
           keyword_string: 'machine learning,data science,artificial intelligence' },
         { name: 'other',

--- a/spec/services/processors/technologies_backfiller_spec.rb
+++ b/spec/services/processors/technologies_backfiller_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe Processors::TechnologiesBackfiller do
       expect(all_technologies).to include('ios')
       expect(all_technologies).to include('android')
       expect(all_technologies).to include('react')
+      expect(all_technologies).to include('react native')
       expect(all_technologies).to include('machine learning')
       expect(all_technologies).to include('other')
     end
@@ -31,7 +32,7 @@ RSpec.describe Processors::TechnologiesBackfiller do
       it 'updates the outdated technologies' do
         described_class.call
 
-        expect(Technology.find_by(name: 'ruby').keyword_string).to eq 'ruby,rails'
+        expect(Technology.find_by(name: 'ruby').keyword_string).to eq 'ruby,rails,ruby on rails'
       end
     end
   end


### PR DESCRIPTION
## What does this PR do?
Changes to technologies table:
- Add `react native`
- Add `ruby on rails` keyword to `ruby`
