### PR TITLE
Fix Review Turnarounds generation

### DIFF
--- a/app/models/events/review.rb
+++ b/app/models/events/review.rb
@@ -52,9 +52,9 @@ module Events
     private
 
     def build_review_turnaround
-      return unless review_request.reviews.count.equal?(1)
+      return unless pull_request.reviews.count.equal?(1)
 
-      Builders::ReviewTurnaround.call(review_request)
+      Builders::ReviewTurnaround.call(pull_request)
     end
   end
 end

--- a/app/models/review_turnaround.rb
+++ b/app/models/review_turnaround.rb
@@ -2,24 +2,24 @@
 #
 # Table name: review_turnarounds
 #
-#  id                :bigint           not null, primary key
-#  value             :integer
-#  created_at        :datetime         not null
-#  updated_at        :datetime         not null
-#  review_request_id :bigint           not null
+#  id              :bigint           not null, primary key
+#  value           :integer
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  pull_request_id :bigint
 #
 # Indexes
 #
-#  index_review_turnarounds_on_review_request_id  (review_request_id)
+#  index_review_turnarounds_on_pull_request_id  (pull_request_id)
 #
 # Foreign Keys
 #
-#  fk_rails_...  (review_request_id => review_requests.id)
+#  fk_rails_...  (pull_request_id => pull_requests.id)
 #
 
 class ReviewTurnaround < ApplicationRecord
-  belongs_to :review_request
+  belongs_to :pull_request, class_name: 'Events::PullRequest'
 
   validates :value, presence: true
-  validates :review_request_id, uniqueness: true
+  validates :pull_request_id, uniqueness: true
 end

--- a/app/services/builders/chartkick/department_distribution_data.rb
+++ b/app/services/builders/chartkick/department_distribution_data.rb
@@ -16,7 +16,7 @@ module Builders
       end
 
       def review_turnarounds
-        ::ReviewTurnaround.joins(review_request: { project: { language: :department } })
+        ::ReviewTurnaround.joins(pull_request: { project: { language: :department } })
                           .where(departments: { id: @entity_id })
                           .where(created_at: @query[:value_timestamp])
       end

--- a/app/services/builders/review_turnaround.rb
+++ b/app/services/builders/review_turnaround.rb
@@ -1,17 +1,17 @@
 module Builders
   class ReviewTurnaround < BaseService
-    def initialize(review_request)
-      @review_request = review_request
+    def initialize(pull_request)
+      @pull_request = pull_request
     end
 
     def call
-      ::ReviewTurnaround.create!(review_request: @review_request, value: calculate_turnaround)
+      ::ReviewTurnaround.create!(pull_request: @pull_request, value: calculate_turnaround)
     end
 
     private
 
     def calculate_turnaround
-      @review_request.reviews.first.opened_at.to_i - @review_request.created_at.to_i
+      @pull_request.opened_at.to_i - @pull_request.reviews.first.created_at.to_i
     end
   end
 end

--- a/db/migrate/20200716151200_relate_review_turnarounds_pull_request.rb
+++ b/db/migrate/20200716151200_relate_review_turnarounds_pull_request.rb
@@ -1,0 +1,11 @@
+class RelateReviewTurnaroundsPullRequest < ActiveRecord::Migration[6.0]
+  def up
+    remove_reference :review_turnarounds, :review_request
+    add_reference :review_turnarounds, :pull_request, foreign_key: true
+  end
+
+  def down
+    remove_reference :review_turnarounds, :pull_request
+    add_reference :review_turnarounds, :review_request, foreign_key: true
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -699,10 +699,10 @@ ALTER SEQUENCE public.review_requests_id_seq OWNED BY public.review_requests.id;
 
 CREATE TABLE public.review_turnarounds (
     id bigint NOT NULL,
-    review_request_id bigint NOT NULL,
     value integer,
     created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
+    updated_at timestamp(6) without time zone NOT NULL,
+    pull_request_id bigint
 );
 
 
@@ -1409,10 +1409,10 @@ CREATE INDEX index_review_requests_on_state ON public.review_requests USING btre
 
 
 --
--- Name: index_review_turnarounds_on_review_request_id; Type: INDEX; Schema: public; Owner: -
+-- Name: index_review_turnarounds_on_pull_request_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_review_turnarounds_on_review_request_id ON public.review_turnarounds USING btree (review_request_id);
+CREATE INDEX index_review_turnarounds_on_pull_request_id ON public.review_turnarounds USING btree (pull_request_id);
 
 
 --
@@ -1488,14 +1488,6 @@ ALTER TABLE ONLY public.blog_posts
 
 
 --
--- Name: review_turnarounds fk_rails_33c3053604; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.review_turnarounds
-    ADD CONSTRAINT fk_rails_33c3053604 FOREIGN KEY (review_request_id) REFERENCES public.review_requests(id);
-
-
---
 -- Name: reviews fk_rails_4862a15e3a; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -1533,6 +1525,14 @@ ALTER TABLE ONLY public.pull_requests
 
 ALTER TABLE ONLY public.pull_requests
     ADD CONSTRAINT fk_rails_658eb0bfb4 FOREIGN KEY (owner_id) REFERENCES public.users(id);
+
+
+--
+-- Name: review_turnarounds fk_rails_7bc2fb6ebc; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.review_turnarounds
+    ADD CONSTRAINT fk_rails_7bc2fb6ebc FOREIGN KEY (pull_request_id) REFERENCES public.pull_requests(id);
 
 
 --
@@ -1708,6 +1708,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20200630165139'),
 ('20200701133311'),
 ('20200703141617'),
-('20200713152004');
+('20200713152004'),
+('20200716151200');
 
 

--- a/spec/factories/review_turnaround.rb
+++ b/spec/factories/review_turnaround.rb
@@ -2,6 +2,6 @@ FactoryBot.define do
   factory :review_turnaround do
     value { Faker::Number.number(digits: 4) }
 
-    association :review_request
+    association :pull_request
   end
 end

--- a/spec/models/events/review_spec.rb
+++ b/spec/models/events/review_spec.rb
@@ -55,14 +55,14 @@ RSpec.describe Events::Review, type: :model do
   describe 'callbacks' do
     context 'when a review is created' do
       before { travel_to(Time.zone.today.beginning_of_day) }
-      let(:review_request) { create(:review_request) }
-      let(:review) { create :review, review_request: review_request }
+      let(:pull_request) { create(:pull_request, opened_at: Time.current + 1.hour) }
+      let(:review) { create :review, pull_request: pull_request }
 
       it 'creates a review turnaround with the correct values' do
         review
         review_turnaround = ReviewTurnaround.last
-        expect(review_turnaround[:value]).to eq(0)
-        expect(review_turnaround[:review_request_id]).to eq(review_request.id)
+        expect(review_turnaround[:value]).to eq(3600)
+        expect(review_turnaround[:pull_request_id]).to eq(pull_request.id)
       end
 
       it 'creates a review turnaround' do
@@ -70,7 +70,7 @@ RSpec.describe Events::Review, type: :model do
       end
 
       context 'when there is more than one review in a review request' do
-        let!(:second_review) { create :review, review_request: review_request }
+        let!(:second_review) { create :review, pull_request: pull_request }
 
         it 'does not create review turnaround' do
           expect { review }.to_not change { ReviewTurnaround.count }

--- a/spec/models/review_turnaround_spec.rb
+++ b/spec/models/review_turnaround_spec.rb
@@ -2,19 +2,19 @@
 #
 # Table name: review_turnarounds
 #
-#  id                :bigint           not null, primary key
-#  value             :integer
-#  created_at        :datetime         not null
-#  updated_at        :datetime         not null
-#  review_request_id :bigint           not null
+#  id              :bigint           not null, primary key
+#  value           :integer
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  pull_request_id :bigint
 #
 # Indexes
 #
-#  index_review_turnarounds_on_review_request_id  (review_request_id)
+#  index_review_turnarounds_on_pull_request_id  (pull_request_id)
 #
 # Foreign Keys
 #
-#  fk_rails_...  (review_request_id => review_requests.id)
+#  fk_rails_...  (pull_request_id => pull_requests.id)
 #
 
 require 'rails_helper'
@@ -32,7 +32,7 @@ RSpec.describe ReviewTurnaround, type: :model do
       expect(subject).to_not be_valid
     end
 
-    it { is_expected.to validate_uniqueness_of(:review_request_id) }
-    it { is_expected.to belong_to(:review_request) }
+    it { is_expected.to validate_uniqueness_of(:pull_request_id) }
+    it { is_expected.to belong_to(:pull_request) }
   end
 end

--- a/spec/services/builders/chartkick/department_distribution_data_spec.rb
+++ b/spec/services/builders/chartkick/department_distribution_data_spec.rb
@@ -27,8 +27,8 @@ RSpec.describe Builders::Chartkick::DepartmentDistributionData do
       context 'when name is review turnaround' do
         before do
           values.each do |value|
-            review_request = create :review_request, project: project
-            create(:review_turnaround, review_request: review_request, value: value)
+            pull_request = create :pull_request, project: project
+            create(:review_turnaround, pull_request: pull_request, value: value)
           end
           query.merge!(name: :review_turnaround)
         end


### PR DESCRIPTION
## What does this PR do?

Fixes the misunderstanding of review turnaround. We were calculating the review turnaround as the first review of a user, which is incorrect, the correct way is to calculate it as the first review of a pull request.
