### PR TITLE
[EM-109] Support multiple technologies per blog post

### DIFF
--- a/app/models/blog_post.rb
+++ b/app/models/blog_post.rb
@@ -31,7 +31,8 @@ class BlogPost < ApplicationRecord
     auto_draft: 'auto-draft'
   }
 
-  belongs_to :technology
+  has_many :blog_post_technologies, dependent: :destroy
+  has_many :technologies, through: :blog_post_technologies
 
   validates :blog_id, uniqueness: true
   validates :status, inclusion: { in: statuses.keys }

--- a/app/models/blog_post_technology.rb
+++ b/app/models/blog_post_technology.rb
@@ -1,0 +1,25 @@
+# == Schema Information
+#
+# Table name: blog_post_technologies
+#
+#  id            :bigint           not null, primary key
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  blog_post_id  :bigint           not null
+#  technology_id :bigint           not null
+#
+# Indexes
+#
+#  index_blog_post_technologies_on_blog_post_id   (blog_post_id)
+#  index_blog_post_technologies_on_technology_id  (technology_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (blog_post_id => blog_posts.id)
+#  fk_rails_...  (technology_id => technologies.id)
+#
+
+class BlogPostTechnology < ApplicationRecord
+  belongs_to :blog_post
+  belongs_to :technology
+end

--- a/app/models/technology.rb
+++ b/app/models/technology.rb
@@ -9,7 +9,8 @@
 #  updated_at     :datetime         not null
 #
 class Technology < ApplicationRecord
-  has_many :blog_posts, dependent: :nullify
+  has_many :blog_post_technologies, dependent: :destroy
+  has_many :blog_posts, through: :blog_post_technologies
   has_many :metrics, as: :ownable, dependent: :destroy
 
   validates :name, uniqueness: true

--- a/app/services/blog_post_categorizer.rb
+++ b/app/services/blog_post_categorizer.rb
@@ -1,10 +1,14 @@
 class BlogPostCategorizer
-  def technology_for(blog_post_payload)
-    technologies.detect(default_technology) do |technology|
+  def technologies_for(blog_post_payload)
+    matching_technologies = technologies.select do |technology|
       keywords_for(blog_post_payload).any? do |keyword|
         technology.keywords.include?(keyword)
       end
     end
+
+    matching_technologies << default_technology if matching_technologies.empty?
+
+    matching_technologies
   end
 
   private
@@ -14,7 +18,7 @@ class BlogPostCategorizer
   end
 
   def default_technology
-    @default_technology ||= proc { Technology.other }
+    @default_technology ||= Technology.other
   end
 
   def keywords_for(blog_post_payload)

--- a/app/services/builders/chart_summary/month_to_date_new_blog_posts.rb
+++ b/app/services/builders/chart_summary/month_to_date_new_blog_posts.rb
@@ -3,7 +3,7 @@ module Builders
     class MonthToDateNewBlogPosts < BaseService
       def call
         BlogPost
-          .where('published_at > ?', Time.zone.now.beginning_of_month)
+          .where('published_at >= ?', Time.zone.now.beginning_of_month)
           .count
       end
     end

--- a/app/services/builders/chart_summary/year_to_date_blog_visits.rb
+++ b/app/services/builders/chart_summary/year_to_date_blog_visits.rb
@@ -3,8 +3,8 @@ module Builders
     class YearToDateBlogVisits < BaseService
       def call
         Metric
-          .where(name: Metric.names[:blog_visits], ownable_type: Technology.to_s)
-          .where('value_timestamp > ?', Time.zone.now.beginning_of_year)
+          .where(name: Metric.names[:blog_visits], ownable_type: BlogPost.to_s)
+          .where('value_timestamp >= ?', Time.zone.now.beginning_of_year)
           .sum(:value).to_i
       end
     end

--- a/app/services/builders/chart_summary/year_to_date_new_blog_posts.rb
+++ b/app/services/builders/chart_summary/year_to_date_new_blog_posts.rb
@@ -3,7 +3,7 @@ module Builders
     class YearToDateNewBlogPosts < BaseService
       def call
         BlogPost
-          .where('published_at > ?', Time.zone.now.beginning_of_year)
+          .where('published_at >= ?', Time.zone.now.beginning_of_year)
           .count
       end
     end

--- a/app/services/builders/metric_chart/base.rb
+++ b/app/services/builders/metric_chart/base.rb
@@ -14,11 +14,7 @@ module Builders
           )
         end
 
-        totals = generate_results_for(
-          entity_name: 'Totals',
-          metrics: Metric.where(ownable_type: metric_ownable_type.to_s),
-          hidden: false
-        )
+        totals = calculate_totals
 
         MetricsDatasetGroup.new(datasets, totals)
       end
@@ -26,6 +22,14 @@ module Builders
       private
 
       attr_reader :periods
+
+      def calculate_totals
+        generate_results_for(
+          entity_name: 'Totals',
+          metrics: Metric.where(ownable_type: metric_ownable_type.to_s),
+          hidden: false
+        )
+      end
 
       def generate_results_for(entity_name:, metrics:, hidden:)
         metrics_data = collect_data(metrics)

--- a/app/services/builders/metric_chart/base.rb
+++ b/app/services/builders/metric_chart/base.rb
@@ -26,7 +26,7 @@ module Builders
       def calculate_totals
         generate_results_for(
           entity_name: 'Totals',
-          metrics: Metric.where(ownable_type: metric_ownable_type.to_s),
+          metrics: Metric.where(ownable_type: metric_totals_ownable_type.to_s),
           hidden: false
         )
       end
@@ -67,7 +67,7 @@ module Builders
         raise NoMethodError
       end
 
-      def metric_ownable_type
+      def metric_totals_ownable_type
         raise NoMethodError
       end
 

--- a/app/services/builders/metric_chart/blog/base.rb
+++ b/app/services/builders/metric_chart/blog/base.rb
@@ -16,8 +16,8 @@ module Builders
           technology.metrics
         end
 
-        def metric_ownable_type
-          Technology
+        def metric_totals_ownable_type
+          BlogPost
         end
 
         def metric_interval

--- a/app/services/builders/metric_chart/blog/technology_blog_post_count.rb
+++ b/app/services/builders/metric_chart/blog/technology_blog_post_count.rb
@@ -5,6 +5,32 @@ module Builders
         def metric_name
           Metric.names[:blog_post_count]
         end
+
+        def calculate_totals
+          {
+            name: 'Totals',
+            data: format_data(totals_data),
+            dataset: { hidden: false }
+          }
+        end
+
+        def totals_data
+          blog_post_count_to_date = BlogPost.where('published_at < ?', period_start).count
+
+          new_monthly_blog_posts.transform_values do |new_blog_post_count|
+            blog_post_count_to_date += new_blog_post_count
+          end
+        end
+
+        def new_monthly_blog_posts
+          BlogPost
+            .group_by_month(:published_at, range: period_start..Time.zone.now)
+            .count
+        end
+
+        def period_start
+          @period_start ||= periods.months.ago.beginning_of_month
+        end
       end
     end
   end

--- a/app/services/builders/metric_chart/open_source/base.rb
+++ b/app/services/builders/metric_chart/open_source/base.rb
@@ -21,7 +21,7 @@ module Builders
           language.projects_metrics
         end
 
-        def metric_ownable_type
+        def metric_totals_ownable_type
           ::Project
         end
 

--- a/app/services/processors/blog_posts_updater.rb
+++ b/app/services/processors/blog_posts_updater.rb
@@ -8,7 +8,7 @@ module Processors
         blog_post.slug = blog_post_payload[:slug]
         blog_post.status = blog_post_payload[:status]
         blog_post.url = blog_post_payload[:URL]
-        blog_post.technologies << technology_for(blog_post_id)
+        blog_post.technologies = technologies_for(blog_post_id)
 
         blog_post.save!
       end
@@ -24,9 +24,9 @@ module Processors
       @categorizer ||= BlogPostCategorizer.new
     end
 
-    def technology_for(blog_post_id)
+    def technologies_for(blog_post_id)
       blog_post_payload = wordpress_service.blog_post(blog_post_id)
-      categorizer.technology_for(blog_post_payload)
+      categorizer.technologies_for(blog_post_payload)
     end
   end
 end

--- a/app/services/processors/blog_posts_updater.rb
+++ b/app/services/processors/blog_posts_updater.rb
@@ -8,7 +8,7 @@ module Processors
         blog_post.slug = blog_post_payload[:slug]
         blog_post.status = blog_post_payload[:status]
         blog_post.url = blog_post_payload[:URL]
-        blog_post.technology = technology_for(blog_post_id)
+        blog_post.technologies << technology_for(blog_post_id)
 
         blog_post.save!
       end

--- a/app/services/processors/blog_technology_views_updater.rb
+++ b/app/services/processors/blog_technology_views_updater.rb
@@ -12,7 +12,9 @@ module Processors
     def blog_views_by_technology_and_month
       metrics_by_timestamp
         .where(name: Metric.names[:blog_visits], ownable_type: BlogPost.name)
-        .joins('JOIN blog_posts on metrics.ownable_id = blog_posts.id')
+        .joins(
+          'JOIN blog_post_technologies on metrics.ownable_id = blog_post_technologies.blog_post_id'
+        )
         .group(:value_timestamp, :technology_id)
         .sum(:value)
     end

--- a/db/migrate/20200714160138_create_blog_post_technologies.rb
+++ b/db/migrate/20200714160138_create_blog_post_technologies.rb
@@ -1,0 +1,10 @@
+class CreateBlogPostTechnologies < ActiveRecord::Migration[6.0]
+  def change
+    create_table :blog_post_technologies do |t|
+      t.references :blog_post, null: false, foreign_key: true, index: true
+      t.references :technology, null: false, foreign_key: true, index: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -207,6 +207,38 @@ CREATE TABLE public.ar_internal_metadata (
 
 
 --
+-- Name: blog_post_technologies; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.blog_post_technologies (
+    id bigint NOT NULL,
+    blog_post_id bigint NOT NULL,
+    technology_id bigint NOT NULL,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: blog_post_technologies_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.blog_post_technologies_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: blog_post_technologies_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.blog_post_technologies_id_seq OWNED BY public.blog_post_technologies.id;
+
+
+--
 -- Name: blog_posts; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -556,8 +588,8 @@ CREATE TABLE public.projects (
     description character varying,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
-    language_id bigint,
-    is_private boolean
+    is_private boolean,
+    language_id bigint
 );
 
 
@@ -882,6 +914,13 @@ ALTER TABLE ONLY public.admin_users ALTER COLUMN id SET DEFAULT nextval('public.
 
 
 --
+-- Name: blog_post_technologies id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.blog_post_technologies ALTER COLUMN id SET DEFAULT nextval('public.blog_post_technologies_id_seq'::regclass);
+
+
+--
 -- Name: blog_posts id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -1036,6 +1075,14 @@ ALTER TABLE ONLY public.admin_users
 
 ALTER TABLE ONLY public.ar_internal_metadata
     ADD CONSTRAINT ar_internal_metadata_pkey PRIMARY KEY (key);
+
+
+--
+-- Name: blog_post_technologies blog_post_technologies_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.blog_post_technologies
+    ADD CONSTRAINT blog_post_technologies_pkey PRIMARY KEY (id);
 
 
 --
@@ -1231,6 +1278,20 @@ CREATE UNIQUE INDEX index_admin_users_on_email ON public.admin_users USING btree
 --
 
 CREATE UNIQUE INDEX index_admin_users_on_reset_password_token ON public.admin_users USING btree (reset_password_token);
+
+
+--
+-- Name: index_blog_post_technologies_on_blog_post_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_blog_post_technologies_on_blog_post_id ON public.blog_post_technologies USING btree (blog_post_id);
+
+
+--
+-- Name: index_blog_post_technologies_on_technology_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_blog_post_technologies_on_technology_id ON public.blog_post_technologies USING btree (technology_id);
 
 
 --
@@ -1488,11 +1549,27 @@ ALTER TABLE ONLY public.blog_posts
 
 
 --
+-- Name: blog_post_technologies fk_rails_2b02d61b04; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.blog_post_technologies
+    ADD CONSTRAINT fk_rails_2b02d61b04 FOREIGN KEY (blog_post_id) REFERENCES public.blog_posts(id);
+
+
+--
 -- Name: review_turnarounds fk_rails_33c3053604; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.review_turnarounds
     ADD CONSTRAINT fk_rails_33c3053604 FOREIGN KEY (review_request_id) REFERENCES public.review_requests(id);
+
+
+--
+-- Name: blog_post_technologies fk_rails_47acaaf20e; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.blog_post_technologies
+    ADD CONSTRAINT fk_rails_47acaaf20e FOREIGN KEY (technology_id) REFERENCES public.technologies(id);
 
 
 --
@@ -1708,6 +1785,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20200630165139'),
 ('20200701133311'),
 ('20200703141617'),
-('20200713152004');
+('20200713152004'),
+('20200714160138');
 
 

--- a/spec/factories/blog_post_technologies.rb
+++ b/spec/factories/blog_post_technologies.rb
@@ -1,0 +1,27 @@
+# == Schema Information
+#
+# Table name: blog_post_technologies
+#
+#  id            :bigint           not null, primary key
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  blog_post_id  :bigint           not null
+#  technology_id :bigint           not null
+#
+# Indexes
+#
+#  index_blog_post_technologies_on_blog_post_id   (blog_post_id)
+#  index_blog_post_technologies_on_technology_id  (technology_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (blog_post_id => blog_posts.id)
+#  fk_rails_...  (technology_id => technologies.id)
+#
+
+FactoryBot.define do
+  factory :blog_post_technology do
+    association blog_post
+    association technology
+  end
+end

--- a/spec/factories/blog_posts.rb
+++ b/spec/factories/blog_posts.rb
@@ -27,7 +27,5 @@ FactoryBot.define do
     url { 'https://www.rotstrap.com/blog/ruby_is_awesome' }
     status { BlogPost.statuses[:publish] }
     published_at { Faker::Time.backward }
-
-    association :technology
   end
 end

--- a/spec/models/blog_post_technology_spec.rb
+++ b/spec/models/blog_post_technology_spec.rb
@@ -1,0 +1,25 @@
+# == Schema Information
+#
+# Table name: blog_post_technologies
+#
+#  id            :bigint           not null, primary key
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  blog_post_id  :bigint           not null
+#  technology_id :bigint           not null
+#
+# Indexes
+#
+#  index_blog_post_technologies_on_blog_post_id   (blog_post_id)
+#  index_blog_post_technologies_on_technology_id  (technology_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (blog_post_id => blog_posts.id)
+#  fk_rails_...  (technology_id => technologies.id)
+#
+
+require 'rails_helper'
+
+RSpec.describe BlogPostTechnology, type: :model do
+end

--- a/spec/models/metrics_dataset_group_spec.rb
+++ b/spec/models/metrics_dataset_group_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe MetricsDatasetGroup do
   let(:technology) { create(:technology) }
-  let!(:blog_post) { create(:blog_post, published_at: Time.zone.now, technology: technology) }
+  let!(:blog_post) { create(:blog_post, published_at: Time.zone.now, technologies: [technology]) }
   let!(:this_month_post_count_metric) do
     create(
       :metric,

--- a/spec/requests/tech_blog_spec.rb
+++ b/spec/requests/tech_blog_spec.rb
@@ -3,15 +3,29 @@ require 'rails_helper'
 describe 'Tech Blog', type: :request do
   describe '#index' do
     let(:technology) { create(:technology) }
-    let!(:blog_post) { create(:blog_post, published_at: Time.zone.now, technologies: [technology]) }
+    let(:now) { Time.zone.local(2020, 7, 1) }
+    let!(:blog_post) do
+      create(
+        :blog_post,
+        published_at: now.last_month.last_month,
+        technologies: [technology]
+      )
+    end
+    let!(:new_blog_post) do
+      create(
+        :blog_post,
+        published_at: now,
+        technologies: [technology]
+      )
+    end
     let!(:previous_month_visits) do
       create(
         :metric,
         name: Metric.names[:blog_visits],
         interval: Metric.intervals[:monthly],
-        ownable: technology,
+        ownable: blog_post,
         value: 125,
-        value_timestamp: Time.zone.now.last_month.last_month.end_of_month
+        value_timestamp: now.last_month.last_month.end_of_month
       )
     end
     let!(:last_month_visits) do
@@ -19,9 +33,9 @@ describe 'Tech Blog', type: :request do
         :metric,
         name: Metric.names[:blog_visits],
         interval: Metric.intervals[:monthly],
-        ownable: technology,
+        ownable: blog_post,
         value: 100,
-        value_timestamp: Time.zone.now.last_month.end_of_month
+        value_timestamp: now.last_month.end_of_month
       )
     end
     let!(:this_month_visits) do
@@ -29,14 +43,16 @@ describe 'Tech Blog', type: :request do
         :metric,
         name: Metric.names[:blog_visits],
         interval: Metric.intervals[:monthly],
-        ownable: technology,
+        ownable: blog_post,
         value: 110,
-        value_timestamp: Time.zone.now.end_of_month
+        value_timestamp: now.end_of_month
       )
     end
     let(:this_year_visits) do
       previous_month_visits.value + last_month_visits.value + this_month_visits.value
     end
+
+    before { travel_to(now) }
 
     describe 'chart summaries' do
       it 'renders this month visits' do
@@ -60,7 +76,7 @@ describe 'Tech Blog', type: :request do
       it 'renders this year new blog posts count' do
         get tech_blog_url
 
-        expect(response.body).to include '1 new posts this year'
+        expect(response.body).to include '2 new posts this year'
       end
 
       it 'renders this month visits growth' do

--- a/spec/requests/tech_blog_spec.rb
+++ b/spec/requests/tech_blog_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe 'Tech Blog', type: :request do
   describe '#index' do
     let(:technology) { create(:technology) }
-    let!(:blog_post) { create(:blog_post, published_at: Time.zone.now, technology: technology) }
+    let!(:blog_post) { create(:blog_post, published_at: Time.zone.now, technologies: [technology]) }
     let!(:previous_month_visits) do
       create(
         :metric,

--- a/spec/services/blog_post_categorizer_spec.rb
+++ b/spec/services/blog_post_categorizer_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe BlogPostCategorizer do
-  describe '#technology_for' do
+  describe '#technologies_for' do
     let!(:ruby_technology) do
       create(:technology, name: 'ruby', keyword_string: 'ruby,rails')
     end
@@ -14,7 +14,7 @@ RSpec.describe BlogPostCategorizer do
       let(:blog_post_payload) { create(:blog_post_payload).with_indifferent_access }
 
       it 'returns the "other" technology' do
-        expect(subject.technology_for(blog_post_payload)).to eq other_technology
+        expect(subject.technologies_for(blog_post_payload)).to contain_exactly other_technology
       end
     end
 
@@ -25,7 +25,7 @@ RSpec.describe BlogPostCategorizer do
       end
 
       it 'returns the matching technology' do
-        expect(subject.technology_for(blog_post_payload)).to eq ruby_technology
+        expect(subject.technologies_for(blog_post_payload)).to contain_exactly ruby_technology
       end
     end
 
@@ -36,7 +36,31 @@ RSpec.describe BlogPostCategorizer do
       end
 
       it 'returns the matching technology' do
-        expect(subject.technology_for(blog_post_payload)).to eq ruby_technology
+        expect(subject.technologies_for(blog_post_payload)).to contain_exactly ruby_technology
+      end
+    end
+
+    context 'when there is more than one technology matching the post tags or categories' do
+      let(:tags) { { 'Ruby': {}, 'Python': {} } }
+      let(:blog_post_payload) do
+        create(:blog_post_payload, tags: tags).with_indifferent_access
+      end
+
+      it 'returns all matching technologies' do
+        expect(subject.technologies_for(blog_post_payload))
+          .to contain_exactly(ruby_technology, python_technology)
+      end
+    end
+
+    context 'when there is a single technology matching more than one tag or category' do
+      let(:tags) { { 'Ruby': {} } }
+      let(:categories) { { 'Rails': {} } }
+      let(:blog_post_payload) do
+        create(:blog_post_payload, tags: tags, categories: categories).with_indifferent_access
+      end
+
+      it 'returns that technology only once' do
+        expect(subject.technologies_for(blog_post_payload)).to contain_exactly ruby_technology
       end
     end
   end

--- a/spec/services/builders/chart_summary/year_to_date_blog_visits_spec.rb
+++ b/spec/services/builders/chart_summary/year_to_date_blog_visits_spec.rb
@@ -3,12 +3,13 @@ require 'rails_helper'
 describe Builders::ChartSummary::YearToDateBlogVisits do
   describe '.call' do
     let(:technology) { create(:technology) }
+    let(:blog_post) { create(:blog_post, technologies: [technology]) }
     let!(:last_year_metric) do
       create(
         :metric,
         name: Metric.names[:blog_visits],
         interval: Metric.intervals[:monthly],
-        ownable: technology,
+        ownable: blog_post,
         value: 100,
         value_timestamp: Time.zone.now.last_year.end_of_month
       )
@@ -18,7 +19,7 @@ describe Builders::ChartSummary::YearToDateBlogVisits do
         :metric,
         name: Metric.names[:blog_visits],
         interval: Metric.intervals[:monthly],
-        ownable: technology,
+        ownable: blog_post,
         value: 50,
         value_timestamp: Time.zone.now.end_of_month
       )

--- a/spec/services/builders/metric_chart/base_spec.rb
+++ b/spec/services/builders/metric_chart/base_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe Builders::MetricChart::Base do
-  subject { Builders::MetricChart::Blog::TechnologyBlogPostCount }
+  subject { Builders::MetricChart::Blog::TechnologyVisits }
 
   describe '.call' do
     describe 'totals' do
@@ -12,7 +12,7 @@ describe Builders::MetricChart::Base do
           :metric,
           ownable: technology_1,
           interval: Metric.intervals[:monthly],
-          name: Metric.names[:blog_post_count],
+          name: Metric.names[:blog_visits],
           value_timestamp: Time.zone.now.end_of_month
         )
       end
@@ -21,7 +21,7 @@ describe Builders::MetricChart::Base do
           :metric,
           ownable: technology_2,
           interval: Metric.intervals[:monthly],
-          name: Metric.names[:blog_post_count],
+          name: Metric.names[:blog_visits],
           value_timestamp: Time.zone.now.end_of_month
         )
       end

--- a/spec/services/builders/metric_chart/base_spec.rb
+++ b/spec/services/builders/metric_chart/base_spec.rb
@@ -5,12 +5,12 @@ describe Builders::MetricChart::Base do
 
   describe '.call' do
     describe 'totals' do
-      let(:technology_1) { create(:technology) }
-      let(:technology_2) { create(:technology) }
+      let(:blog_post_1) { create(:blog_post) }
+      let(:blog_post_2) { create(:blog_post) }
       let!(:metric_1) do
         create(
           :metric,
-          ownable: technology_1,
+          ownable: blog_post_1,
           interval: Metric.intervals[:monthly],
           name: Metric.names[:blog_visits],
           value_timestamp: Time.zone.now.end_of_month
@@ -19,7 +19,7 @@ describe Builders::MetricChart::Base do
       let!(:metric_2) do
         create(
           :metric,
-          ownable: technology_2,
+          ownable: blog_post_2,
           interval: Metric.intervals[:monthly],
           name: Metric.names[:blog_visits],
           value_timestamp: Time.zone.now.end_of_month
@@ -78,8 +78,8 @@ describe Builders::MetricChart::Base do
       it_behaves_like 'abstract method', :entity_metrics, 1
     end
 
-    describe '#metric_ownable_type' do
-      it_behaves_like 'abstract method', :metric_ownable_type, 0
+    describe '#metric_totals_ownable_type' do
+      it_behaves_like 'abstract method', :metric_totals_ownable_type, 0
     end
 
     describe '#metric_name' do

--- a/spec/services/builders/metric_chart/blog/technology_blog_post_count_spec.rb
+++ b/spec/services/builders/metric_chart/blog/technology_blog_post_count_spec.rb
@@ -38,4 +38,36 @@ describe Builders::MetricChart::Blog::TechnologyBlogPostCount do
       expect(described_class.call.datasets).to include(technology_metrics_hash)
     end
   end
+
+  describe 'totals' do
+    context 'when a blog post has more than one technology' do
+      let(:technology_1) { create(:technology) }
+      let(:technology_2) { create(:technology) }
+      let!(:blog_post) { create(:blog_post, technologies: [technology_1, technology_2]) }
+      let(:current_month_key) { Time.zone.now.strftime('%B %Y') }
+
+      before do
+        create(
+          :metric,
+          ownable: technology_1,
+          interval: Metric.intervals[:monthly],
+          name: Metric.names[:blog_post_count],
+          value: 1,
+          value_timestamp: Time.zone.now.end_of_month
+        )
+        create(
+          :metric,
+          ownable: technology_2,
+          interval: Metric.intervals[:monthly],
+          name: Metric.names[:blog_post_count],
+          value: 1,
+          value_timestamp: Time.zone.now.end_of_month
+        )
+      end
+
+      it 'the totals hash only counts the blog post once' do
+        expect(described_class.call.totals[:data][current_month_key]).to eq 1
+      end
+    end
+  end
 end

--- a/spec/services/builders/metric_chart/blog/technology_visits_growth_mom_spec.rb
+++ b/spec/services/builders/metric_chart/blog/technology_visits_growth_mom_spec.rb
@@ -3,31 +3,26 @@ require 'rails_helper'
 describe Builders::MetricChart::Blog::TechnologyVisitsGrowthMom do
   describe '.call' do
     let(:technology) { create(:technology) }
-    let(:metric_name) { Metric.names[:blog_visits] }
+    let(:blog_post) { create(:blog_post, technologies: [technology]) }
+    let(:current_month_timestamp) { Time.zone.now.end_of_month }
+    let(:last_month_timestamp) { current_month_timestamp.last_month }
+    let(:current_month_key) { current_month_timestamp.strftime('%B %Y') }
     let(:last_month_value) { 100 }
+    let!(:last_month_blog_post_metric) do
+      create_visits_metric(blog_post, last_month_value, last_month_timestamp)
+    end
+    let!(:current_month_blog_post_metric) do
+      create_visits_metric(blog_post, 120, current_month_timestamp)
+    end
 
     before do
-      create(
-        :metric,
-        name: metric_name,
-        interval: Metric.intervals[:monthly],
-        ownable: technology,
-        value: last_month_value,
-        value_timestamp: Time.zone.now.last_month.end_of_month
-      )
-      create(
-        :metric,
-        name: metric_name,
-        interval: Metric.intervals[:monthly],
-        ownable: technology,
-        value: 120,
-        value_timestamp: Time.zone.now.end_of_month
-      )
+      create_visits_metric(technology, last_month_value, last_month_timestamp)
+      create_visits_metric(technology, 120, current_month_timestamp)
     end
 
     it 'returns a hash with the growth month over month rate of the given metric' do
       expect(described_class.call(1).datasets)
-        .to include(a_hash_including(data: a_hash_including(Time.zone.now.strftime('%B %Y') => 20)))
+        .to include(a_hash_including(data: a_hash_including(current_month_key => 20)))
     end
 
     context 'when last month metric was 0' do
@@ -35,43 +30,61 @@ describe Builders::MetricChart::Blog::TechnologyVisitsGrowthMom do
 
       it 'this month metric is not calculated' do
         expect(described_class.call(1).datasets)
-          .not_to include(a_hash_including(data: a_hash_including(Time.zone.now.strftime('%B %Y'))))
+          .not_to include(a_hash_including(data: a_hash_including(current_month_key)))
       end
     end
 
     describe 'totals' do
-      let(:other_tecnology) { create(:technology) }
+      let(:other_technology) { create(:technology) }
+      let(:other_blog_post) { create(:blog_post, technologies: [other_technology]) }
+      let!(:last_month_other_blog_post_metric) do
+        create_visits_metric(other_blog_post, 100, last_month_timestamp)
+      end
+      let!(:current_month_other_blog_post_metric) do
+        create_visits_metric(other_blog_post, 100, current_month_timestamp)
+      end
       let(:totals_hash) do
         a_hash_including(
           name: 'Totals',
           data: a_hash_including(
-            Time.zone.now.strftime('%B %Y') => 10
+            current_month_key => 10
           )
         )
       end
 
       before do
-        create(
-          :metric,
-          name: metric_name,
-          interval: Metric.intervals[:monthly],
-          ownable: other_tecnology,
-          value: 100,
-          value_timestamp: Time.zone.now.last_month.end_of_month
-        )
-        create(
-          :metric,
-          name: metric_name,
-          interval: Metric.intervals[:monthly],
-          ownable: other_tecnology,
-          value: 100,
-          value_timestamp: Time.zone.now.end_of_month
-        )
+        create_visits_metric(other_technology, 100, last_month_timestamp)
+        create_visits_metric(other_technology, 100, current_month_timestamp)
       end
 
       it 'returns a hash with the growth month over month rate of each month total visits' do
         expect(described_class.call(1).totals).to match(totals_hash)
       end
+
+      context 'when there are blog posts with more than one technology' do
+        let(:other_blog_post) { create(:blog_post, technologies: [technology, other_technology]) }
+        let!(:last_month_blog_post_metric) do
+          create_visits_metric(blog_post, 0, last_month_timestamp)
+        end
+        let!(:current_month_blog_post_metric) do
+          create_visits_metric(blog_post, 20, current_month_timestamp)
+        end
+
+        it 'the totals hash only counts those blog posts visits once' do
+          expect(described_class.call.totals[:data][current_month_key]).to eq 20
+        end
+      end
     end
+  end
+
+  def create_visits_metric(ownable, value, timestamp)
+    create(
+      :metric,
+      name: Metric.names[:blog_visits],
+      interval: Metric.intervals[:monthly],
+      ownable: ownable,
+      value: value,
+      value_timestamp: timestamp
+    )
   end
 end

--- a/spec/services/builders/metric_chart/blog/technology_visits_spec.rb
+++ b/spec/services/builders/metric_chart/blog/technology_visits_spec.rb
@@ -37,4 +37,45 @@ describe Builders::MetricChart::Blog::TechnologyVisits do
       expect(described_class.call.datasets).to include(technology_metrics_hash)
     end
   end
+
+  describe 'totals' do
+    context 'when a blog post has more than one technology' do
+      let(:technology_1) { create(:technology) }
+      let(:technology_2) { create(:technology) }
+      let!(:blog_post) { create(:blog_post, technologies: [technology_1, technology_2]) }
+      let(:current_month_timestamp) { Time.zone.now.end_of_month }
+      let(:current_month_key) { current_month_timestamp.strftime('%B %Y') }
+
+      before do
+        create(
+          :metric,
+          ownable: blog_post,
+          interval: Metric.intervals[:monthly],
+          name: Metric.names[:blog_visits],
+          value: 10,
+          value_timestamp: current_month_timestamp
+        )
+        create(
+          :metric,
+          ownable: technology_1,
+          interval: Metric.intervals[:monthly],
+          name: Metric.names[:blog_visits],
+          value: 10,
+          value_timestamp: current_month_timestamp
+        )
+        create(
+          :metric,
+          ownable: technology_2,
+          interval: Metric.intervals[:monthly],
+          name: Metric.names[:blog_visits],
+          value: 10,
+          value_timestamp: current_month_timestamp
+        )
+      end
+
+      it 'the totals hash only counts the blog post visits once' do
+        expect(described_class.call.totals[:data][current_month_key]).to eq 10
+      end
+    end
+  end
 end

--- a/spec/services/processors/blog_metrics_updater_spec.rb
+++ b/spec/services/processors/blog_metrics_updater_spec.rb
@@ -3,8 +3,8 @@ require 'rails_helper'
 describe Processors::BlogMetricsUpdater do
   describe '.call' do
     let!(:technology) { create(:technology) }
-    let(:blog_post_1) { create(:blog_post, technology: technology) }
-    let(:blog_post_2) { create(:blog_post, technology: technology) }
+    let(:blog_post_1) { create(:blog_post, technologies: [technology]) }
+    let(:blog_post_2) { create(:blog_post, technologies: [technology]) }
     let(:blog_post_views_payload_1) { create(:blog_post_views_payload) }
     let(:blog_post_views_payload_2) { create(:blog_post_views_payload) }
     let(:blog_post_1_month_count) { months_count_for(blog_post_views_payload_1) }

--- a/spec/services/processors/blog_post_count_metrics_full_updater_spec.rb
+++ b/spec/services/processors/blog_post_count_metrics_full_updater_spec.rb
@@ -5,7 +5,9 @@ describe Processors::BlogPostCountMetricsFullUpdater do
     context 'when there are already metrics generated' do
       let(:publish_date) { Time.zone.now.last_month }
       let(:technology) { create(:technology) }
-      let!(:blog_post) { create(:blog_post, published_at: publish_date, technology: technology) }
+      let!(:blog_post) do
+        create(:blog_post, published_at: publish_date, technologies: [technology])
+      end
 
       before do
         create(

--- a/spec/services/processors/blog_post_count_metrics_partial_updater_spec.rb
+++ b/spec/services/processors/blog_post_count_metrics_partial_updater_spec.rb
@@ -4,7 +4,7 @@ describe Processors::BlogPostCountMetricsPartialUpdater do
   describe '.call' do
     let(:publish_date) { Time.zone.now.last_month }
     let(:technology) { create(:technology) }
-    let!(:blog_post) { create(:blog_post, published_at: publish_date, technology: technology) }
+    let!(:blog_post) { create(:blog_post, published_at: publish_date, technologies: [technology]) }
 
     context 'when there are no metrics generated' do
       it 'generates all of them' do

--- a/spec/services/processors/blog_post_count_metrics_updater_spec.rb
+++ b/spec/services/processors/blog_post_count_metrics_updater_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Processors::BlogPostCountMetricsUpdater do
     let(:publish_time) { Time.zone.now }
 
     before do
-      create(:blog_post, published_at: publish_time, technology: technology)
+      create(:blog_post, published_at: publish_time, technologies: [technology])
     end
 
     subject(:updater) { Processors::BlogPostCountMetricsPartialUpdater }
@@ -26,7 +26,7 @@ RSpec.describe Processors::BlogPostCountMetricsUpdater do
     context 'having more than one technology' do
       before do
         other_technology = create(:technology)
-        create(:blog_post, published_at: Time.zone.now, technology: other_technology)
+        create(:blog_post, published_at: Time.zone.now, technologies: [other_technology])
       end
 
       it 'creates metrics for all of them' do
@@ -56,7 +56,7 @@ RSpec.describe Processors::BlogPostCountMetricsUpdater do
 
     context 'when there are blog posts published in different months' do
       before do
-        create(:blog_post, published_at: Time.zone.now.last_month, technology: technology)
+        create(:blog_post, published_at: Time.zone.now.last_month, technologies: [technology])
       end
 
       it 'creates a metric for every month' do
@@ -107,7 +107,11 @@ RSpec.describe Processors::BlogPostCountMetricsUpdater do
         let(:publish_time) { empty_month_timestamp.last_month }
 
         before do
-          create(:blog_post, published_at: empty_month_timestamp.next_month, technology: technology)
+          create(
+            :blog_post,
+            published_at: empty_month_timestamp.next_month,
+            technologies: [technology]
+          )
         end
 
         it 'adds the metric for that month with the unchanged value' do
@@ -128,7 +132,7 @@ RSpec.describe Processors::BlogPostCountMetricsUpdater do
 
         before do
           other_technology = create(:technology)
-          create(:blog_post, published_at: empty_month_timestamp, technology: other_technology)
+          create(:blog_post, published_at: empty_month_timestamp, technologies: [other_technology])
         end
 
         it 'adds the metric for that month with the unchanged value' do

--- a/spec/services/processors/blog_technology_views_full_updater_spec.rb
+++ b/spec/services/processors/blog_technology_views_full_updater_spec.rb
@@ -4,7 +4,7 @@ describe Processors::BlogTechnologyViewsFullUpdater do
   describe '.call' do
     let!(:technology) { create(:technology) }
     let(:metric_timestamp) { Time.zone.now.end_of_month }
-    let(:blog_post) { create(:blog_post, technology: technology) }
+    let(:blog_post) { create(:blog_post, technologies: [technology]) }
     let!(:blog_post_views_metric) do
       create(
         :metric,

--- a/spec/services/processors/blog_technology_views_partial_updater_spec.rb
+++ b/spec/services/processors/blog_technology_views_partial_updater_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Processors::BlogTechnologyViewsPartialUpdater do
   describe '.call' do
     let!(:technology) { create(:technology) }
     let(:metric_timestamp) { Time.zone.now.end_of_month }
-    let(:blog_post) { create(:blog_post, technology: technology) }
+    let(:blog_post) { create(:blog_post, technologies: [technology]) }
     let!(:blog_post_views_metric) do
       create(
         :metric,

--- a/spec/services/processors/blog_technology_views_updater_spec.rb
+++ b/spec/services/processors/blog_technology_views_updater_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Processors::BlogTechnologyViewsUpdater do
   describe '.call' do
     let!(:technology) { create(:technology) }
     let(:metric_timestamp) { Time.zone.now.end_of_month }
-    let(:blog_post_1) { create(:blog_post, technology: technology) }
+    let(:blog_post_1) { create(:blog_post, technologies: [technology]) }
     let!(:blog_post_1_views_metric) do
       create(
         :metric,
@@ -14,7 +14,7 @@ RSpec.describe Processors::BlogTechnologyViewsUpdater do
         ownable: blog_post_1
       )
     end
-    let(:blog_post_2) { create(:blog_post, technology: technology) }
+    let(:blog_post_2) { create(:blog_post, technologies: [technology]) }
     let!(:blog_post_2_views_metric) do
       create(
         :metric,
@@ -61,7 +61,7 @@ RSpec.describe Processors::BlogTechnologyViewsUpdater do
 
     context 'when there is more than one technology' do
       let!(:technology_2) { create(:technology) }
-      let(:blog_post_for_tech_2) { create(:blog_post, technology: technology_2) }
+      let(:blog_post_for_tech_2) { create(:blog_post, technologies: [technology_2]) }
       let!(:blog_post_for_tech_2_views_metric) do
         create(
           :metric,


### PR DESCRIPTION
## What does this PR do?
It allows blog posts to have more than one technology associated.

To do so, it:
- Creates the `BlogPostTechnology` model, which corresponds to the new `blog_post_technologies` joined table between blog_posts and technologies
- Updates the `BlogPostsUpdater` to add every matching technology to the blog post
- Changes the way metric totals are calculated. As calculating them through the technology metrics may result in counting the same blog post metric more than once, they are now calculated directly from the blog posts metrics.

**Note**
To prevent any information loss, this PR **will not** get rid of the `technology_id` column in `blog_posts` (though it's already not used anymore in this PR). Once we confirm the new implementation is working correctly, I'll create another PR to get rid of it.
