### PR TITLE
[EM-121] Make technologies factory create them with unique names

### DIFF
--- a/spec/factories/technologies.rb
+++ b/spec/factories/technologies.rb
@@ -10,7 +10,7 @@
 #
 FactoryBot.define do
   factory :technology do
-    name { Faker::Lorem.word }
+    name { Faker::ProgrammingLanguage.unique.name }
     keyword_string { Faker::Lorem.word }
   end
 end


### PR DESCRIPTION
## What does this PR do?
It prevents different technologies to be created with the same name when running specs.
The `Technology` model has a `uniqueness` constraint on `name`, so when a technology was created with the same name as another one, the test would fail.
According to the [Faker gem documentation](https://github.com/faker-ruby/faker#ensuring-unique-values) this can be avoided by chaining a `unique` method call to the generation of the random name. 

Resolves https://rootstrap.atlassian.net/browse/EM-121
