### PR TITLE
[EM-122] Remove technology_id column from blog_posts

### DIFF
--- a/app/models/blog_post.rb
+++ b/app/models/blog_post.rb
@@ -2,23 +2,14 @@
 #
 # Table name: blog_posts
 #
-#  id            :bigint           not null, primary key
-#  published_at  :datetime
-#  slug          :string
-#  status        :string
-#  url           :string
-#  created_at    :datetime         not null
-#  updated_at    :datetime         not null
-#  blog_id       :integer
-#  technology_id :bigint
-#
-# Indexes
-#
-#  index_blog_posts_on_technology_id  (technology_id)
-#
-# Foreign Keys
-#
-#  fk_rails_...  (technology_id => technologies.id)
+#  id           :bigint           not null, primary key
+#  published_at :datetime
+#  slug         :string
+#  status       :string
+#  url          :string
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  blog_id      :integer
 #
 class BlogPost < ApplicationRecord
   enum status: {

--- a/db/migrate/20200723174621_delete_technology_id_column_in_blog_posts.rb
+++ b/db/migrate/20200723174621_delete_technology_id_column_in_blog_posts.rb
@@ -1,0 +1,5 @@
+class DeleteTechnologyIdColumnInBlogPosts < ActiveRecord::Migration[6.0]
+  def change
+    remove_reference :blog_posts, :technology, foreign_key: true, index: true
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -262,8 +262,7 @@ CREATE TABLE public.blog_posts (
     url character varying,
     status character varying,
     created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL,
-    technology_id bigint
+    updated_at timestamp(6) without time zone NOT NULL
 );
 
 
@@ -1358,13 +1357,6 @@ CREATE INDEX index_blog_post_technologies_on_technology_id ON public.blog_post_t
 
 
 --
--- Name: index_blog_posts_on_technology_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_blog_posts_on_technology_id ON public.blog_posts USING btree (technology_id);
-
-
---
 -- Name: index_code_climate_project_metrics_on_project_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -1626,14 +1618,6 @@ ALTER TABLE ONLY public.completed_review_turnarounds
 
 
 --
--- Name: blog_posts fk_rails_24521f9a19; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.blog_posts
-    ADD CONSTRAINT fk_rails_24521f9a19 FOREIGN KEY (technology_id) REFERENCES public.technologies(id);
-
-
---
 -- Name: blog_post_technologies fk_rails_2b02d61b04; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -1873,8 +1857,8 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20200713152004'),
 ('20200714160138'),
 ('20200720155715'),
+('20200723174621'),
 ('20200730142418'),
 ('20200806131024'),
 ('20200813162522');
-
 

--- a/spec/factories/blog_posts.rb
+++ b/spec/factories/blog_posts.rb
@@ -2,23 +2,14 @@
 #
 # Table name: blog_posts
 #
-#  id            :bigint           not null, primary key
-#  published_at  :datetime
-#  slug          :string
-#  status        :string
-#  url           :string
-#  created_at    :datetime         not null
-#  updated_at    :datetime         not null
-#  blog_id       :integer
-#  technology_id :bigint
-#
-# Indexes
-#
-#  index_blog_posts_on_technology_id  (technology_id)
-#
-# Foreign Keys
-#
-#  fk_rails_...  (technology_id => technologies.id)
+#  id           :bigint           not null, primary key
+#  published_at :datetime
+#  slug         :string
+#  status       :string
+#  url          :string
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  blog_id      :integer
 #
 FactoryBot.define do
   factory :blog_post do

--- a/spec/models/blog_post_spec.rb
+++ b/spec/models/blog_post_spec.rb
@@ -2,23 +2,14 @@
 #
 # Table name: blog_posts
 #
-#  id            :bigint           not null, primary key
-#  published_at  :datetime
-#  slug          :string
-#  status        :string
-#  url           :string
-#  created_at    :datetime         not null
-#  updated_at    :datetime         not null
-#  blog_id       :integer
-#  technology_id :bigint
-#
-# Indexes
-#
-#  index_blog_posts_on_technology_id  (technology_id)
-#
-# Foreign Keys
-#
-#  fk_rails_...  (technology_id => technologies.id)
+#  id           :bigint           not null, primary key
+#  published_at :datetime
+#  slug         :string
+#  status       :string
+#  url          :string
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  blog_id      :integer
 #
 require 'rails_helper'
 


### PR DESCRIPTION
## What does this PR do?
It deletes the no longer needed `technology_id` column in the `blog_posts` table.

Resolves https://rootstrap.atlassian.net/browse/EM-122
