### PR TITLE
[EM-127] Fix Blog Metrics tab error

### DIFF
--- a/app/models/metrics_dataset_group.rb
+++ b/app/models/metrics_dataset_group.rb
@@ -11,7 +11,7 @@ class MetricsDatasetGroup
   end
 
   def totals_for(date)
-    totals[:data][key_for(date)]
+    totals[:data][key_for(date)] || 0
   end
 
   private

--- a/spec/models/metrics_dataset_group_spec.rb
+++ b/spec/models/metrics_dataset_group_spec.rb
@@ -30,5 +30,13 @@ describe MetricsDatasetGroup do
     it 'returns the totals value matching the given date' do
       expect(blog_metrics_dataset_group.totals_for(date)).to eq this_month_post_count_metric.value
     end
+
+    context 'when there is no data for the given date' do
+      let(:date) { Time.zone.now.next_month }
+
+      it 'returns 0 as a default value instead of nil' do
+        expect(blog_metrics_dataset_group.totals_for(date)).to eq 0
+      end
+    end
   end
 end


### PR DESCRIPTION
## What does this PR do?
It avoids returning `nil` when asking for the totals corresponding to a certain date to a `MetricsDatasetGroup`. This `nil` value causes `NoMethodError`s to be raised when trying to make further operations on the value.
It now returns `0` as a default value.

This fixes the error shown on the Blog Metrics tab and makes the summary of the visits growth MoM chart show `0%` even when no data can be retrieved for the chart.

![image](https://user-images.githubusercontent.com/7276679/88334684-8b605480-cd08-11ea-8bac-d6968c91d180.png)

Resolves https://rootstrap.atlassian.net/browse/EM-127
