### PR TITLE
[EM-128] Hide elements without data for Open Source metrics tab

### DIFF
--- a/app/views/open_source/index.erb
+++ b/app/views/open_source/index.erb
@@ -9,12 +9,12 @@
     <div class='open-source-chart'>
       <%= line_chart @visits_per_language.all_datasets, ytitle: "Weekly Repository Unique Visits" %>
     </div>
-    <div class='metrics-summary-group'>
+    <div class='metrics-summary-group' hidden>
       <span class='metrics-summary-item'>800 visits this month</span>
       <span class='metrics-summary-item'>3500 visits this year</span>
     </div>
   </div>
-  <div class="main-container">
+  <div class="main-container" hidden>
     <div class='open-source-chart'>
       <%= line_chart [{}], ytitle: "Stars" %>
     </div>


### PR DESCRIPTION
## What does this PR do?
It hides the elements in the Open Source metrics tab for which we are not currently calculating the correspondent data.

![image](https://user-images.githubusercontent.com/7276679/88338780-3e33b100-cd0f-11ea-8048-cd93a4ad52e5.png)


Resolves https://rootstrap.atlassian.net/browse/EM-128
