### PR TITLE
[EM-132] Add relevance to projects

### DIFF
--- a/app/admin/projects.rb
+++ b/app/admin/projects.rb
@@ -1,5 +1,5 @@
 ActiveAdmin.register Project do
-  permit_params :language_id, :description, :name, :github_id
+  permit_params :language_id, :description, :name, :github_id, :relevance
   remove_filter :events
 
   index do
@@ -11,6 +11,7 @@ ActiveAdmin.register Project do
     column :language_id do |r|
       r.language.name
     end
+    column :relevance
     actions
   end
 
@@ -20,6 +21,7 @@ ActiveAdmin.register Project do
       f.input :name
       f.input :description, required: false
       f.input :language
+      f.input :relevance, as: :radio, collection: Project.relevances.values
     end
     f.actions
   end

--- a/db/migrate/20200730142418_add_relevance_to_projects.rb
+++ b/db/migrate/20200730142418_add_relevance_to_projects.rb
@@ -1,0 +1,17 @@
+class AddRelevanceToProjects < ActiveRecord::Migration[6.0]
+  def up
+    execute <<-SQL
+      CREATE TYPE project_relevance AS ENUM ('commercial', 'internal', 'ignored', 'unassigned');
+    SQL
+
+    add_column :projects, :relevance, :project_relevance, index: true, null: false, default: 'unassigned'
+  end
+
+  def down
+    remove_column :projects, :relevance
+
+    execute <<-SQL
+      DROP TYPE project_relevance;
+    SQL
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -78,6 +78,18 @@ CREATE TYPE public.metric_name AS ENUM (
 
 
 --
+-- Name: project_relevance; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.project_relevance AS ENUM (
+    'commercial',
+    'internal',
+    'ignored',
+    'unassigned'
+);
+
+
+--
 -- Name: pull_request_state; Type: TYPE; Schema: public; Owner: -
 --
 
@@ -621,7 +633,8 @@ CREATE TABLE public.projects (
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
     language_id bigint,
-    is_private boolean
+    is_private boolean,
+    relevance public.project_relevance DEFAULT 'unassigned'::public.project_relevance NOT NULL
 );
 
 
@@ -1849,6 +1862,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20200703141617'),
 ('20200713152004'),
 ('20200714160138'),
-('20200720155715');
+('20200720155715'),
+('20200730142418');
 
 

--- a/spec/factories/projects.rb
+++ b/spec/factories/projects.rb
@@ -6,6 +6,7 @@
 #  description :string
 #  is_private  :boolean
 #  name        :string
+#  relevance   :enum             default("unassigned"), not null
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
 #  github_id   :integer          not null
@@ -26,6 +27,7 @@ FactoryBot.define do
 
     trait :open_source do
       language { Language.find_by(name: 'ruby') }
+      relevance { Project.relevances[:internal] }
       is_private { false }
     end
   end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -6,6 +6,7 @@
 #  description :string
 #  is_private  :boolean
 #  name        :string
+#  relevance   :enum             default("unassigned"), not null
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
 #  github_id   :integer          not null
@@ -37,9 +38,38 @@ RSpec.describe Project, type: :model do
 
   describe 'open_source' do
     let(:language) { Language.find_by(name: 'ruby') }
-    let!(:private_project) { create(:project, is_private: true, language: language) }
-    let!(:unassigned_project) { create(:project, language: Language.unassigned) }
-    let!(:open_source_project) { create(:project, is_private: false, language: language) }
+    let!(:private_project) do
+      create(
+        :project,
+        is_private: true,
+        language: language,
+        relevance: Project.relevances[:internal]
+      )
+    end
+    let!(:unassigned_project) do
+      create(
+        :project,
+        is_private: false,
+        language: Language.unassigned,
+        relevance: Project.relevances[:internal]
+      )
+    end
+    let!(:ignored_project) do
+      create(
+        :project,
+        is_private: false,
+        language: language,
+        relevance: Project.relevances[:ignored]
+      )
+    end
+    let!(:open_source_project) do
+      create(
+        :project,
+        is_private: false,
+        language: language,
+        relevance: Project.relevances[:internal]
+      )
+    end
 
     it 'returns the projects that have an assigned language and are not private' do
       expect(Project.open_source).to contain_exactly(open_source_project)
@@ -53,6 +83,16 @@ RSpec.describe Project, type: :model do
 
     it 'returns the projects that have an assigned language' do
       expect(Project.with_language).to contain_exactly(project_with_language)
+    end
+  end
+
+  describe 'internal' do
+    let!(:commercial_project) { create(:project, relevance: Project.relevances[:commercial]) }
+    let!(:internal_project) { create(:project, relevance: Project.relevances[:internal]) }
+    let!(:unassigned_project) { create(:project, relevance: Project.relevances[:unassigned]) }
+
+    it 'returns only the internal projects' do
+      expect(Project.internal).to contain_exactly(internal_project)
     end
   end
 end

--- a/spec/services/builders/chart_summary/lifetime_open_source_project_count_spec.rb
+++ b/spec/services/builders/chart_summary/lifetime_open_source_project_count_spec.rb
@@ -8,8 +8,8 @@ describe Builders::ChartSummary::LifetimeOpenSourceProjectCount do
     let(:project_count_2) { 6 }
 
     before do
-      create_list(:project, project_count_1, language: language_1, is_private: false)
-      create_list(:project, project_count_2, language: language_2, is_private: false)
+      create_list(:project, project_count_1, :open_source, language: language_1)
+      create_list(:project, project_count_2, :open_source, language: language_2)
     end
 
     it 'returns the total amount of projects per language' do


### PR DESCRIPTION
## What does this PR do?
It adds the `relevance` attribute to projects, which can be either:
- `commercial`
- `internal`
- `ignored`
- `unassigned`

Now, Open Source projects are those that meet all these conditions:
- Are not private (`is_private` set to `false`) (same as before)
- Have a language (`language` is not `nil` nor `unassigned`) (same as before)
- Are Internal (`relevance` is `internal`) (new condition)

Resolves [132](https://rootstrap.atlassian.net/browse/EM-132)
