### PR TITLE
Replace individual people with team in CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,4 +3,4 @@
 # @global-owner1 and @global-owner2 will be requested for
 # review when someone opens a pull request.
 
-* @hdamico @santiagovidal @santib @horacio @hvilloria
+* @rootstrap/reviewers-rs-code-review-metrics


### PR DESCRIPTION
## What does this PR do?
Adds a Github team to the CODEOWNERS file and removes the individual users

The team is https://github.com/orgs/rootstrap/teams/reviewers-rs-code-review-metrics
