### PR TITLE
[EM-133] Fix charts starting at the same month in Tech Blog metrics

### DIFF
--- a/app/services/builders/metric_chart/blog/technology_blog_post_count.rb
+++ b/app/services/builders/metric_chart/blog/technology_blog_post_count.rb
@@ -29,7 +29,7 @@ module Builders
         end
 
         def period_start
-          @period_start ||= periods.months.ago.beginning_of_month
+          @period_start ||= (periods - 1).months.ago.beginning_of_month
         end
       end
     end

--- a/spec/services/builders/metric_chart/blog/technology_blog_post_count_spec.rb
+++ b/spec/services/builders/metric_chart/blog/technology_blog_post_count_spec.rb
@@ -69,5 +69,18 @@ describe Builders::MetricChart::Blog::TechnologyBlogPostCount do
         expect(described_class.call.totals[:data][current_month_key]).to eq 1
       end
     end
+
+    describe 'periods returned' do
+      let(:technology) { create(:technology) }
+      let(:periods) { 13 }
+
+      before do
+        create(:blog_post, published_at: 3.years.ago, technologies: [technology])
+      end
+
+      it 'returns only the requested amount of periods' do
+        expect(described_class.call(periods).totals[:data].count).to eq periods
+      end
+    end
   end
 end


### PR DESCRIPTION
## What does this PR do?
It fixes the difference in the starting point shown in the Tech Blog chart, where the Blog Posts chart started a month earlier than the Visits one.

![image](https://user-images.githubusercontent.com/7276679/89069254-32687000-d349-11ea-8b35-f5ccb7b624f4.png)


Resolves [133](https://rootstrap.atlassian.net/browse/EM-133)
