### PR TITLE
Change repository views endpoint

### DIFF
--- a/app/services/code_owners/request.rb
+++ b/app/services/code_owners/request.rb
@@ -2,7 +2,7 @@ module CodeOwners
   class Request < BaseService
     def call
       Project.find_each do |project|
-        content_file = GithubRepositoryClient.new(project.name).code_owners
+        content_file = GithubRepositoryClient.new(project).code_owners
         next if content_file.empty?
 
         code_owners = CodeOwners::FileHandler.call(content_file)

--- a/app/services/processors/open_source_project_views_updater.rb
+++ b/app/services/processors/open_source_project_views_updater.rb
@@ -32,7 +32,7 @@ module Processors
     end
 
     def views_payload
-      GithubRepositoryClient.new(project.name).repository_views
+      GithubRepositoryClient.new(project).repository_views
     end
 
     def update_views_metric(timestamp, views)

--- a/spec/services/github_repository_client_spec.rb
+++ b/spec/services/github_repository_client_spec.rb
@@ -2,10 +2,12 @@ require 'rails_helper'
 
 RSpec.describe GithubRepositoryClient do
   describe '#code_owners' do
+    let(:project) { create(:project, name: 'rs-code-metrics') }
+
     context 'when the project or the file is not found' do
       before { stub_get_code_owners_not_found }
       it 'returns an empty string' do
-        expect(described_class.new('rs-code-metrics').code_owners)
+        expect(described_class.new(project).code_owners)
           .to be_empty
       end
     end
@@ -13,7 +15,7 @@ RSpec.describe GithubRepositoryClient do
     context 'when the project or the file is found' do
       before { stub_get_code_owners_file_ok }
       it 'returns a string with the codeowners as mentions' do
-        expect(described_class.new('rs-code-metrics').code_owners)
+        expect(described_class.new(project).code_owners)
           .to include('@santiagovidal')
       end
     end
@@ -23,10 +25,10 @@ RSpec.describe GithubRepositoryClient do
     let(:project) { create(:project) }
     let(:repository_views_payload) { create(:repository_views_payload) }
 
-    before { stub_repository_views(project.name, repository_views_payload) }
+    before { stub_repository_views(project, repository_views_payload) }
 
     it 'returns the views hash of that project on Github' do
-      expect(described_class.new(project.name).repository_views).to eq repository_views_payload
+      expect(described_class.new(project).repository_views).to eq repository_views_payload
     end
   end
 end

--- a/spec/services/processors/open_source_metrics_updater_spec.rb
+++ b/spec/services/processors/open_source_metrics_updater_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Processors::OpenSourceMetricsUpdater do
     let(:total_metrics_generated) { open_source_repository_views_payload['views'].count }
 
     before do
-      stub_repository_views(open_source_project.name, open_source_repository_views_payload)
+      stub_repository_views(open_source_project, open_source_repository_views_payload)
     end
 
     it 'generates visits metrics for all open source projects' do

--- a/spec/services/processors/open_source_project_views_updater_spec.rb
+++ b/spec/services/processors/open_source_project_views_updater_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Processors::OpenSourceProjectViewsUpdater do
     let(:repository_views_payload) { create(:repository_views_payload) }
 
     before do
-      stub_repository_views(project.name, repository_views_payload)
+      stub_repository_views(project, repository_views_payload)
     end
 
     it 'generates visits metrics for the given project' do

--- a/spec/support/helpers/github_api_mocker.rb
+++ b/spec/support/helpers/github_api_mocker.rb
@@ -12,11 +12,11 @@ module GithubApiMock
       )
   end
 
-  def stub_repository_views(project_name, repository_views_payload)
+  def stub_repository_views(project, repository_views_payload)
     stub_env('GITHUB_ADMIN_USER', github_admin_user)
     stub_env('GITHUB_ADMIN_TOKEN', github_admin_token)
 
-    url = "#{GithubRepositoryClient::URL}/#{project_name}/traffic/views"
+    url = "https://api.github.com/repositories/#{project.github_id}/traffic/views"
 
     stub_request(:get, url)
       .with(basic_auth: [github_admin_user, github_admin_token], query: { per: 'week' })


### PR DESCRIPTION
## What does this PR do?
It fixes [this error](http://engineering-metrics.herokuapp.com/exception_hunter/errors/19), which shows up when a project has changed its name and we haven't updated it in our database. As the request we make to Github is to an endpoint generated from the repository name, if Github can't find that name, the request fails.

In those cases, Github returns a 301 code (moved permanently), and an optional endpoint to access the data, built using the repository ID. Knowing this, we assume (after some tests) that endpoint works the same way for the rest of the projects.

Long story short, we are then replacing the endpoint `/repos/{owner}/{repository_name}/traffic/views` with `/repositories/{repository_id}/traffic/views`
