### PR TITLE
Make open source jobs catch api errors

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -112,10 +112,7 @@ detectors:
     accept: []
   UncommunicativeVariableName:
     enabled: true
-    exclude: [
-      'EventsProcessor#process',
-      'ActionHandlers::PullRequest#review_requested'
-    ]
+    exclude: []
     reject:
       - "/^.$/"
       - "/[0-9]$/"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -77,6 +77,9 @@ Metrics/ParameterLists:
 Metrics/PerceivedComplexity:
   Max: 12
 
+Naming/RescuedExceptionsVariableName:
+  PreferredName: exception
+
 Rails:
   Enabled: true
 

--- a/app/services/github_repository_client.rb
+++ b/app/services/github_repository_client.rb
@@ -26,7 +26,9 @@ class GithubRepositoryClient
         request.headers['Accept'] = 'application/vnd.github.v3.raw'
       end
 
-      return response.body if response.success?
+      return response.body
+    rescue Faraday::ResourceNotFound
+      next
     end
     ''
   end
@@ -34,6 +36,7 @@ class GithubRepositoryClient
   def connection
     Faraday.new('https://api.github.com') do |conn|
       conn.basic_auth(ENV['GITHUB_ADMIN_USER'], ENV['GITHUB_ADMIN_TOKEN'])
+      conn.response :raise_error
     end
   end
 end

--- a/app/services/processors/open_source_project_views_updater.rb
+++ b/app/services/processors/open_source_project_views_updater.rb
@@ -11,6 +11,8 @@ module Processors
           project_views_payload['uniques']
         )
       end
+    rescue Faraday::Error => exception
+      ExceptionHunter.track(exception)
     end
 
     private

--- a/lib/events_processor.rb
+++ b/lib/events_processor.rb
@@ -11,8 +11,8 @@ class EventsProcessor
         event_name = resolve_event_name(event.name)
         Builders::Project.call(payload['repository'])
         process_event(event, event_name)
-      rescue StandardError => e
-        error = error_msg(event, e)
+      rescue StandardError => exception
+        error = error_msg(event, exception)
         errors << error unless error.nil?
       end
       Rails.logger.error errors unless errors.empty?

--- a/spec/services/github_repository_client_spec.rb
+++ b/spec/services/github_repository_client_spec.rb
@@ -25,10 +25,20 @@ RSpec.describe GithubRepositoryClient do
     let(:project) { create(:project) }
     let(:repository_views_payload) { create(:repository_views_payload) }
 
-    before { stub_repository_views(project, repository_views_payload) }
+    context 'when the request succeeds' do
+      before { stub_successful_repository_views(project, repository_views_payload) }
 
-    it 'returns the views hash of that project on Github' do
-      expect(described_class.new(project).repository_views).to eq repository_views_payload
+      it 'returns the views hash of that project on Github' do
+        expect(described_class.new(project).repository_views).to eq repository_views_payload
+      end
+    end
+
+    context 'when the request fails' do
+      before { stub_failed_repository_views(project) }
+
+      it 'raises an exception' do
+        expect { described_class.new(project).repository_views }.to raise_error Faraday::ClientError
+      end
     end
   end
 end

--- a/spec/services/processors/open_source_metrics_updater_spec.rb
+++ b/spec/services/processors/open_source_metrics_updater_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Processors::OpenSourceMetricsUpdater do
     let(:total_metrics_generated) { open_source_repository_views_payload['views'].count }
 
     before do
-      stub_repository_views(open_source_project, open_source_repository_views_payload)
+      stub_successful_repository_views(open_source_project, open_source_repository_views_payload)
     end
 
     it 'generates visits metrics for all open source projects' do

--- a/spec/services/processors/open_source_project_views_updater_spec.rb
+++ b/spec/services/processors/open_source_project_views_updater_spec.rb
@@ -3,60 +3,73 @@ require 'rails_helper'
 RSpec.describe Processors::OpenSourceProjectViewsUpdater do
   describe '.call' do
     let(:project) { create(:project, :open_source) }
-    let(:repository_views_payload) { create(:repository_views_payload) }
 
-    before do
-      stub_successful_repository_views(project, repository_views_payload)
-    end
-
-    it 'generates visits metrics for the given project' do
-      expect { described_class.call(project) }
-        .to change {
-          Metric.where(
-            name: Metric.names[:open_source_visits],
-            interval: Metric.intervals[:weekly]
-          ).count
-        }
-        .by(repository_views_payload['views'].count)
-    end
-
-    context 'when the project already has some views metrics' do
-      let(:old_views) { 3 }
-      let(:this_week_views_payload) { repository_views_payload['views'].last }
-      let(:this_week_timestamp) { this_week_views_payload['timestamp'] }
-      let(:new_views) { this_week_views_payload['uniques'] }
-      let(:this_week_metric) do
-        Metric.find_by(
-          name: Metric.names[:open_source_visits],
-          interval: Metric.intervals[:weekly],
-          ownable: project,
-          value_timestamp: this_week_timestamp
-        )
-      end
+    context 'when the request to get the repository views succeeds' do
+      let(:repository_views_payload) { create(:repository_views_payload) }
 
       before do
-        repository_views_payload['views'].each do |views_payload|
-          Metric.create(
+        stub_successful_repository_views(project, repository_views_payload)
+      end
+
+      it 'generates visits metrics for the given project' do
+        expect { described_class.call(project) }
+          .to change {
+            Metric.where(
+              name: Metric.names[:open_source_visits],
+              interval: Metric.intervals[:weekly]
+            ).count
+          }
+          .by(repository_views_payload['views'].count)
+      end
+
+      context 'when the project already has some views metrics' do
+        let(:old_views) { 3 }
+        let(:this_week_views_payload) { repository_views_payload['views'].last }
+        let(:this_week_timestamp) { this_week_views_payload['timestamp'] }
+        let(:new_views) { this_week_views_payload['uniques'] }
+        let(:this_week_metric) do
+          Metric.find_by(
             name: Metric.names[:open_source_visits],
             interval: Metric.intervals[:weekly],
             ownable: project,
-            value: old_views,
-            value_timestamp: views_payload['timestamp']
+            value_timestamp: this_week_timestamp
           )
+        end
+
+        before do
+          repository_views_payload['views'].each do |views_payload|
+            Metric.create(
+              name: Metric.names[:open_source_visits],
+              interval: Metric.intervals[:weekly],
+              ownable: project,
+              value: old_views,
+              value_timestamp: views_payload['timestamp']
+            )
+          end
+        end
+
+        it 'updates the last metric value' do
+          expect { described_class.call(project) }
+            .to change { this_week_metric.reload.value }
+            .from(old_views)
+            .to(new_views)
+        end
+
+        it 'only tries to update the last metric' do
+          expect(Metric).to receive(:find_or_initialize_by).once.and_call_original
+
+          described_class.call(project)
         end
       end
 
-      it 'updates the last metric value' do
-        expect { described_class.call(project) }
-          .to change { this_week_metric.reload.value }
-          .from(old_views)
-          .to(new_views)
-      end
+      context 'when the request to get the repository views fails' do
+        before { stub_failed_repository_views(project) }
 
-      it 'only tries to update the last metric' do
-        expect(Metric).to receive(:find_or_initialize_by).once.and_call_original
+        it 'notifies the error to exception hunter' do
+          expect(ExceptionHunter).to receive(:track).with(kind_of(Faraday::Error))
 
-        described_class.call(project)
+          described_class.call(project)
+        end
       end
     end
   end

--- a/spec/services/processors/open_source_project_views_updater_spec.rb
+++ b/spec/services/processors/open_source_project_views_updater_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Processors::OpenSourceProjectViewsUpdater do
     let(:repository_views_payload) { create(:repository_views_payload) }
 
     before do
-      stub_repository_views(project, repository_views_payload)
+      stub_successful_repository_views(project, repository_views_payload)
     end
 
     it 'generates visits metrics for the given project' do

--- a/spec/support/helpers/github_api_mocker.rb
+++ b/spec/support/helpers/github_api_mocker.rb
@@ -12,7 +12,19 @@ module GithubApiMock
       )
   end
 
-  def stub_repository_views(project, repository_views_payload)
+  def stub_successful_repository_views(project, repository_views_payload)
+    stub_repository_views(project, repository_views_payload, 200)
+  end
+
+  def stub_failed_repository_views(project)
+    response_body = {
+      'message': 'Not Found',
+      'documentation_url': 'https://docs.github.com/rest/reference/repos#get-page-views'
+    }
+    stub_repository_views(project, response_body, 404)
+  end
+
+  def stub_repository_views(project, response_body, status_code)
     stub_env('GITHUB_ADMIN_USER', github_admin_user)
     stub_env('GITHUB_ADMIN_TOKEN', github_admin_token)
 
@@ -20,7 +32,7 @@ module GithubApiMock
 
     stub_request(:get, url)
       .with(basic_auth: [github_admin_user, github_admin_token], query: { per: 'week' })
-      .to_return(body: JSON.generate(repository_views_payload), status: 200)
+      .to_return(body: JSON.generate(response_body), status: status_code)
   end
 
   def not_found_body_from_github


### PR DESCRIPTION
## What does this PR do?
It prevents the job `OpenSourceMetricsUpdaterJob` from ending in failure due to any single failed API call made to Github.
If such an error may occur, it will only affect the problematic project and the rest will be able to be updated successfully. The error occurrence will also be tracked by Exception Hunter.
