### PR TITLE
Make blog jobs catch api errors

### DIFF
--- a/app/services/processors/blog_post_views_updater.rb
+++ b/app/services/processors/blog_post_views_updater.rb
@@ -14,6 +14,8 @@ module Processors
           create_metric(year, month, views)
         end
       end
+    rescue Faraday::Error => exception
+      ExceptionHunter.track(exception)
     end
 
     private

--- a/app/services/processors/blog_posts_updater.rb
+++ b/app/services/processors/blog_posts_updater.rb
@@ -2,13 +2,12 @@ module Processors
   class BlogPostsUpdater < BaseService
     def call
       blog_posts.each do |blog_post_payload|
-        blog_post_id = blog_post_payload[:ID]
-        blog_post = BlogPost.find_or_initialize_by(blog_id: blog_post_id)
+        blog_post = BlogPost.find_or_initialize_by(blog_id: blog_post_payload[:ID])
         blog_post.published_at = blog_post_payload[:date]
         blog_post.slug = blog_post_payload[:slug]
         blog_post.status = blog_post_payload[:status]
         blog_post.url = blog_post_payload[:URL]
-        blog_post.technologies = technologies_for(blog_post_id)
+        blog_post.technologies = technologies_for(blog_post)
 
         blog_post.save!
       end
@@ -24,9 +23,12 @@ module Processors
       @categorizer ||= BlogPostCategorizer.new
     end
 
-    def technologies_for(blog_post_id)
-      blog_post_payload = wordpress_service.blog_post(blog_post_id)
+    def technologies_for(blog_post)
+      blog_post_payload = wordpress_service.blog_post(blog_post.blog_id)
       categorizer.technologies_for(blog_post_payload)
+    rescue Faraday::Error => exception
+      ExceptionHunter.track(exception)
+      blog_post.technologies
     end
   end
 end

--- a/app/services/wordpress_service.rb
+++ b/app/services/wordpress_service.rb
@@ -5,12 +5,7 @@ class WordpressService
       after: since&.iso8601,
       page_handle: next_page_token
     }
-    response = connection.get(
-      'rest/v1.1/me/posts',
-      request_params,
-      Authorization: "Bearer #{access_token}"
-    )
-    response_body = JSON.parse(response.body).with_indifferent_access
+    response_body = get_response_body('me/posts', request_params)
 
     posts += response_body[:posts]
 
@@ -24,24 +19,21 @@ class WordpressService
   end
 
   def blog_post_views(blog_post_id)
-    response = connection.get(
-      "https://public-api.wordpress.com/rest/v1.1/sites/#{site_id}/stats/post/#{blog_post_id}",
-      {},
-      Authorization: "Bearer #{access_token}"
-    )
-    JSON.parse(response.body).with_indifferent_access
+    get_response_body("sites/#{site_id}/stats/post/#{blog_post_id}")
   end
 
   def blog_post(blog_post_id)
-    response = connection.get(
-      "https://public-api.wordpress.com/rest/v1.1/sites/#{site_id}/posts/#{blog_post_id}",
-      {},
-      Authorization: "Bearer #{access_token}"
-    )
-    JSON.parse(response.body).with_indifferent_access
+    get_response_body("sites/#{site_id}/posts/#{blog_post_id}")
   end
 
   private
+
+  def get_response_body(url, request_params = {})
+    response = connection.get(url) do |request|
+      request.params = request_params
+    end
+    JSON.parse(response.body).with_indifferent_access
+  end
 
   def access_token
     @access_token ||= request_access_token
@@ -55,7 +47,7 @@ class WordpressService
       username: username,
       password: password
     }
-    response = connection.post('oauth2/token', request_body)
+    response = Faraday.post('https://public-api.wordpress.com/oauth2/token', request_body)
     response_body = JSON.parse(response.body)
     raise_invalid_token_error(response_body) if response.status == 400
 
@@ -63,7 +55,9 @@ class WordpressService
   end
 
   def connection
-    Faraday.new('https://public-api.wordpress.com/')
+    Faraday.new('https://public-api.wordpress.com/rest/v1.1/') do |conn|
+      conn.authorization(:Bearer, access_token)
+    end
   end
 
   def raise_invalid_token_error(response_body)

--- a/app/services/wordpress_service.rb
+++ b/app/services/wordpress_service.rb
@@ -57,6 +57,7 @@ class WordpressService
   def connection
     Faraday.new('https://public-api.wordpress.com/rest/v1.1/') do |conn|
       conn.authorization(:Bearer, access_token)
+      conn.response(:raise_error)
     end
   end
 

--- a/app/services/wordpress_service.rb
+++ b/app/services/wordpress_service.rb
@@ -1,4 +1,6 @@
 class WordpressService
+  BASE_API_URL = 'https://public-api.wordpress.com'.freeze
+
   def blog_posts(since: Time.zone.at(0), posts: [], next_page_token: nil)
     request_params = {
       status: BlogPost.statuses[:publish],
@@ -47,7 +49,7 @@ class WordpressService
       username: username,
       password: password
     }
-    response = Faraday.post('https://public-api.wordpress.com/oauth2/token', request_body)
+    response = Faraday.post("#{BASE_API_URL}/oauth2/token", request_body)
     response_body = JSON.parse(response.body)
     raise_invalid_token_error(response_body) if response.status == 400
 
@@ -55,7 +57,7 @@ class WordpressService
   end
 
   def connection
-    Faraday.new('https://public-api.wordpress.com/rest/v1.1/') do |conn|
+    Faraday.new("#{BASE_API_URL}/rest/v1.1/") do |conn|
       conn.authorization(:Bearer, access_token)
       conn.response(:raise_error)
     end

--- a/spec/services/processors/blog_metrics_updater_spec.rb
+++ b/spec/services/processors/blog_metrics_updater_spec.rb
@@ -54,6 +54,22 @@ describe Processors::BlogMetricsUpdater do
           .by total_months_since_first_blog_post_published
       end
     end
+
+    context 'when there is an error in a request to the Wordpress API' do
+      let(:failing_blog_post) { create(:blog_post) }
+      let(:succeeding_blog_post) { create(:blog_post) }
+
+      before do
+        stub_failed_blog_post_views_response(failing_blog_post.blog_id)
+        stub_successful_blog_post_views_response(succeeding_blog_post.blog_id)
+      end
+
+      it 'successfully updates the rest of the blog posts' do
+        updater.call
+
+        expect(Metric.find_by(ownable: succeeding_blog_post)).not_to be_nil
+      end
+    end
   end
 end
 

--- a/spec/services/processors/blog_metrics_updater_spec.rb
+++ b/spec/services/processors/blog_metrics_updater_spec.rb
@@ -11,8 +11,8 @@ describe Processors::BlogMetricsUpdater do
     let(:blog_post_2_month_count) { months_count_for(blog_post_views_payload_2) }
 
     before do
-      stub_blog_post_views_response(blog_post_1.blog_id, blog_post_views_payload_1)
-      stub_blog_post_views_response(blog_post_2.blog_id, blog_post_views_payload_2)
+      stub_successful_blog_post_views_response(blog_post_1.blog_id, blog_post_views_payload_1)
+      stub_successful_blog_post_views_response(blog_post_2.blog_id, blog_post_views_payload_2)
     end
 
     subject(:updater) { Processors::BlogMetricsPartialUpdater }

--- a/spec/services/processors/blog_post_views_updater_spec.rb
+++ b/spec/services/processors/blog_post_views_updater_spec.rb
@@ -12,7 +12,7 @@ describe Processors::BlogPostViewsUpdater do
     end
 
     before do
-      stub_blog_post_views_response(blog_post.blog_id, blog_post_views_payload)
+      stub_successful_blog_post_views_response(blog_post.blog_id, blog_post_views_payload)
     end
 
     it 'creates views metrics for the blog post' do

--- a/spec/services/processors/blog_post_views_updater_spec.rb
+++ b/spec/services/processors/blog_post_views_updater_spec.rb
@@ -3,74 +3,87 @@ require 'rails_helper'
 describe Processors::BlogPostViewsUpdater do
   describe '.call' do
     let(:blog_post) { create(:blog_post, published_at: publish_date) }
-    let(:blog_post_views_payload) do
-      create(:blog_post_views_payload, publish_datetime: publish_date).with_indifferent_access
-    end
     let(:publish_date) { Time.zone.now.beginning_of_month }
-    let(:current_month_views) do
-      blog_post_views_payload['years'][publish_date.year.to_s]['months'][publish_date.month.to_s]
-    end
 
-    before do
-      stub_successful_blog_post_views_response(blog_post.blog_id, blog_post_views_payload)
-    end
-
-    it 'creates views metrics for the blog post' do
-      described_class.call(blog_post.blog_id)
-
-      created_metric = Metric.find_by(
-        ownable: blog_post,
-        interval: Metric.intervals[:monthly],
-        name: Metric.names[:blog_visits]
-      )
-      expect(created_metric.value).to eq current_month_views
-      expect(created_metric.value_timestamp.to_s).to eq publish_date.end_of_month.to_s
-    end
-
-    context 'when the blog post has already registered views this month' do
-      let(:outdated_month_views) { current_month_views - 10 }
+    context 'when the request to get the post views succeeds' do
+      let(:blog_post_views_payload) do
+        create(:blog_post_views_payload, publish_datetime: publish_date).with_indifferent_access
+      end
+      let(:current_month_views) do
+        blog_post_views_payload['years'][publish_date.year.to_s]['months'][publish_date.month.to_s]
+      end
 
       before do
-        create(
-          :metric,
-          name: Metric.names[:blog_visits],
+        stub_successful_blog_post_views_response(blog_post.blog_id, blog_post_views_payload)
+      end
+
+      it 'creates views metrics for the blog post' do
+        described_class.call(blog_post.blog_id)
+
+        created_metric = Metric.find_by(
+          ownable: blog_post,
           interval: Metric.intervals[:monthly],
-          value: outdated_month_views,
-          value_timestamp: publish_date.end_of_month,
-          ownable: blog_post
+          name: Metric.names[:blog_visits]
         )
+        expect(created_metric.value).to eq current_month_views
+        expect(created_metric.value_timestamp.to_s).to eq publish_date.end_of_month.to_s
       end
 
-      it 'updates the views amount with the latest info' do
-        metric = Metric.find_by(ownable: blog_post)
-
-        expect { described_class.call(blog_post.blog_id) }
-          .to change { metric.reload.value }
-          .from(outdated_month_views)
-          .to(current_month_views)
-      end
-
-      context 'and all months since it publication' do
-        let(:publish_date) { Time.zone.now.last_year }
+      context 'when the blog post has already registered views this month' do
+        let(:outdated_month_views) { current_month_views - 10 }
 
         before do
-          (publish_date.to_date..Time.zone.today).map(&:end_of_month).uniq.each do |time|
-            create(
-              :metric,
-              name: Metric.names[:blog_visits],
-              interval: Metric.intervals[:monthly],
-              value: outdated_month_views,
-              value_timestamp: time.end_of_day,
-              ownable: blog_post
-            )
+          create(
+            :metric,
+            name: Metric.names[:blog_visits],
+            interval: Metric.intervals[:monthly],
+            value: outdated_month_views,
+            value_timestamp: publish_date.end_of_month,
+            ownable: blog_post
+          )
+        end
+
+        it 'updates the views amount with the latest info' do
+          metric = Metric.find_by(ownable: blog_post)
+
+          expect { described_class.call(blog_post.blog_id) }
+            .to change { metric.reload.value }
+            .from(outdated_month_views)
+            .to(current_month_views)
+        end
+
+        context 'and all months since it publication' do
+          let(:publish_date) { Time.zone.now.last_year }
+
+          before do
+            (publish_date.to_date..Time.zone.today).map(&:end_of_month).uniq.each do |time|
+              create(
+                :metric,
+                name: Metric.names[:blog_visits],
+                interval: Metric.intervals[:monthly],
+                value: outdated_month_views,
+                value_timestamp: time.end_of_day,
+                ownable: blog_post
+              )
+            end
+          end
+
+          it 'does not access last month views as they will not have changed' do
+            expect(Metric).to receive(:find_or_initialize_by).once.and_call_original
+
+            described_class.call(blog_post.blog_id)
           end
         end
+      end
+    end
 
-        it 'does not access last month views as they will not have changed' do
-          expect(Metric).to receive(:find_or_initialize_by).once.and_call_original
+    context 'when the request to get the post views fails' do
+      before { stub_failed_blog_post_views_response(blog_post.blog_id) }
 
-          described_class.call(blog_post.blog_id)
-        end
+      it 'notifies the error to exception hunter' do
+        expect(ExceptionHunter).to receive(:track).with(kind_of(Faraday::Error))
+
+        described_class.call(blog_post.blog_id)
       end
     end
   end

--- a/spec/services/processors/blog_posts_full_updater_spec.rb
+++ b/spec/services/processors/blog_posts_full_updater_spec.rb
@@ -25,8 +25,8 @@ describe Processors::BlogPostsFullUpdater do
       before do
         create(:technology, name: 'other')
         stub_blog_posts_response(blog_post_payloads: blog_post_payload)
-        stub_blog_post_response(stored_blog_post_payload)
-        stub_blog_post_response(new_blog_post_payload)
+        stub_successful_blog_post_response(stored_blog_post_payload)
+        stub_successful_blog_post_response(new_blog_post_payload)
       end
 
       it 'updates the stored blog post' do

--- a/spec/services/processors/blog_posts_partial_updater_spec.rb
+++ b/spec/services/processors/blog_posts_partial_updater_spec.rb
@@ -28,7 +28,7 @@ describe Processors::BlogPostsPartialUpdater do
           request_params: { after: publish_date.utc.iso8601 },
           blog_post_payloads: partial_blog_post_payload
         )
-        stub_blog_post_response(new_blog_post_payload)
+        stub_successful_blog_post_response(new_blog_post_payload)
       end
 
       it 'does not update the stored blog post' do

--- a/spec/services/processors/blog_posts_updater_spec.rb
+++ b/spec/services/processors/blog_posts_updater_spec.rb
@@ -4,22 +4,42 @@ RSpec.describe Processors::BlogPostsUpdater do
   describe '.call' do
     subject { Processors::BlogPostsFullUpdater.call }
 
+    let(:blog_post_payload) { create(:blog_post_payload) }
+
     before do
       create(:technology, name: 'other')
-      blog_post_payload = create(:blog_post_payload)
       stub_blog_posts_response(blog_post_payloads: [blog_post_payload])
-      stub_successful_blog_post_response(blog_post_payload)
     end
 
-    it 'saves all blog posts in the db' do
-      expect { subject }.to change(BlogPost, :count).by(1)
+    context 'when all requests succeed' do
+      before do
+        stub_successful_blog_post_response(blog_post_payload)
+      end
+
+      it 'saves all blog posts in the db' do
+        expect { subject }.to change(BlogPost, :count).by(1)
+      end
+
+      context 'when the post has already been imported' do
+        before { subject }
+
+        it 'does not create another blog post' do
+          expect { subject }.not_to change(BlogPost, :count)
+        end
+      end
     end
 
-    context 'when the post has already been imported' do
-      before { subject }
+    context 'when the request to get a blog post full payload fails' do
+      before { stub_failed_blog_post_response(blog_post_payload['ID']) }
 
-      it 'does not create another blog post' do
-        expect { subject }.not_to change(BlogPost, :count)
+      it 'creates the blog post anyway' do
+        expect { subject }.to change(BlogPost, :count).by(1)
+      end
+
+      it 'notifies the error to exception hunter' do
+        expect(ExceptionHunter).to receive(:track).with(kind_of(Faraday::Error))
+
+        subject
       end
     end
   end

--- a/spec/services/processors/blog_posts_updater_spec.rb
+++ b/spec/services/processors/blog_posts_updater_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Processors::BlogPostsUpdater do
       create(:technology, name: 'other')
       blog_post_payload = create(:blog_post_payload)
       stub_blog_posts_response(blog_post_payloads: [blog_post_payload])
-      stub_blog_post_response(blog_post_payload)
+      stub_successful_blog_post_response(blog_post_payload)
     end
 
     it 'saves all blog posts in the db' do

--- a/spec/services/wordpress_service_spec.rb
+++ b/spec/services/wordpress_service_spec.rb
@@ -34,43 +34,53 @@ RSpec.describe WordpressService do
   end
 
   describe '#blog_posts' do
-    let(:blog_post) { create(:blog_post_payload) }
-
-    before do
-      stub_blog_posts_response(blog_post_payloads: [blog_post])
-    end
-
-    it 'returns the published blog posts of the site' do
-      expect(subject.blog_posts).to contain_exactly(blog_post.deep_symbolize_keys)
-    end
-
-    context 'when there is more than 1 page of results' do
-      let(:blog_post_2) { create(:blog_post_payload) }
+    context 'when the request succeeds' do
+      let(:blog_post) { create(:blog_post_payload) }
 
       before do
-        stub_blog_posts_response(blog_post_payloads: [blog_post, blog_post_2], page_size: 1)
+        stub_blog_posts_response(blog_post_payloads: [blog_post])
       end
 
-      it 'returns all the published blog posts of the site' do
-        expect(subject.blog_posts).to contain_exactly(blog_post, blog_post_2)
+      it 'returns the published blog posts of the site' do
+        expect(subject.blog_posts).to contain_exactly(blog_post.deep_symbolize_keys)
+      end
+
+      context 'when there is more than 1 page of results' do
+        let(:blog_post_2) { create(:blog_post_payload) }
+
+        before do
+          stub_blog_posts_response(blog_post_payloads: [blog_post, blog_post_2], page_size: 1)
+        end
+
+        it 'returns all the published blog posts of the site' do
+          expect(subject.blog_posts).to contain_exactly(blog_post, blog_post_2)
+        end
+      end
+
+      context 'when given a starting date' do
+        let(:starting_date) { 30.days.ago }
+        let(:blog_post_date) { Faker::Time.between(from: starting_date, to: Time.zone.today) }
+        let(:blog_post) { create(:blog_post_payload, date: blog_post_date.iso8601) }
+
+        before do
+          stub_blog_posts_response(
+            request_params: { after: starting_date.iso8601 },
+            blog_post_payloads: [blog_post]
+          )
+        end
+
+        it 'returns the published blog posts created since the given date' do
+          expect(subject.blog_posts(since: starting_date))
+            .to contain_exactly(blog_post.deep_symbolize_keys)
+        end
       end
     end
 
-    context 'when given a starting date' do
-      let(:starting_date) { 30.days.ago }
-      let(:blog_post_date) { Faker::Time.between(from: starting_date, to: Time.zone.today) }
-      let(:blog_post) { create(:blog_post_payload, date: blog_post_date.iso8601) }
+    context 'when the request fails' do
+      before { stub_failed_blog_posts_response }
 
-      before do
-        stub_blog_posts_response(
-          request_params: { after: starting_date.iso8601 },
-          blog_post_payloads: [blog_post]
-        )
-      end
-
-      it 'returns the published blog posts created since the given date' do
-        expect(subject.blog_posts(since: starting_date))
-          .to contain_exactly(blog_post.deep_symbolize_keys)
+      it 'raises an exception' do
+        expect { subject.blog_posts }.to raise_error Faraday::ClientError
       end
     end
   end
@@ -78,16 +88,27 @@ RSpec.describe WordpressService do
   describe '#blog_post_views' do
     let(:blog_post) { create(:blog_post) }
     let(:blog_post_id) { blog_post.blog_id }
-    let(:blog_post_views_payload) do
-      create(:blog_post_views_payload, publish_datetime: blog_post.published_at)
+
+    context 'when the request succeeds' do
+      let(:blog_post_views_payload) do
+        create(:blog_post_views_payload, publish_datetime: blog_post.published_at)
+      end
+
+      before do
+        stub_successful_blog_post_views_response(blog_post_id, blog_post_views_payload)
+      end
+
+      it 'returns the views hash for the requested post' do
+        expect(subject.blog_post_views(blog_post_id)).to eq blog_post_views_payload
+      end
     end
 
-    before do
-      stub_blog_post_views_response(blog_post_id, blog_post_views_payload)
-    end
+    context 'when the request fails' do
+      before { stub_failed_blog_post_views_response(blog_post_id) }
 
-    it 'returns the views hash for the requested post' do
-      expect(subject.blog_post_views(blog_post_id)).to eq blog_post_views_payload
+      it 'raises an exception' do
+        expect { subject.blog_post_views(blog_post_id) }.to raise_error Faraday::ClientError
+      end
     end
   end
 
@@ -95,12 +116,20 @@ RSpec.describe WordpressService do
     let(:blog_post_payload) { create(:blog_post_payload) }
     let(:blog_post_id) { blog_post_payload['ID'] }
 
-    before do
-      stub_blog_post_response(blog_post_payload)
+    context 'when the request succeeds' do
+      before { stub_successful_blog_post_response(blog_post_payload) }
+
+      it 'returns the payload of the requested post' do
+        expect(subject.blog_post(blog_post_id)).to eq blog_post_payload
+      end
     end
 
-    it 'returns the payload of the requested post' do
-      expect(subject.blog_post(blog_post_id)).to eq blog_post_payload
+    context 'when the request fails' do
+      before { stub_failed_blog_post_response(blog_post_id) }
+
+      it 'raises an exception' do
+        expect { subject.blog_post(blog_post_id) }.to raise_error Faraday::ClientError
+      end
     end
   end
 end

--- a/spec/support/helpers/wordpress_api_mocker.rb
+++ b/spec/support/helpers/wordpress_api_mocker.rb
@@ -14,7 +14,7 @@ module WordpressApiMocker
     stub_access_token_response
     stub_env('WORDPRESS_SITE_ID', blog_site_id)
 
-    url = 'https://public-api.wordpress.com/rest/v1.1/sites/' \
+    url = "#{WordpressService::BASE_API_URL}/rest/v1.1/sites/" \
           "#{blog_site_id}/stats/post/#{blog_post_id}"
     stub_request(:get, url)
       .with(headers: authorization_header)
@@ -29,7 +29,7 @@ module WordpressApiMocker
       after: default_starting_time.iso8601
     }.merge(request_params)
 
-    stub_request(:get, 'https://public-api.wordpress.com/rest/v1.1/me/posts')
+    stub_request(:get, "#{WordpressService::BASE_API_URL}/rest/v1.1/me/posts")
       .with(query: request_params.merge(page_handle: nil), headers: authorization_header)
       .to_return(status: 404)
   end
@@ -75,7 +75,7 @@ module WordpressApiMocker
 
     blog_posts_response.merge!('meta': { 'next_page': next_page_token }) if next_page_token.present?
 
-    stub_request(:get, 'https://public-api.wordpress.com/rest/v1.1/me/posts')
+    stub_request(:get, "#{WordpressService::BASE_API_URL}/rest/v1.1/me/posts")
       .with(query: request_params.merge(page_handle: page_token), headers: authorization_header)
       .to_return(body: JSON.generate(blog_posts_response), status: 200)
   end
@@ -92,7 +92,7 @@ module WordpressApiMocker
     stub_access_token_response
     stub_env('WORDPRESS_SITE_ID', blog_site_id)
 
-    url = 'https://public-api.wordpress.com/rest/v1.1/sites/' \
+    url = "#{WordpressService::BASE_API_URL}/rest/v1.1/sites/" \
           "#{blog_site_id}/posts/#{blog_post_id}"
     stub_request(:get, url)
       .with(headers: authorization_header)
@@ -113,7 +113,7 @@ module WordpressApiMocker
       password: password
     }
 
-    stub_request(:post, 'https://public-api.wordpress.com/oauth2/token')
+    stub_request(:post, "#{WordpressService::BASE_API_URL}/oauth2/token")
       .with(body: request_params)
       .to_return(body: JSON.generate(response_body), status: response_status)
   end


### PR DESCRIPTION
## What does this PR do?
It prevents all blog-related jobs from ending in failure due to any single failed API call made to the Wordpress API*.
If such an error may occur, it will only affect the problematic blog post and the rest will be able to be updated successfully. The error occurrence will also be tracked by Exception Hunter.

*The only exception being a failed request to the `me/posts` endpoint, which retrieves all blog posts. If it failed, no update could be made anyway, so we'll let the job fail