### PR TITLE
[EM-142] Fix order for project names in Project metrics dropdown

### DIFF
--- a/app/helpers/models_names_helper.rb
+++ b/app/helpers/models_names_helper.rb
@@ -1,6 +1,6 @@
 module ModelsNamesHelper
   def all_projects_names
-    Project.pluck(:name).sort
+    Project.pluck(:name).sort_by(&:downcase)
   end
 
   def all_users_names

--- a/spec/helpers/models_names_helper_spec.rb
+++ b/spec/helpers/models_names_helper_spec.rb
@@ -33,6 +33,16 @@ RSpec.describe ModelsNamesHelper, type: :helper do
     it 'returns the rs-site-django as third project in the collection' do
       expect(helper.all_projects_names.third).to eq(rs_site_django_project.name)
     end
+
+    context 'when one of the project names start with an uppercase' do
+      let!(:elon1_raspberry_project) do
+        create(:project, name: 'Elon1-raspberry', language: Language.find_by(name: 'python'))
+      end
+
+      it 'still places it in the correct position' do
+        expect(helper.all_projects_names.second).to eq(elon1_raspberry_project.name)
+      end
+    end
   end
 
   describe '.all_users_names' do


### PR DESCRIPTION
## What does this PR do?
It fixes the order of the project names in the Project metrics dropdown

![image](https://user-images.githubusercontent.com/7276679/90144582-5bc7c980-dd55-11ea-8bc4-a533c0ab9b66.png)


Resolves [#142](https://rootstrap.atlassian.net/browse/EM-142)
