### PR TITLE
Ignore projects with the archived property

### DIFF
--- a/app/services/builders/project.rb
+++ b/app/services/builders/project.rb
@@ -15,6 +15,7 @@ module Builders
         project.name = @repository_data['name']
         project.description = @repository_data['description']
         project.is_private = @repository_data['private']
+        project.relevance = ::Project.relevances[:ignored] if @repository_data['archived']
       end
     end
   end

--- a/spec/factories/payloads/repository.rb
+++ b/spec/factories/payloads/repository.rb
@@ -7,6 +7,7 @@ FactoryBot.define do
     name { Faker::App.name }
     description { '' }
     private { false }
+    archived { false }
 
     initialize_with { attributes.deep_stringify_keys }
   end

--- a/spec/services/builders/project_spec.rb
+++ b/spec/services/builders/project_spec.rb
@@ -38,5 +38,29 @@ RSpec.describe Builders::Project do
         expect(described_class.call(repository_payload)).to eq project
       end
     end
+
+    describe 'archived property' do
+      context 'when the project is archived' do
+        let(:repository_payload) { create(:repository_payload, archived: true) }
+
+        it 'the project is assigned the "ignored" relevance' do
+          described_class.call(repository_payload)
+
+          project = Project.find_by(github_id: repository_payload['id'])
+          expect(project.relevance).to eq Project.relevances[:ignored]
+        end
+      end
+
+      context 'when the project is not archived' do
+        let(:repository_payload) { create(:repository_payload, archived: false) }
+
+        it 'the project is not assigned a relevance' do
+          described_class.call(repository_payload)
+
+          project = Project.find_by(github_id: repository_payload['id'])
+          expect(project.relevance).to eq Project.relevances[:unassigned]
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
## What does this PR do?
It marks projects as `ignored` if their payload shows they're `archived` (when creating/updating them)
