### PR TITLE
Add relevance filter to projects in admin

### DIFF
--- a/app/admin/projects.rb
+++ b/app/admin/projects.rb
@@ -1,5 +1,7 @@
 ActiveAdmin.register Project do
   permit_params :language_id, :description, :name, :github_id, :relevance
+  preserve_default_filters!
+  filter :relevance, as: :select, collection: Project.relevances.values
   remove_filter :events
 
   index do


### PR DESCRIPTION
## What does this PR do?
It adds a `relevance` filter to the projects list in admin
