### PR TITLE
[EM-151] Change code climate repository endpoint

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -13,7 +13,7 @@ detectors:
     exclude: []
   DataClump:
     enabled: true
-    exclude: []
+    exclude: ['CodeClimateApiMocker']
     max_copies: 2
     min_clump_size: 2
   DuplicateMethodCall:

--- a/app/models/code_climate_project_metric.rb
+++ b/app/models/code_climate_project_metric.rb
@@ -10,6 +10,7 @@
 #  wont_fix_issues_count :integer
 #  created_at            :datetime         not null
 #  updated_at            :datetime         not null
+#  cc_repository_id      :string
 #  project_id            :bigint           not null
 #
 # Indexes

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -45,6 +45,8 @@ class Project < ApplicationRecord
            through: :code_owner_projects,
            source: :user
 
+  has_one :code_climate_project_metric, dependent: :destroy
+
   validates :github_id, presence: true, uniqueness: true
   validates :relevance, inclusion: { in: relevances.keys }
 

--- a/app/services/code_climate/api/client.rb
+++ b/app/services/code_climate/api/client.rb
@@ -18,6 +18,11 @@ module CodeClimate
         Repository.new(repository_data)
       end
 
+      def repository_by_repo_id(repo_id:)
+        json = get_json(repository_by_id_remote_query(repository_id: repo_id))
+        Repository.new(json['data'].first)
+      end
+
       def snapshot(repo_id:, snapshot_id:)
         json = get_json(snapshot_remote_query(repo_id: repo_id, snapshot_id: snapshot_id))
         Snapshot.new(json['data'], repo_id)

--- a/app/services/code_climate/api/client.rb
+++ b/app/services/code_climate/api/client.rb
@@ -20,7 +20,7 @@ module CodeClimate
 
       def repository_by_repo_id(repo_id:)
         json = get_json(repository_by_id_remote_query(repository_id: repo_id))
-        Repository.new(json['data'].first)
+        Repository.new(json['data'])
       end
 
       def snapshot(repo_id:, snapshot_id:)

--- a/app/services/code_climate/api/snapshot.rb
+++ b/app/services/code_climate/api/snapshot.rb
@@ -11,7 +11,8 @@ module CodeClimate
       def summary
         ProjectSummary.new(rate: ratings.first,
                            issues: issues_collection,
-                           snapshot_time: snapshot_time)
+                           snapshot_time: snapshot_time,
+                           repository_id: repo_id)
       end
 
       private

--- a/app/services/code_climate/get_project_summary.rb
+++ b/app/services/code_climate/get_project_summary.rb
@@ -1,15 +1,31 @@
 module CodeClimate
   class GetProjectSummary < BaseService
-    def initialize(github_slug:)
-      @github_slug = github_slug
+    CODE_CLIMATE_API_ORG_NAME = 'rootstrap'.freeze
+
+    def initialize(project:)
+      @project = project
     end
 
     def call
       repository&.summary
     end
 
+    private
+
+    attr_reader :project
+
     def repository
-      CodeClimate::Api::Client.new.repository_by_slug(github_slug: @github_slug)
+      repo_id = project.code_climate_project_metric&.cc_repository_id
+
+      if repo_id.present?
+        CodeClimate::Api::Client.new.repository_by_repo_id(repo_id: repo_id)
+      else
+        CodeClimate::Api::Client.new.repository_by_slug(github_slug: github_slug)
+      end
+    end
+
+    def github_slug
+      "#{CODE_CLIMATE_API_ORG_NAME}/#{project.name}"
     end
   end
 end

--- a/app/services/code_climate/project_summary.rb
+++ b/app/services/code_climate/project_summary.rb
@@ -1,15 +1,16 @@
 module CodeClimate
   class ProjectSummary
     attr_reader :rate, :invalid_issues_count, :open_issues_count,
-                :wont_fix_issues_count, :snapshot_time, :name
+                :wont_fix_issues_count, :snapshot_time, :name, :repo_id
 
-    def initialize(rate:, issues:, snapshot_time:, name: nil)
+    def initialize(rate:, issues:, snapshot_time:, name: nil, repository_id: nil)
       @rate = rate
       @invalid_issues_count = issues[:invalid_issues_count]
       @open_issues_count = issues[:open_issues_count]
       @wont_fix_issues_count = issues[:wont_fix_issues_count]
       @snapshot_time = snapshot_time
       @name = name
+      @repo_id = repository_id
     end
   end
 end

--- a/app/services/code_climate/update_project_service.rb
+++ b/app/services/code_climate/update_project_service.rb
@@ -1,7 +1,5 @@
 module CodeClimate
   class UpdateProjectService < BaseService
-    CODE_CLIMATE_API_ORG_NAME = 'rootstrap'.freeze
-
     def initialize(project)
       @project = project
     end
@@ -16,6 +14,8 @@ module CodeClimate
 
     private
 
+    attr_reader :project
+
     def update_metric
       create_project_code_climate_metric unless project_code_climate_metric
 
@@ -29,8 +29,7 @@ module CodeClimate
     end
 
     def code_climate_project_summary
-      @code_climate_project_summary ||=
-        CodeClimate::GetProjectSummary.call(github_slug: project_name)
+      @code_climate_project_summary ||= CodeClimate::GetProjectSummary.call(project: project)
     end
 
     def today
@@ -42,18 +41,14 @@ module CodeClimate
     end
 
     def project_code_climate_metric
-      @project_code_climate_metric ||= CodeClimateProjectMetric.find_by(project: @project)
+      @project_code_climate_metric ||= CodeClimateProjectMetric.find_by(project: project)
     end
 
     def create_project_code_climate_metric
       @project_code_climate_metric = CodeClimateProjectMetric.create!(
-        project: @project,
+        project: project,
         snapshot_time: code_climate_project_summary.snapshot_time
       )
-    end
-
-    def project_name
-      "#{CODE_CLIMATE_API_ORG_NAME}/#{@project.name}"
     end
   end
 end

--- a/app/services/code_climate/update_project_service.rb
+++ b/app/services/code_climate/update_project_service.rb
@@ -7,6 +7,8 @@ module CodeClimate
     def call
       return unless update_metric? && code_climate_project_summary.present?
 
+      create_project_code_climate_metric if project_code_climate_metric.blank?
+
       update_metric
     rescue Faraday::Error => exception
       ExceptionHunter.track(exception)
@@ -17,14 +19,13 @@ module CodeClimate
     attr_reader :project
 
     def update_metric
-      create_project_code_climate_metric unless project_code_climate_metric
-
       project_code_climate_metric.update!(
         code_climate_rate: code_climate_project_summary.rate,
         invalid_issues_count: code_climate_project_summary.invalid_issues_count,
         open_issues_count: code_climate_project_summary.open_issues_count,
         wont_fix_issues_count: code_climate_project_summary.wont_fix_issues_count,
-        snapshot_time: code_climate_project_summary.snapshot_time
+        snapshot_time: code_climate_project_summary.snapshot_time,
+        cc_repository_id: code_climate_project_summary.repo_id
       )
     end
 

--- a/db/migrate/20200819142237_add_cc_repository_id_to_code_climate_project_metrics.rb
+++ b/db/migrate/20200819142237_add_cc_repository_id_to_code_climate_project_metrics.rb
@@ -1,0 +1,5 @@
+class AddCcRepositoryIdToCodeClimateProjectMetrics < ActiveRecord::Migration[6.0]
+  def change
+    add_column :code_climate_project_metrics, :cc_repository_id, :string
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -298,7 +298,8 @@ CREATE TABLE public.code_climate_project_metrics (
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
     open_issues_count integer,
-    snapshot_time timestamp without time zone NOT NULL
+    snapshot_time timestamp without time zone NOT NULL,
+    cc_repository_id character varying
 );
 
 
@@ -1860,5 +1861,6 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20200723174621'),
 ('20200730142418'),
 ('20200806131024'),
-('20200813162522');
+('20200813162522'),
+('20200819142237');
 

--- a/spec/factories/code_climate_project_metrics.rb
+++ b/spec/factories/code_climate_project_metrics.rb
@@ -10,6 +10,7 @@
 #  wont_fix_issues_count :integer
 #  created_at            :datetime         not null
 #  updated_at            :datetime         not null
+#  cc_repository_id      :string
 #  project_id            :bigint           not null
 #
 # Indexes
@@ -30,5 +31,6 @@ FactoryBot.define do
     wont_fix_issues_count { Faker::Number.between(from: 0, to: 30) }
     snapshot_time { Faker::Date.between(from: 1.month.ago, to: Time.zone.now) }
     updated_at { DateTime.current }
+    cc_repository_id { Faker::Alphanumeric.alphanumeric(number: 24) }
   end
 end

--- a/spec/factories/payloads/code_climate_repository.rb
+++ b/spec/factories/payloads/code_climate_repository.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
     skip_create
 
     transient do
-      id { Faker::Number.number(digits: 4) }
+      id { Faker::Alphanumeric.alphanumeric(number: 24) }
       name { Faker::Internet.slug(glue: '-') }
       latest_default_branch_snapshot_id { Faker::Number.number(digits: 4) }
     end

--- a/spec/factories/payloads/code_climate_repository.rb
+++ b/spec/factories/payloads/code_climate_repository.rb
@@ -1,17 +1,14 @@
 FactoryBot.define do
-  factory :code_climate_repository_payload, class: Hash do
+  factory :code_climate_repository_payload,
+          aliases: [:code_climate_repository_by_id_payload],
+          class: Hash do
     skip_create
 
     transient do
       id { Faker::Alphanumeric.alphanumeric(number: 24) }
       name { Faker::Internet.slug(glue: '-') }
       latest_default_branch_snapshot_id { Faker::Number.number(digits: 4) }
-    end
-
-    # Despite of the name this endpoint returns a collection of repositories:
-    #   https://developer.codeclimate.com/#get-repository
-    data do
-      [
+      repository_payload do
         {
           'id' => id,
           'type' => 'repos',
@@ -36,9 +33,19 @@ FactoryBot.define do
             }
           }
         }
-      ]
+      end
     end
 
+    data { repository_payload }
+
     initialize_with { attributes.deep_stringify_keys }
+
+    factory :code_climate_repository_by_slug_payload, class: Hash do
+      # Despite of the name this endpoint returns a collection of repositories:
+      #   https://developer.codeclimate.com/#get-repository
+      after(:build) do |payload|
+        payload['data'] = [payload['data']]
+      end
+    end
   end
 end

--- a/spec/models/code_climate_project_metric_spec.rb
+++ b/spec/models/code_climate_project_metric_spec.rb
@@ -10,6 +10,7 @@
 #  wont_fix_issues_count :integer
 #  created_at            :datetime         not null
 #  updated_at            :datetime         not null
+#  cc_repository_id      :string
 #  project_id            :bigint           not null
 #
 # Indexes

--- a/spec/services/code_climate/api/client_spec.rb
+++ b/spec/services/code_climate/api/client_spec.rb
@@ -17,7 +17,7 @@ describe CodeClimate::Api::Client do
 
       context 'and has repository data' do
         let(:code_climate_repository_json) do
-          create(:code_climate_repository_payload, name: project.name)
+          create(:code_climate_repository_by_slug_payload, name: project.name)
         end
 
         it 'returns a Repository with the data' do
@@ -28,7 +28,7 @@ describe CodeClimate::Api::Client do
 
       context 'but has no repository data' do
         let(:code_climate_repository_json) do
-          create(:code_climate_repository_payload, data: [])
+          create(:code_climate_repository_by_slug_payload, data: [])
         end
 
         it 'returns nil' do
@@ -55,10 +55,9 @@ describe CodeClimate::Api::Client do
   describe '#repository_by_repo_id' do
     let(:project) { create(:project) }
     let(:code_climate_repository_json) do
-      create(:code_climate_repository_payload, name: project.name)
+      create(:code_climate_repository_by_id_payload, name: project.name)
     end
-    let(:repo_json) { code_climate_repository_json['data'].first }
-    let(:repo_id) { repo_json['id'] }
+    let(:repo_id) { code_climate_repository_json['data']['id'] }
 
     context 'when the request succeeds' do
       before do
@@ -92,7 +91,7 @@ describe CodeClimate::Api::Client do
   describe '#snapshot' do
     let(:project) { create(:project) }
     let(:code_climate_repository_json) do
-      create(:code_climate_repository_payload, name: project.name)
+      create(:code_climate_repository_by_slug_payload, name: project.name)
     end
     let(:repo_json) { code_climate_repository_json['data'].first }
     let(:repo_id) { repo_json['id'] }
@@ -138,7 +137,7 @@ describe CodeClimate::Api::Client do
   describe '#snapshot_issues' do
     let(:project) { create(:project) }
     let(:code_climate_repository_json) do
-      create(:code_climate_repository_payload, name: project.name)
+      create(:code_climate_repository_by_slug_payload, name: project.name)
     end
     let(:repo_json) { code_climate_repository_json['data'].first }
     let(:repo_id) { repo_json['id'] }

--- a/spec/services/code_climate/get_project_summary_spec.rb
+++ b/spec/services/code_climate/get_project_summary_spec.rb
@@ -5,7 +5,7 @@ describe CodeClimate::GetProjectSummary do
     subject(:repository) { described_class.send(:new, project: project).send(:repository) }
 
     let(:project) { create(:project) }
-    let(:code_climate_repository_json) { create(:code_climate_repository_payload) }
+    let(:code_climate_repository_json) { create(:code_climate_repository_by_slug_payload) }
 
     context 'when the project does not have a code climate project metric' do
       before do

--- a/spec/services/code_climate/get_project_summary_spec.rb
+++ b/spec/services/code_climate/get_project_summary_spec.rb
@@ -1,0 +1,55 @@
+require 'rails_helper'
+
+describe CodeClimate::GetProjectSummary do
+  describe '#repository' do
+    subject(:repository) { described_class.send(:new, project: project).send(:repository) }
+
+    let(:project) { create(:project) }
+    let(:code_climate_repository_json) { create(:code_climate_repository_payload) }
+
+    context 'when the project does not have a code climate project metric' do
+      before do
+        on_request_repository_by_slug(
+          project_name: project.name,
+          respond: { status: 200, body: code_climate_repository_json }
+        )
+      end
+
+      it 'gets the repository by slug' do
+        expect(repository).to be_a(CodeClimate::Api::Repository)
+      end
+    end
+
+    context 'when the project has a code climate project metric' do
+      context 'but not a repository id' do
+        before do
+          create(:code_climate_project_metric, cc_repository_id: nil, project: project)
+
+          on_request_repository_by_slug(
+            project_name: project.name,
+            respond: { status: 200, body: code_climate_repository_json }
+          )
+        end
+
+        it 'gets the repository by slug' do
+          expect(repository).to be_a(CodeClimate::Api::Repository)
+        end
+      end
+
+      context 'and a repository id' do
+        before do
+          code_climate_project_metric = create(:code_climate_project_metric, project: project)
+
+          on_request_repository_by_repo_id(
+            repo_id: code_climate_project_metric.cc_repository_id,
+            respond: { status: 200, body: code_climate_repository_json }
+          )
+        end
+
+        it 'gets the repository by repo id' do
+          expect(repository).to be_a(CodeClimate::Api::Repository)
+        end
+      end
+    end
+  end
+end

--- a/spec/services/code_climate/update_project_service/api_call_failures_spec.rb
+++ b/spec/services/code_climate/update_project_service/api_call_failures_spec.rb
@@ -7,7 +7,7 @@ describe CodeClimate::UpdateProjectService do
   let(:snapshot_id) { code_climate_snapshot_json['data']['id'] }
 
   let(:code_climate_repository_json) do
-    build :code_climate_repository_payload,
+    build :code_climate_repository_by_slug_payload,
           latest_default_branch_snapshot_id: code_climate_snapshot_json['data']['id']
   end
   let(:code_climate_snapshot_json) do
@@ -49,7 +49,9 @@ describe CodeClimate::UpdateProjectService do
         )
       end
 
-      let(:code_climate_repository_json) { build(:code_climate_repository_payload, data: []) }
+      let(:code_climate_repository_json) do
+        build(:code_climate_repository_by_slug_payload, data: [])
+      end
 
       it 'does not update a CodeClimateProjectMetric record' do
         expect { update_project_code_climate_info }

--- a/spec/services/code_climate/update_project_service/api_call_failures_spec.rb
+++ b/spec/services/code_climate/update_project_service/api_call_failures_spec.rb
@@ -25,8 +25,8 @@ describe CodeClimate::UpdateProjectService do
   context 'when the call to /repos' do
     context 'returns anything but 200' do
       before do
-        on_request_repository(project_name: project.name,
-                              respond: { status: 500 })
+        on_request_repository_by_slug(project_name: project.name,
+                                      respond: { status: 500 })
       end
 
       it 'does not update a CodeClimateProjectMetric record' do
@@ -43,8 +43,10 @@ describe CodeClimate::UpdateProjectService do
 
     context 'returns empty data' do
       before do
-        on_request_repository(project_name: project.name,
-                              respond: { status: 200, body: code_climate_repository_json })
+        on_request_repository_by_slug(
+          project_name: project.name,
+          respond: { status: 200, body: code_climate_repository_json }
+        )
       end
 
       let(:code_climate_repository_json) { build(:code_climate_repository_payload, data: []) }
@@ -59,8 +61,10 @@ describe CodeClimate::UpdateProjectService do
   context 'when the call to /repos/:id/snapshots/' do
     context 'returns anything but 200' do
       before do
-        on_request_repository(project_name: project.name,
-                              respond: { status: 200, body: code_climate_repository_json })
+        on_request_repository_by_slug(
+          project_name: project.name,
+          respond: { status: 200, body: code_climate_repository_json }
+        )
 
         on_request_snapshot(repo_id: repo_id,
                             snapshot_id: snapshot_id,
@@ -83,8 +87,10 @@ describe CodeClimate::UpdateProjectService do
   context 'when the call to /repos/:id/snapshots/issues' do
     context 'returns anything but 200' do
       before do
-        on_request_repository(project_name: project.name,
-                              respond: { status: 200, body: code_climate_repository_json })
+        on_request_repository_by_slug(
+          project_name: project.name,
+          respond: { status: 200, body: code_climate_repository_json }
+        )
 
         on_request_snapshot(repo_id: repo_id,
                             snapshot_id: snapshot_id,

--- a/spec/services/code_climate/update_project_service/information_update_spec.rb
+++ b/spec/services/code_climate/update_project_service/information_update_spec.rb
@@ -13,10 +13,10 @@ describe CodeClimate::UpdateProjectService do
                       respond: { status: 200, body: code_climate_snapshot_issues_json })
   end
 
-  let(:repo_id) { code_climate_repository_json['data'].first['id'] }
+  let(:repo_id) { repository_payload['data']['id'] }
   let(:snapshot_id) { code_climate_snapshot_json['data']['id'] }
 
-  let(:code_climate_repository_json) do
+  let(:repository_payload) do
     build :code_climate_repository_payload,
           latest_default_branch_snapshot_id: code_climate_snapshot_json['data']['id']
   end
@@ -40,6 +40,11 @@ describe CodeClimate::UpdateProjectService do
                                     respond: { status: 404 })
     end
 
+    let(:code_climate_repository_json) do
+      build :code_climate_repository_by_slug_payload,
+            repository_payload: repository_payload['data']
+    end
+
     it 'does not create a CodeClimateProjectMetric record' do
       expect { update_project_code_climate_info }.not_to change { CodeClimateProjectMetric.count }
     end
@@ -51,6 +56,11 @@ describe CodeClimate::UpdateProjectService do
         project_name: project.name,
         respond: { status: 200, body: code_climate_repository_json }
       )
+    end
+
+    let(:code_climate_repository_json) do
+      build :code_climate_repository_by_slug_payload,
+            repository_payload: repository_payload['data']
     end
 
     it 'creates a CodeClimateProjectMetric record' do
@@ -88,9 +98,14 @@ describe CodeClimate::UpdateProjectService do
       existing_code_climate_project_metric
 
       on_request_repository_by_repo_id(
-        repo_id: existing_code_climate_project_metric.cc_repository_id,
+        repo_id: repo_id,
         respond: { status: 200, body: code_climate_repository_json }
       )
+    end
+
+    let(:code_climate_repository_json) do
+      build :code_climate_repository_by_id_payload,
+            repository_payload: repository_payload['data']
     end
 
     let(:existing_code_climate_project_metric) do
@@ -100,6 +115,7 @@ describe CodeClimate::UpdateProjectService do
              invalid_issues_count: 0,
              wont_fix_issues_count: 0,
              open_issues_count: 0,
+             cc_repository_id: repo_id,
              updated_at: yesterday
     end
 
@@ -138,9 +154,14 @@ describe CodeClimate::UpdateProjectService do
       existing_code_climate_project_metric
 
       on_request_repository_by_repo_id(
-        repo_id: existing_code_climate_project_metric.cc_repository_id,
+        repo_id: repo_id,
         respond: { status: 200, body: code_climate_repository_json }
       )
+    end
+
+    let(:code_climate_repository_json) do
+      build :code_climate_repository_by_id_payload,
+            repository_payload: repository_payload['data']
     end
 
     let(:existing_code_climate_project_metric) do
@@ -149,6 +170,7 @@ describe CodeClimate::UpdateProjectService do
              code_climate_rate: 'C',
              invalid_issues_count: 0,
              wont_fix_issues_count: 0,
+             cc_repository_id: repo_id,
              updated_at: today
     end
 

--- a/spec/services/code_climate/update_project_service/information_update_spec.rb
+++ b/spec/services/code_climate/update_project_service/information_update_spec.rb
@@ -76,6 +76,11 @@ describe CodeClimate::UpdateProjectService do
       update_project_code_climate_info
       expect(CodeClimateProjectMetric.first.open_issues_count).to eq(3)
     end
+
+    it 'sets the new CodeClimate repository id for the project' do
+      update_project_code_climate_info
+      expect(CodeClimateProjectMetric.first.cc_repository_id).to eq(repo_id)
+    end
   end
 
   context 'with a project registered in CodeClimate that is outdated' do
@@ -120,6 +125,11 @@ describe CodeClimate::UpdateProjectService do
     it 'sets the new CodeClimate open_issues_count for the project' do
       update_project_code_climate_info
       expect(CodeClimateProjectMetric.first.open_issues_count).to eq(3)
+    end
+
+    it 'sets the new CodeClimate repository id for the project' do
+      update_project_code_climate_info
+      expect(CodeClimateProjectMetric.first.cc_repository_id).to eq(repo_id)
     end
   end
 

--- a/spec/support/helpers/code_climate_api_mocker.rb
+++ b/spec/support/helpers/code_climate_api_mocker.rb
@@ -1,8 +1,13 @@
 module CodeClimateApiMocker
   CODE_CLIMATE_API_URL = ENV['CODE_CLIMATE_API_URL']
 
-  def on_request_repository(project_name:, respond:)
+  def on_request_repository_by_slug(project_name:, respond:)
     stub_request(:get, "#{CODE_CLIMATE_API_URL}/repos?github_slug=rootstrap/#{project_name}")
+      .to_return(status: respond[:status], body: JSON.generate(respond[:body]))
+  end
+
+  def on_request_repository_by_repo_id(repo_id:, respond:)
+    stub_request(:get, "#{CODE_CLIMATE_API_URL}/repos/#{repo_id}")
       .to_return(status: respond[:status], body: JSON.generate(respond[:body]))
   end
 


### PR DESCRIPTION
## What does this PR do?
It adds a new way to get the project info from Code Climate.
We used to get it using the project name, but if the name changed on Github and not in Code Climate, we wouldn't be able to retrieve the info anymore.
[As the docs for Code Climate state](https://developer.codeclimate.com/#get-repository), there are two ways to get this info: using the project name or using the repository id. So, to avoid the problem described above, we will opt to use the endpoint with the repository id, which we know can't change.

To do so, we now:
- Start saving this repository id in our own database (by the name of `cc_repository_id` in `CodeClimateProjectMetric`)
- Use it (when available) to get the project info from Code Climate

**Note**: The only way to get this repository id is by hitting the Code Climate repository endpoint with the project name. So the first time we query any project info from Code Climate we will be forced to do so with that endpoint anyway.

Resolves [#151](https://rootstrap.atlassian.net/browse/EM-151)
