### PR TITLE
[EM-119] Show coverage in code climate summary

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -35,7 +35,8 @@ detectors:
   LongParameterList:
     enabled: true
     exclude: ['WordpressApiMocker#stub_single_blog_post_response',
-              'Metrics::Base#create_or_update_metric']
+              'Metrics::Base#create_or_update_metric',
+              'CodeClimate::ProjectSummary']
     max_params: 4
     overrides:
       initialize:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -32,6 +32,8 @@ Metrics/AbcSize:
   # The ABC size is a calculated magnitude, so this number can be an Integer or
   # a Float.
   Max: 15
+  Exclude:
+    - app/services/code_climate/update_project_service.rb
 
 Metrics/BlockLength:
   CountComments: false  # count full line comments?
@@ -75,6 +77,8 @@ Layout/LineLength:
 Metrics/ParameterLists:
   Max: 5
   CountKeywordArgs: true
+  Exclude:
+    - app/services/code_climate/project_summary.rb
 
 Metrics/PerceivedComplexity:
   Max: 12

--- a/app/models/code_climate_project_metric.rb
+++ b/app/models/code_climate_project_metric.rb
@@ -7,6 +7,7 @@
 #  invalid_issues_count  :integer
 #  open_issues_count     :integer
 #  snapshot_time         :datetime         not null
+#  test_coverage         :decimal(, )
 #  wont_fix_issues_count :integer
 #  created_at            :datetime         not null
 #  updated_at            :datetime         not null

--- a/app/services/code_climate/api/client.rb
+++ b/app/services/code_climate/api/client.rb
@@ -33,6 +33,11 @@ module CodeClimate
         json['data'].map { |issue_json| SnapshotIssue.new(issue_json) }
       end
 
+      def test_report(repo_id:, test_report_id:)
+        json = get_json(test_report_remote_query(repo_id: repo_id, test_report_id: test_report_id))
+        TestReport.new(json['data'])
+      end
+
       private
 
       def repository_by_id_remote_query(repository_id:)
@@ -49,6 +54,10 @@ module CodeClimate
 
       def snapshot_issues_remote_query(repo_id:, snapshot_id:)
         RemoteQuery.new("repos/#{repo_id}/snapshots/#{snapshot_id}/issues")
+      end
+
+      def test_report_remote_query(repo_id:, test_report_id:)
+        RemoteQuery.new("repos/#{repo_id}/test_reports/#{test_report_id}")
       end
 
       def get_json(remote_query)

--- a/app/services/code_climate/api/repository.rb
+++ b/app/services/code_climate/api/repository.rb
@@ -1,20 +1,43 @@
 module CodeClimate
   module Api
     class Repository < Resource
-      delegate :summary, to: :default_branch_most_recent_snapshot
+      delegate :ratings, :issues_collection, :snapshot_time,
+               to: :default_branch_most_recent_snapshot
+      delegate :coverage,
+               to: :default_branch_most_recent_test_report
 
-      def repository_id
-        @json['id']
+      def summary
+        ProjectSummary.new(
+          rate: ratings.first,
+          issues: issues_collection,
+          snapshot_time: snapshot_time,
+          test_coverage: coverage,
+          repository_id: repository_id
+        )
       end
 
       private
 
+      def repository_id
+        @repository_id ||= @json['id']
+      end
+
       def default_branch_most_recent_snapshot
-        api_client.snapshot(repo_id: repository_id, snapshot_id: snapshot_id)
+        @default_branch_most_recent_snapshot ||=
+          api_client.snapshot(repo_id: repository_id, snapshot_id: snapshot_id)
+      end
+
+      def default_branch_most_recent_test_report
+        @default_branch_most_recent_test_report ||=
+          api_client.test_report(repo_id: repository_id, test_report_id: test_report_id)
       end
 
       def snapshot_id
         @json.dig('relationships', 'latest_default_branch_snapshot', 'data', 'id')
+      end
+
+      def test_report_id
+        @json.dig('relationships', 'latest_default_branch_test_report', 'data', 'id')
       end
     end
   end

--- a/app/services/code_climate/api/repository.rb
+++ b/app/services/code_climate/api/repository.rb
@@ -4,7 +4,8 @@ module CodeClimate
       delegate :ratings, :issues_collection, :snapshot_time,
                to: :default_branch_most_recent_snapshot
       delegate :coverage,
-               to: :default_branch_most_recent_test_report
+               to: :default_branch_most_recent_test_report,
+               allow_nil: true
 
       def summary
         ProjectSummary.new(
@@ -28,6 +29,8 @@ module CodeClimate
       end
 
       def default_branch_most_recent_test_report
+        return if test_report_id.blank?
+
         @default_branch_most_recent_test_report ||=
           api_client.test_report(repo_id: repository_id, test_report_id: test_report_id)
       end

--- a/app/services/code_climate/api/snapshot.rb
+++ b/app/services/code_climate/api/snapshot.rb
@@ -1,24 +1,9 @@
 module CodeClimate
   module Api
     class Snapshot < Resource
-      attr_reader :repo_id
-
       def initialize(json, repo_id)
         super(json)
         @repo_id = repo_id
-      end
-
-      def summary
-        ProjectSummary.new(rate: ratings.first,
-                           issues: issues_collection,
-                           snapshot_time: snapshot_time,
-                           repository_id: repo_id)
-      end
-
-      private
-
-      def snapshot_id
-        @json['id']
       end
 
       def ratings
@@ -30,16 +15,24 @@ module CodeClimate
         DateTime.parse(@json.dig('attributes', 'committed_at'))
       end
 
-      def issues
-        @issues ||= api_client.snapshot_issues(repo_id: repo_id, snapshot_id: snapshot_id)
-      end
-
       def issues_collection
         {
           invalid_issues_count: invalid_issues_count,
           open_issues_count: open_issues_count,
           wont_fix_issues_count: wont_fix_issues_count
         }
+      end
+
+      private
+
+      attr_reader :repo_id
+
+      def snapshot_id
+        @json['id']
+      end
+
+      def issues
+        @issues ||= api_client.snapshot_issues(repo_id: repo_id, snapshot_id: snapshot_id)
       end
 
       def invalid_issues_count

--- a/app/services/code_climate/api/test_report.rb
+++ b/app/services/code_climate/api/test_report.rb
@@ -1,0 +1,9 @@
+module CodeClimate
+  module Api
+    class TestReport < Resource
+      def coverage
+        @json.dig('attributes', 'covered_percent')
+      end
+    end
+  end
+end

--- a/app/services/code_climate/project_summary.rb
+++ b/app/services/code_climate/project_summary.rb
@@ -1,14 +1,17 @@
 module CodeClimate
   class ProjectSummary
     attr_reader :rate, :invalid_issues_count, :open_issues_count,
-                :wont_fix_issues_count, :snapshot_time, :name, :repo_id
+                :wont_fix_issues_count, :snapshot_time, :name,
+                :repo_id, :test_coverage
 
-    def initialize(rate:, issues:, snapshot_time:, name: nil, repository_id: nil)
+    def initialize(rate:, issues:, snapshot_time:,
+                   test_coverage: nil, name: nil, repository_id: nil)
       @rate = rate
       @invalid_issues_count = issues[:invalid_issues_count]
       @open_issues_count = issues[:open_issues_count]
       @wont_fix_issues_count = issues[:wont_fix_issues_count]
       @snapshot_time = snapshot_time
+      @test_coverage = test_coverage
       @name = name
       @repo_id = repository_id
     end

--- a/app/services/code_climate/projects_details_service.rb
+++ b/app/services/code_climate/projects_details_service.rb
@@ -15,6 +15,7 @@ module CodeClimate
         ProjectSummary.new(rate: metric.code_climate_rate,
                            issues: issues_collection(metric),
                            snapshot_time: metric.snapshot_time,
+                           test_coverage: metric.test_coverage.round,
                            name: metric.project.name)
       end
     end

--- a/app/services/code_climate/projects_details_service.rb
+++ b/app/services/code_climate/projects_details_service.rb
@@ -15,7 +15,7 @@ module CodeClimate
         ProjectSummary.new(rate: metric.code_climate_rate,
                            issues: issues_collection(metric),
                            snapshot_time: metric.snapshot_time,
-                           test_coverage: metric.test_coverage.round,
+                           test_coverage: metric.test_coverage&.round,
                            name: metric.project.name)
       end
     end

--- a/app/services/code_climate/update_project_service.rb
+++ b/app/services/code_climate/update_project_service.rb
@@ -23,7 +23,8 @@ module CodeClimate
         open_issues_count: code_climate_project_summary.open_issues_count,
         wont_fix_issues_count: code_climate_project_summary.wont_fix_issues_count,
         snapshot_time: code_climate_project_summary.snapshot_time,
-        cc_repository_id: code_climate_project_summary.repo_id
+        cc_repository_id: code_climate_project_summary.repo_id,
+        test_coverage: code_climate_project_summary.test_coverage
       )
     end
 

--- a/app/views/code_climate/departments/_code_climate_department_report.erb
+++ b/app/views/code_climate/departments/_code_climate_department_report.erb
@@ -10,6 +10,7 @@
               invalid_issues_count: project_summary.invalid_issues_count,
               wont_fix_issues_count: project_summary.wont_fix_issues_count,
               open_issues_count: project_summary.open_issues_count,
+              test_coverage: project_summary.test_coverage
             } %>
         <% end -%>
       </tbody>

--- a/app/views/code_climate/departments/_code_climate_project_report.erb
+++ b/app/views/code_climate/departments/_code_climate_project_report.erb
@@ -18,4 +18,7 @@
   <td>
     <span class="code-climate-summary text-danger"><%= code_climate[:open_issues_count] %> open issues</span>
   </td>
+  <td>
+    <span class="code-climate-summary text-success"><%= code_climate[:test_coverage] %> %</span>
+  </td>
 </tr>

--- a/app/views/code_climate/departments/_code_climate_project_report.erb
+++ b/app/views/code_climate/departments/_code_climate_project_report.erb
@@ -19,6 +19,12 @@
     <span class="code-climate-summary text-danger"><%= code_climate[:open_issues_count] %> open issues</span>
   </td>
   <td>
-    <span class="code-climate-summary text-success"><%= code_climate[:test_coverage] %> %</span>
+    <span class="code-climate-summary">
+      <% if code_climate[:test_coverage].present? %>
+        <span class="text-success"><%= code_climate[:test_coverage] %> %</span>
+      <% else %>
+        <span class="text-muted">N/D</span>
+      <% end %>
+    </span>
   </td>
 </tr>

--- a/db/migrate/20200820180521_add_test_coverage_to_code_climate_project_metrics.rb
+++ b/db/migrate/20200820180521_add_test_coverage_to_code_climate_project_metrics.rb
@@ -1,0 +1,5 @@
+class AddTestCoverageToCodeClimateProjectMetrics < ActiveRecord::Migration[6.0]
+  def change
+    add_column :code_climate_project_metrics, :test_coverage, :decimal
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -299,7 +299,8 @@ CREATE TABLE public.code_climate_project_metrics (
     updated_at timestamp(6) without time zone NOT NULL,
     open_issues_count integer,
     snapshot_time timestamp without time zone NOT NULL,
-    cc_repository_id character varying
+    cc_repository_id character varying,
+    test_coverage numeric
 );
 
 
@@ -1862,5 +1863,6 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20200730142418'),
 ('20200806131024'),
 ('20200813162522'),
-('20200819142237');
+('20200819142237'),
+('20200820180521');
 

--- a/spec/factories/code_climate_project_metrics.rb
+++ b/spec/factories/code_climate_project_metrics.rb
@@ -33,5 +33,6 @@ FactoryBot.define do
     snapshot_time { Faker::Date.between(from: 1.month.ago, to: Time.zone.now) }
     updated_at { DateTime.current }
     cc_repository_id { Faker::Alphanumeric.alphanumeric(number: 24) }
+    test_coverage { Faker::Number.decimal(l_digits: 2, r_digits: 10) }
   end
 end

--- a/spec/factories/code_climate_project_metrics.rb
+++ b/spec/factories/code_climate_project_metrics.rb
@@ -7,6 +7,7 @@
 #  invalid_issues_count  :integer
 #  open_issues_count     :integer
 #  snapshot_time         :datetime         not null
+#  test_coverage         :decimal(, )
 #  wont_fix_issues_count :integer
 #  created_at            :datetime         not null
 #  updated_at            :datetime         not null

--- a/spec/factories/payloads/code_climate_repository.rb
+++ b/spec/factories/payloads/code_climate_repository.rb
@@ -8,6 +8,7 @@ FactoryBot.define do
       id { Faker::Alphanumeric.alphanumeric(number: 24) }
       name { Faker::Internet.slug(glue: '-') }
       latest_default_branch_snapshot_id { Faker::Number.number(digits: 4) }
+      latest_default_branch_test_report_id { Faker::Alphanumeric.alphanumeric(number: 24) }
       repository_payload do
         {
           'id' => id,
@@ -29,6 +30,12 @@ FactoryBot.define do
               'data' => {
                 'id' => latest_default_branch_snapshot_id,
                 'type' => 'snapshots'
+              }
+            },
+            'latest_default_branch_test_report' => {
+              'data' => {
+                'id' => latest_default_branch_test_report_id,
+                'type' => 'test_reports'
               }
             }
           }

--- a/spec/factories/payloads/code_climate_test_report.rb
+++ b/spec/factories/payloads/code_climate_test_report.rb
@@ -1,0 +1,33 @@
+FactoryBot.define do
+  factory :code_climate_test_report_payload, class: Hash do
+    skip_create
+
+    transient do
+      id { Faker::Alphanumeric.alphanumeric(number: 24) }
+      coverage { Faker::Number.decimal(l_digits: 2, r_digits: 10) }
+    end
+
+    data do
+      {
+        id: id,
+        type: 'test_reports',
+        attributes: {
+          branch: 'develop',
+          commit_sha: 'db36165a645accc5ac78d3c70dffffa4aef7d8a2',
+          committed_at: '2017-07-14T20:00:26.765Z',
+          covered_percent: coverage,
+          lines_of_code: 456,
+          rating: {
+            letter: 'A',
+            measure: {
+              value: coverage,
+              unit: 'percent'
+            }
+          }
+        }
+      }
+    end
+
+    initialize_with { attributes.deep_stringify_keys }
+  end
+end

--- a/spec/models/code_climate_project_metric_spec.rb
+++ b/spec/models/code_climate_project_metric_spec.rb
@@ -7,6 +7,7 @@
 #  invalid_issues_count  :integer
 #  open_issues_count     :integer
 #  snapshot_time         :datetime         not null
+#  test_coverage         :decimal(, )
 #  wont_fix_issues_count :integer
 #  created_at            :datetime         not null
 #  updated_at            :datetime         not null

--- a/spec/requests/code_climate/departments_spec.rb
+++ b/spec/requests/code_climate/departments_spec.rb
@@ -50,5 +50,13 @@ describe 'CodeClimate department projects report page ', type: :request do
     it 'shows the first project test coverage' do
       expect(response.body).to include(test_coverage.round.to_s)
     end
+
+    context 'when the project does not have test coverage' do
+      let(:test_coverage) { nil }
+
+      it 'shows N/D instead' do
+        expect(response.body).to include('N/D')
+      end
+    end
   end
 end

--- a/spec/requests/code_climate/departments_spec.rb
+++ b/spec/requests/code_climate/departments_spec.rb
@@ -1,10 +1,11 @@
 require 'rails_helper'
 
-describe 'CodeClimate deparment projects report page ', type: :request do
+describe 'CodeClimate department projects report page ', type: :request do
   describe '#index' do
     let(:ruby_lang) { Language.find_by(name: 'ruby') }
     let(:department) { project.language.department }
     let(:project) { create :project, language: ruby_lang }
+    let(:test_coverage) { 97.832 }
 
     before do
       create :code_climate_project_metric,
@@ -13,6 +14,7 @@ describe 'CodeClimate deparment projects report page ', type: :request do
              wont_fix_issues_count: 2,
              open_issues_count: 3,
              code_climate_rate: 'A',
+             test_coverage: test_coverage,
              snapshot_time: Time.zone.now.ago(1.week)
 
       get "/development_metrics/code_climate/departments/#{department.name}",
@@ -43,6 +45,10 @@ describe 'CodeClimate deparment projects report page ', type: :request do
 
     it 'shows the first project invalid issues count' do
       expect(response.body).to include('3 open issues')
+    end
+
+    it 'shows the first project test coverage' do
+      expect(response.body).to include(test_coverage.round.to_s)
     end
   end
 end

--- a/spec/services/code_climate/api/client_spec.rb
+++ b/spec/services/code_climate/api/client_spec.rb
@@ -21,7 +21,7 @@ describe CodeClimate::Api::Client do
         end
 
         it 'returns a Repository with the data' do
-          expect(subject.repository_by_slug(github_slug: github_slug).repository_id)
+          expect(subject.repository_by_slug(github_slug: github_slug).send(:repository_id))
             .to eq(code_climate_repository_json['data'].first['id'])
         end
       end
@@ -68,7 +68,7 @@ describe CodeClimate::Api::Client do
       end
 
       it 'returns a Repository with the data' do
-        expect(subject.repository_by_repo_id(repo_id: repo_id).repository_id)
+        expect(subject.repository_by_repo_id(repo_id: repo_id).send(:repository_id))
           .to eq(repo_id)
       end
     end

--- a/spec/services/code_climate/api/client_spec.rb
+++ b/spec/services/code_climate/api/client_spec.rb
@@ -179,4 +179,51 @@ describe CodeClimate::Api::Client do
       end
     end
   end
+
+  describe '#test_report' do
+    let(:project) { create(:project) }
+    let(:code_climate_repository_json) do
+      create(:code_climate_repository_by_slug_payload, name: project.name)
+    end
+    let(:repo_json) { code_climate_repository_json['data'].first }
+    let(:repo_id) { repo_json['id'] }
+    let(:test_report_id) do
+      repo_json['relationships']['latest_default_branch_test_report']['data']['id']
+    end
+
+    context 'when the request succeeds' do
+      let(:coverage) { 99.0 }
+      let(:code_climate_test_report_json) do
+        create(:code_climate_test_report_payload, id: test_report_id, coverage: coverage)
+      end
+
+      before do
+        on_request_test_report(
+          repo_id: repo_id,
+          test_report_id: test_report_id,
+          respond: { status: 200, body: code_climate_test_report_json }
+        )
+      end
+
+      it 'returns a test_report with the data' do
+        expect(subject.test_report(repo_id: repo_id, test_report_id: test_report_id).coverage)
+          .to eq(coverage)
+      end
+    end
+
+    context 'when the request fails' do
+      before do
+        on_request_test_report(
+          repo_id: repo_id,
+          test_report_id: test_report_id,
+          respond: { status: 404 }
+        )
+      end
+
+      it 'raises a Faraday error' do
+        expect { subject.test_report(repo_id: repo_id, test_report_id: test_report_id) }
+          .to raise_error Faraday::Error
+      end
+    end
+  end
 end

--- a/spec/services/code_climate/api/test_report_spec.rb
+++ b/spec/services/code_climate/api/test_report_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe CodeClimate::Api::TestReport do
+  describe '#coverage' do
+    let(:coverage) { 99.0 }
+    let(:code_climate_test_report_payload) do
+      create(:code_climate_test_report_payload, coverage: coverage)
+    end
+
+    subject(:test_report) do
+      CodeClimate::Api::TestReport.new(code_climate_test_report_payload['data'])
+    end
+
+    it 'returns the test coverage percentage of the report' do
+      expect(test_report.coverage).to eq coverage
+    end
+  end
+end

--- a/spec/services/code_climate/update_project_service/api_call_failures_spec.rb
+++ b/spec/services/code_climate/update_project_service/api_call_failures_spec.rb
@@ -5,10 +5,12 @@ describe CodeClimate::UpdateProjectService do
 
   let(:repo_id) { code_climate_repository_json['data'].first['id'] }
   let(:snapshot_id) { code_climate_snapshot_json['data']['id'] }
+  let(:test_report_id) { code_climate_test_report_json['data']['id'] }
 
   let(:code_climate_repository_json) do
     build :code_climate_repository_by_slug_payload,
-          latest_default_branch_snapshot_id: code_climate_snapshot_json['data']['id']
+          latest_default_branch_snapshot_id: snapshot_id,
+          latest_default_branch_test_report_id: test_report_id
   end
   let(:code_climate_snapshot_json) do
     build :code_climate_snapshot_payload,
@@ -17,6 +19,9 @@ describe CodeClimate::UpdateProjectService do
   let(:code_climate_snapshot_issues_json) do
     build :code_climate_snapshot_issues_payload,
           status: %w[invalid wontfix invalid]
+  end
+  let(:code_climate_test_report_json) do
+    build :code_climate_test_report_payload
   end
 
   let(:project) { create :project, name: 'rs-code-review-metrics' }
@@ -101,6 +106,40 @@ describe CodeClimate::UpdateProjectService do
         on_request_issues(repo_id: repo_id,
                           snapshot_id: snapshot_id,
                           respond: { status: 500 })
+      end
+
+      it 'does not update a CodeClimateProjectMetric record' do
+        expect { update_project_code_climate_info }
+          .not_to change { CodeClimateProjectMetric.count }
+      end
+
+      it 'notifies the error to exception hunter' do
+        expect(ExceptionHunter).to receive(:track).with(kind_of(Faraday::Error))
+
+        update_project_code_climate_info
+      end
+    end
+  end
+
+  context 'when the call to /repos/:id/test_report/' do
+    context 'returns anything but 200' do
+      before do
+        on_request_repository_by_slug(
+          project_name: project.name,
+          respond: { status: 200, body: code_climate_repository_json }
+        )
+
+        on_request_snapshot(repo_id: repo_id,
+                            snapshot_id: snapshot_id,
+                            respond: { status: 200, body: code_climate_snapshot_json })
+
+        on_request_issues(repo_id: repo_id,
+                          snapshot_id: snapshot_id,
+                          respond: { status: 200, body: code_climate_snapshot_issues_json })
+
+        on_request_test_report(repo_id: repo_id,
+                               test_report_id: test_report_id,
+                               respond: { status: 500 })
       end
 
       it 'does not update a CodeClimateProjectMetric record' do

--- a/spec/services/code_climate/update_project_service/information_update_spec.rb
+++ b/spec/services/code_climate/update_project_service/information_update_spec.rb
@@ -11,14 +11,20 @@ describe CodeClimate::UpdateProjectService do
     on_request_issues(repo_id: repo_id,
                       snapshot_id: snapshot_id,
                       respond: { status: 200, body: code_climate_snapshot_issues_json })
+
+    on_request_test_report(repo_id: repo_id,
+                           test_report_id: test_report_id,
+                           respond: { status: 200, body: code_climate_test_report_json })
   end
 
   let(:repo_id) { repository_payload['data']['id'] }
   let(:snapshot_id) { code_climate_snapshot_json['data']['id'] }
+  let(:test_report_id) { code_climate_test_report_json['data']['id'] }
 
   let(:repository_payload) do
     build :code_climate_repository_payload,
-          latest_default_branch_snapshot_id: code_climate_snapshot_json['data']['id']
+          latest_default_branch_snapshot_id: snapshot_id,
+          latest_default_branch_test_report_id: test_report_id
   end
   let(:code_climate_snapshot_json) do
     build :code_climate_snapshot_payload,
@@ -28,11 +34,16 @@ describe CodeClimate::UpdateProjectService do
     build :code_climate_snapshot_issues_payload,
           status: %w[invalid wontfix invalid new open confirmed]
   end
+  let(:code_climate_test_report_json) do
+    build :code_climate_test_report_payload,
+          coverage: coverage
+  end
 
   let(:project) { create :project, name: 'rs-code-review-metrics' }
   let(:update_project_code_climate_info) { subject.call(project) }
   let(:yesterday) { Time.zone.yesterday.beginning_of_day }
   let(:today) { Time.zone.today.beginning_of_day }
+  let(:coverage) { 99.0 }
 
   context 'with a project not registered in CodeClimate' do
     before do
@@ -91,6 +102,11 @@ describe CodeClimate::UpdateProjectService do
       update_project_code_climate_info
       expect(CodeClimateProjectMetric.first.cc_repository_id).to eq(repo_id)
     end
+
+    it 'sets the new CodeClimate test coverage for the project' do
+      update_project_code_climate_info
+      expect(CodeClimateProjectMetric.first.test_coverage).to eq(coverage)
+    end
   end
 
   context 'with a project registered in CodeClimate that is outdated' do
@@ -146,6 +162,11 @@ describe CodeClimate::UpdateProjectService do
     it 'sets the new CodeClimate repository id for the project' do
       update_project_code_climate_info
       expect(CodeClimateProjectMetric.first.cc_repository_id).to eq(repo_id)
+    end
+
+    it 'sets the new CodeClimate test coverage for the project' do
+      update_project_code_climate_info
+      expect(CodeClimateProjectMetric.first.test_coverage).to eq(coverage)
     end
   end
 

--- a/spec/services/code_climate/update_project_service/information_update_spec.rb
+++ b/spec/services/code_climate/update_project_service/information_update_spec.rb
@@ -209,4 +209,28 @@ describe CodeClimate::UpdateProjectService do
       expect(CodeClimateProjectMetric.first.updated_at).to eq(today)
     end
   end
+
+  context 'with a project registered in CodeClimate that has no test reports' do
+    let(:repository_payload) do
+      build :code_climate_repository_payload,
+            latest_default_branch_snapshot_id: snapshot_id,
+            latest_default_branch_test_report_id: nil
+    end
+    let(:code_climate_repository_json) do
+      build :code_climate_repository_by_slug_payload,
+            repository_payload: repository_payload['data']
+    end
+
+    before do
+      on_request_repository_by_slug(
+        project_name: project.name,
+        respond: { status: 200, body: code_climate_repository_json }
+      )
+    end
+
+    it 'does not set test coverage for the project metric' do
+      update_project_code_climate_info
+      expect(CodeClimateProjectMetric.first.test_coverage).to be_nil
+    end
+  end
 end

--- a/spec/support/helpers/code_climate_api_mocker.rb
+++ b/spec/support/helpers/code_climate_api_mocker.rb
@@ -20,4 +20,9 @@ module CodeClimateApiMocker
     stub_request(:get, "#{CODE_CLIMATE_API_URL}/repos/#{repo_id}/snapshots/#{snapshot_id}/issues")
       .to_return(status: respond[:status], body: JSON.generate(respond[:body]))
   end
+
+  def on_request_test_report(repo_id:, test_report_id:, respond:)
+    stub_request(:get, "#{CODE_CLIMATE_API_URL}/repos/#{repo_id}/test_reports/#{test_report_id}")
+      .to_return(status: respond[:status], body: JSON.generate(respond[:body]))
+  end
 end


### PR DESCRIPTION
## What does this PR do?
It shows the test coverage of projects in the Code Climate project summary by department.
When the project does not have any test coverage info, `N/D` will be shown instead.

![image](https://user-images.githubusercontent.com/7276679/91073938-361ea800-e612-11ea-8c9e-ac200911dbea.png)

Resolves [#119](https://rootstrap.atlassian.net/browse/EM-119)
