### PR TITLE
Use the CODE_CLIMATE_API_ORG_NAME env var

### DIFF
--- a/app/services/code_climate/get_project_summary.rb
+++ b/app/services/code_climate/get_project_summary.rb
@@ -1,6 +1,6 @@
 module CodeClimate
   class GetProjectSummary < BaseService
-    CODE_CLIMATE_API_ORG_NAME = 'rootstrap'.freeze
+    CODE_CLIMATE_API_ORG_NAME = ENV['CODE_CLIMATE_API_ORG_NAME']
 
     def initialize(project:)
       @project = project

--- a/spec/support/helpers/code_climate_api_mocker.rb
+++ b/spec/support/helpers/code_climate_api_mocker.rb
@@ -2,7 +2,11 @@ module CodeClimateApiMocker
   CODE_CLIMATE_API_URL = ENV['CODE_CLIMATE_API_URL']
 
   def on_request_repository_by_slug(project_name:, respond:)
-    stub_request(:get, "#{CODE_CLIMATE_API_URL}/repos?github_slug=rootstrap/#{project_name}")
+    stub_env('CODE_CLIMATE_API_ORG_NAME', 'rootstrap')
+    code_climate_org_name = CodeClimate::GetProjectSummary::CODE_CLIMATE_API_ORG_NAME
+    url = "#{CODE_CLIMATE_API_URL}/repos?github_slug=#{code_climate_org_name}/#{project_name}"
+
+    stub_request(:get, url)
       .to_return(status: respond[:status], body: JSON.generate(respond[:body]))
   end
 


### PR DESCRIPTION
## What does this PR do?
It removes the hardcoded code climate organization name from the code and uses the already set env var instead