### PR TITLE
[EM-143] Show overview info for department projects

### DIFF
--- a/app/assets/stylesheets/metrics/_code-climate-deparments.scss
+++ b/app/assets/stylesheets/metrics/_code-climate-deparments.scss
@@ -27,26 +27,3 @@ table.code-climate-projects-report {
     color: black;
   }
 }
-
-.code-climate-summary {
-  .container {
-    background-color: gainsboro;
-  }
-
-  .title {
-    padding: 0.5em 4em;
-  }
-
-  .info {
-    display: flex;
-    flex-direction: row;
-    justify-content: space-between;
-    padding: 0 4em;
-  }
-
-  .item-list {
-    display: flex;
-    flex-direction: column;
-    align-items: flex-start;
-  }
-}

--- a/app/assets/stylesheets/metrics/_deparments-summary.scss
+++ b/app/assets/stylesheets/metrics/_deparments-summary.scss
@@ -1,0 +1,34 @@
+.departments-summary {
+  .container {
+    background-color: gainsboro;
+    margin-bottom: 1em;
+  }
+
+  .title {
+    padding: 0.5em 4em;
+  }
+
+  .info {
+    display: flex;
+    flex-direction: row;
+    padding: 0 4em;
+  }
+
+  .item-list {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .overview {
+    .info {
+      justify-content: space-evenly;
+    }
+  }
+
+  .code-climate {
+    .info {
+      justify-content: space-between;
+    }
+  }
+}

--- a/app/controllers/development_metrics_controller.rb
+++ b/app/controllers/development_metrics_controller.rb
@@ -16,6 +16,7 @@ class DevelopmentMetricsController < ApplicationController
 
     build_metrics(department.id, Department.name)
     @code_climate = code_climate_department_summary
+    @overview = department_overview
   end
 
   def users; end
@@ -51,5 +52,9 @@ class DevelopmentMetricsController < ApplicationController
       from: metric_params[:period],
       technologies: []
     )
+  end
+
+  def department_overview
+    Builders::DepartmentOverview.call(department)
   end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -62,6 +62,10 @@ class Project < ApplicationRecord
     where(relevance: relevances[:internal])
   }
 
+  scope :relevant, lambda {
+    where(relevance: [relevances[:commercial], relevances[:internal]])
+  }
+
   private
 
   def set_default_language

--- a/app/services/builders/department_overview.rb
+++ b/app/services/builders/department_overview.rb
@@ -7,11 +7,9 @@ module Builders
     end
 
     def call
-      department_overview = language_names.each_with_object({}) do |language, overview|
+      language_names.each_with_object({}) { |language, overview|
         overview[language] = language_overview(language)
-      end
-
-      department_overview.with_indifferent_access
+      }.with_indifferent_access
     end
 
     private
@@ -37,8 +35,8 @@ module Builders
     end
 
     def relevances_overview(language)
-      project_relevances.each_with_object({}) do |relevance, overview|
-        overview[relevance] = projects_by_language_and_relevance[[language, relevance]] || 0
+      project_relevances.index_with do |relevance|
+        projects_by_language_and_relevance[[language, relevance]] || 0
       end
     end
 

--- a/app/services/builders/department_overview.rb
+++ b/app/services/builders/department_overview.rb
@@ -1,0 +1,57 @@
+module Builders
+  class DepartmentOverview < BaseService
+    include ModelsNamesHelper
+
+    def initialize(department)
+      @department = department
+    end
+
+    def call
+      department_overview = language_names.each_with_object({}) do |language, overview|
+        overview[language] = language_overview(language)
+      end
+
+      department_overview.with_indifferent_access
+    end
+
+    private
+
+    attr_reader :department
+
+    def projects_by_language_and_relevance
+      @projects_by_language_and_relevance ||=
+        department
+        .languages
+        .joins(:projects)
+        .merge(::Project.relevant)
+        .group('languages.name', 'projects.relevance')
+        .count
+    end
+
+    def language_overview(language)
+      relevances_overview = relevances_overview(language)
+      {
+        per_relevance: relevances_overview,
+        totals: relevances_overview.values.sum
+      }
+    end
+
+    def relevances_overview(language)
+      project_relevances.each_with_object({}) do |relevance, overview|
+        overview[relevance] = projects_by_language_and_relevance[[language, relevance]] || 0
+      end
+    end
+
+    def language_names
+      all_languages_names(department)
+    end
+
+    def project_relevances
+      relevances = ::Project.relevances
+      [
+        relevances[:internal],
+        relevances[:commercial]
+      ]
+    end
+  end
+end

--- a/app/views/development_metrics/_department_overview.erb
+++ b/app/views/development_metrics/_department_overview.erb
@@ -1,0 +1,21 @@
+<div class="departments-summary col-md-12">
+  <div class="overview">
+    <div class="container p-3">
+      <div class="title">
+        <b>Overview</b>
+      </div>
+      <div class="info">
+        <% overview.each do |language, language_overview| %>
+          <div class="item-list">
+            <span>
+              <%= language_overview[:totals] %> <b><%= language.titleize %></b> <%= 'project'.pluralize(language_overview[:totals]) %>, of which:
+            </span>
+            <% language_overview[:per_relevance].each do |relevance, project_count| %>
+              <li><b><%= project_count %></b> <%= relevance %></li>
+            <% end %>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/development_metrics/code_climate/_code_climate_department_summary.erb
+++ b/app/views/development_metrics/code_climate/_code_climate_department_summary.erb
@@ -1,36 +1,38 @@
-<div class="code-climate-summary col-md-12">
-  <div class="container p-3">
-    <div class="title">
-      <b>CodeClimate summary</b>
+<div class="departments-summary col-md-12">
+  <div class="code-climate">
+    <div class="container p-3">
+      <div class="title">
+        <b>CodeClimate summary</b>
+      </div>
+      <% if !code_climate || code_climate.empty? -%>
+        <div class="row">
+          <div class="col-md-12 text-center mt-2">
+            <span class="text-danger">No information available</span>
+          </div>
+        </div>
+      <% else -%>
+        <div class="info">
+          <div class="item-list">
+            <% code_climate.each_project_rate do |letter, projects_count| -%>
+              <div>
+                <%= projects_count %> <%= 'project'.pluralize(projects_count) %> with
+                <span class="text-primary"><b><%= letter %></b></span>
+              </div>
+            <% end -%>
+          </div>
+          <div class="item-list">
+            <span>Average of <b><%= code_climate.invalid_issues_count_average %> invalid</b> issues</span>
+            <span>Average of <b><%= code_climate.wont_fix_issues_count_average %> won't fix</b> issues</span>
+            <span>Average of <b><%= code_climate.open_issues_count_average %> open</b> issues</span>
+          </div>
+          <div>
+            <%= link_to 'See report',
+                        code_climate_department_path(department.name, filter_url_query),
+                        class: 'btn btn-secondary'
+            %>
+          </div>
+        </div>
+      <% end -%>
     </div>
-    <% if !code_climate || code_climate.empty? -%>
-      <div class="row">
-        <div class="col-md-12 text-center mt-2">
-          <span class="text-danger">No information available</span>
-        </div>
-      </div>
-    <% else -%>
-      <div class="info">
-        <div class="item-list">
-          <% code_climate.each_project_rate do |letter, projects_count| -%>
-            <div>
-              <%= projects_count %> <%= 'project'.pluralize(projects_count) %> with
-              <span class="text-primary"><b><%= letter %></b></span>
-            </div>
-          <% end -%>
-        </div>
-        <div class="item-list">
-          <span>Average of <b><%= code_climate.invalid_issues_count_average %> invalid</b> issues</span>
-          <span>Average of <b><%= code_climate.wont_fix_issues_count_average %> won't fix</b> issues</span>
-          <span>Average of <b><%= code_climate.open_issues_count_average %> open</b> issues</span>
-        </div>
-        <div>
-          <%= link_to 'See report',
-                      code_climate_department_path(department.name, filter_url_query),
-                      class: 'btn btn-secondary'
-          %>
-        </div>
-      </div>
-    <% end -%>
   </div>
 </div>

--- a/app/views/development_metrics/departments.erb
+++ b/app/views/development_metrics/departments.erb
@@ -14,6 +14,11 @@
             <% end %>
           </div>
         </div>
+        <% if @overview %>
+          <div class="row">
+            <%= render 'development_metrics/department_overview', overview: @overview %>
+          </div>
+        <% end %>
         <div class="row">
           <%= render 'development_metrics/code_climate/code_climate_department_summary',
           department: @department, code_climate: @code_climate %>

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -95,4 +95,15 @@ RSpec.describe Project, type: :model do
       expect(Project.internal).to contain_exactly(internal_project)
     end
   end
+
+  describe 'relevant' do
+    let!(:commercial_project) { create(:project, relevance: Project.relevances[:commercial]) }
+    let!(:internal_project) { create(:project, relevance: Project.relevances[:internal]) }
+    let!(:ignored_project) { create(:project, relevance: Project.relevances[:ignored]) }
+    let!(:unassigned_project) { create(:project, relevance: Project.relevances[:unassigned]) }
+
+    it 'returns both commecial and internal projects' do
+      expect(Project.relevant).to contain_exactly(commercial_project, internal_project)
+    end
+  end
 end

--- a/spec/requests/development_metrics_spec.rb
+++ b/spec/requests/development_metrics_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+RSpec.describe 'Development Metrics', type: :request do
+  describe '#departments' do
+    describe 'overview' do
+      let(:internal) { Project.relevances[:internal] }
+      let(:commercial) { Project.relevances[:commercial] }
+
+      let(:ruby) { Language.find_or_create_by(name: 'ruby') }
+      let!(:ruby_internal_project_1) { create(:project, language: ruby, relevance: internal) }
+      let!(:ruby_internal_project_2) { create(:project, language: ruby, relevance: internal) }
+      let!(:ruby_commercial_project) { create(:project, language: ruby, relevance: commercial) }
+
+      let(:department) { ruby.department.name }
+
+      describe 'language count' do
+        it 'renders the total project count for the language' do
+          get departments_development_metrics_url,
+              params: { department_name: department, metric: { period: 4 } }
+
+          expect(response.body)
+            .to include("3 <b>#{ruby.name.titleize}</b> projects")
+        end
+      end
+
+      describe 'relevance count' do
+        it 'renders the each relevance project count' do
+          get departments_development_metrics_url,
+              params: { department_name: department, metric: { period: 4 } }
+
+          expect(response.body)
+            .to include("<b>1</b> #{commercial}", "<b>2</b> #{internal}")
+        end
+      end
+    end
+  end
+end

--- a/spec/services/builders/department_overview_spec.rb
+++ b/spec/services/builders/department_overview_spec.rb
@@ -1,0 +1,54 @@
+require 'rails_helper'
+
+RSpec.describe Builders::DepartmentOverview do
+  describe '.call' do
+    let(:internal) { Project.relevances[:internal] }
+    let(:commercial) { Project.relevances[:commercial] }
+    let(:ignored) { Project.relevances[:ignored] }
+    let(:unassigned) { Project.relevances[:unassigned] }
+
+    let(:ruby) { Language.find_or_create_by(name: 'ruby') }
+    let!(:ruby_internal_project) { create(:project, language: ruby, relevance: internal) }
+    let!(:ruby_commercial_project) { create(:project, language: ruby, relevance: commercial) }
+    let!(:ruby_unassigned_project) { create(:project, language: ruby, relevance: unassigned) }
+
+    let(:python) { Language.find_or_create_by(name: 'python') }
+    let!(:python_internal_project_1) { create(:project, language: python, relevance: internal) }
+    let!(:python_internal_project_2) { create(:project, language: python, relevance: internal) }
+    let!(:python_ignored_project) { create(:project, language: python, relevance: ignored) }
+
+    let!(:nodejs) { Language.find_or_create_by(name: 'nodejs') }
+
+    let(:department) { ruby.department }
+
+    describe 'count by relevance' do
+      it 'returns the amount of projects by language and relevance' do
+        overview = described_class.call(department)
+
+        expect(overview[:ruby][:per_relevance][:internal]).to eq 1
+        expect(overview[:ruby][:per_relevance][:commercial]).to eq 1
+        expect(overview[:python][:per_relevance][:internal]).to eq 2
+        expect(overview[:python][:per_relevance][:commercial]).to eq 0
+        expect(overview[:nodejs][:per_relevance][:internal]).to eq 0
+        expect(overview[:nodejs][:per_relevance][:commercial]).to eq 0
+      end
+
+      it 'does not count any ignored or unassigned project' do
+        overview = described_class.call(department)
+
+        expect(overview[:ruby][:per_relevance][:unassigned]).not_to be_present
+        expect(overview[:python][:per_relevance][:ignored]).not_to be_present
+      end
+    end
+
+    describe 'total count' do
+      it 'returns the totals for each language' do
+        overview = described_class.call(department)
+
+        expect(overview[:ruby][:totals]).to eq 2
+        expect(overview[:python][:totals]).to eq 2
+        expect(overview[:nodejs][:totals]).to eq 0
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What does this PR do?
It adds an overview to the department metrics page showing the amount of projects per language and relevance within that department.

![image (2)](https://user-images.githubusercontent.com/7276679/91314605-1f509080-e78d-11ea-9646-a9709ca74ce9.png)

Resolves [#143](https://rootstrap.atlassian.net/browse/EM-143)
