### PR TITLE
[EM-156] Show department overview projects in given timeframe

### DIFF
--- a/app/controllers/development_metrics_controller.rb
+++ b/app/controllers/development_metrics_controller.rb
@@ -55,6 +55,6 @@ class DevelopmentMetricsController < ApplicationController
   end
 
   def department_overview
-    Builders::DepartmentOverview.call(department)
+    Builders::DepartmentOverview.call(department, from: metric_params[:period].to_i.weeks.ago)
   end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -68,6 +68,18 @@ class Project < ApplicationRecord
     where(relevance: [relevances[:commercial], relevances[:internal]])
   }
 
+  scope :with_activity_after, lambda { |date|
+    with_a_pr_merged_after(date).or(with_a_pr_opened_after(date))
+  }
+
+  scope :with_a_pr_opened_after, lambda { |date|
+    joins(:pull_requests).where('pull_requests.opened_at > ?', date)
+  }
+
+  scope :with_a_pr_merged_after, lambda { |date|
+    joins(:pull_requests).where('pull_requests.merged_at > ?', date)
+  }
+
   private
 
   def set_default_language

--- a/app/services/builders/department_overview.rb
+++ b/app/services/builders/department_overview.rb
@@ -2,8 +2,9 @@ module Builders
   class DepartmentOverview < BaseService
     include ModelsNamesHelper
 
-    def initialize(department)
+    def initialize(department, from:)
       @department = department
+      @from = from
     end
 
     def call
@@ -14,14 +15,14 @@ module Builders
 
     private
 
-    attr_reader :department
+    attr_reader :department, :from
 
     def projects_by_language_and_relevance
       @projects_by_language_and_relevance ||=
         department
         .languages
         .joins(:projects)
-        .merge(::Project.relevant)
+        .merge(::Project.relevant.with_activity_after(from))
         .group('languages.name', 'projects.relevance')
         .count
     end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Project, type: :model do
     it { is_expected.to have_many(:events) }
   end
 
-  describe 'open_source' do
+  describe '#open_source' do
     let(:language) { Language.find_by(name: 'ruby') }
     let!(:private_project) do
       create(
@@ -76,7 +76,7 @@ RSpec.describe Project, type: :model do
     end
   end
 
-  describe 'with_language' do
+  describe '#with_language' do
     let(:language) { Language.find_by(name: 'ruby') }
     let!(:project_with_language) { create(:project, language: language) }
     let!(:project_without_language) { create(:project, language: Language.unassigned) }
@@ -86,7 +86,7 @@ RSpec.describe Project, type: :model do
     end
   end
 
-  describe 'internal' do
+  describe '#internal' do
     let!(:commercial_project) { create(:project, relevance: Project.relevances[:commercial]) }
     let!(:internal_project) { create(:project, relevance: Project.relevances[:internal]) }
     let!(:unassigned_project) { create(:project, relevance: Project.relevances[:unassigned]) }
@@ -96,7 +96,7 @@ RSpec.describe Project, type: :model do
     end
   end
 
-  describe 'relevant' do
+  describe '#relevant' do
     let!(:commercial_project) { create(:project, relevance: Project.relevances[:commercial]) }
     let!(:internal_project) { create(:project, relevance: Project.relevances[:internal]) }
     let!(:ignored_project) { create(:project, relevance: Project.relevances[:ignored]) }
@@ -104,6 +104,37 @@ RSpec.describe Project, type: :model do
 
     it 'returns both commecial and internal projects' do
       expect(Project.relevant).to contain_exactly(commercial_project, internal_project)
+    end
+  end
+
+  describe '#with_activity_after' do
+    let(:date) { 4.weeks.ago }
+    let!(:updated_project) { create(:project) }
+    let!(:not_updated_project) { create(:project) }
+
+    context 'when a project has a pull request opened after the given date' do
+      let!(:pull_request) do
+        create(:pull_request, project: updated_project, opened_at: 2.weeks.ago)
+      end
+
+      it 'returns only that project' do
+        expect(Project.with_activity_after(date)).to contain_exactly(updated_project)
+      end
+    end
+
+    context 'when a project has a pull request merged after the given date' do
+      let!(:pull_request) do
+        create(
+          :pull_request,
+          project: updated_project,
+          opened_at: 6.weeks.ago,
+          merged_at: 2.weeks.ago
+        )
+      end
+
+      it 'returns only that project' do
+        expect(Project.with_activity_after(date)).to contain_exactly(updated_project)
+      end
     end
   end
 end

--- a/spec/requests/development_metrics_spec.rb
+++ b/spec/requests/development_metrics_spec.rb
@@ -12,11 +12,19 @@ RSpec.describe 'Development Metrics', type: :request do
       let!(:ruby_commercial_project) { create(:project, language: ruby, relevance: commercial) }
 
       let(:department) { ruby.department.name }
+      let(:number_of_weeks) { 4 }
+
+      before do
+        opened_date = number_of_weeks.weeks.ago.tomorrow
+        create(:pull_request, project: ruby_internal_project_1, opened_at: opened_date)
+        create(:pull_request, project: ruby_internal_project_2, opened_at: opened_date)
+        create(:pull_request, project: ruby_commercial_project, opened_at: opened_date)
+      end
 
       describe 'language count' do
         it 'renders the total project count for the language' do
           get departments_development_metrics_url,
-              params: { department_name: department, metric: { period: 4 } }
+              params: { department_name: department, metric: { period: number_of_weeks } }
 
           expect(response.body)
             .to include("3 <b>#{ruby.name.titleize}</b> projects")
@@ -26,7 +34,7 @@ RSpec.describe 'Development Metrics', type: :request do
       describe 'relevance count' do
         it 'renders the each relevance project count' do
           get departments_development_metrics_url,
-              params: { department_name: department, metric: { period: 4 } }
+              params: { department_name: department, metric: { period: number_of_weeks } }
 
           expect(response.body)
             .to include("<b>1</b> #{commercial}", "<b>2</b> #{internal}")


### PR DESCRIPTION
## What does this PR do?
It makes the department overview only count the projects which have had activity in the requested timeframe.
We consider a project has activity when it has a PR being opened or merged.

![Screen-Recording-2020-08-27-at-2](https://user-images.githubusercontent.com/7276679/91475447-fb1aaf80-e871-11ea-82d2-f29c4abdf8ec.gif)

Resolves [#156](https://rootstrap.atlassian.net/browse/EM-156)
