### PR TITLE
[EM-146.1] Add PR Size metric

### DIFF
--- a/app/models/events/pull_request.rb
+++ b/app/models/events/pull_request.rb
@@ -46,6 +46,7 @@ module Events
                        inverse_of: :pull_request
     has_many :events, as: :handleable, dependent: :destroy
     has_one :merge_time, dependent: :destroy
+    has_one :pull_request_size, dependent: :destroy
 
     validates :state, inclusion: { in: states.keys }
     validates :github_id,

--- a/app/models/pull_request_size.rb
+++ b/app/models/pull_request_size.rb
@@ -1,0 +1,25 @@
+# == Schema Information
+#
+# Table name: pull_request_sizes
+#
+#  id              :bigint           not null, primary key
+#  value           :integer
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  pull_request_id :bigint           not null
+#
+# Indexes
+#
+#  index_pull_request_sizes_on_pull_request_id  (pull_request_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (pull_request_id => pull_requests.id)
+#
+
+class PullRequestSize < ApplicationRecord
+  belongs_to :pull_request, class_name: 'Events::PullRequest'
+
+  validates :value, presence: true
+  validates :pull_request_id, uniqueness: true
+end

--- a/app/models/pull_request_size.rb
+++ b/app/models/pull_request_size.rb
@@ -3,7 +3,7 @@
 # Table name: pull_request_sizes
 #
 #  id              :bigint           not null, primary key
-#  value           :integer
+#  value           :integer          not null
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
 #  pull_request_id :bigint           not null

--- a/app/services/builders/events/pull_request.rb
+++ b/app/services/builders/events/pull_request.rb
@@ -9,11 +9,11 @@ module Builders
         pull_request_data = @payload['pull_request']
         ::Events::PullRequest
           .find_or_create_by!(github_id: pull_request_data['id']) do |pull_request|
-          assign_attrs(pull_request, pull_request_data)
-
           ATTR_PAYLOAD_MAP.each do |key, value|
             pull_request.public_send("#{key}=", pull_request_data.fetch(value))
           end
+
+          assign_attrs(pull_request, pull_request_data)
         end
       end
 
@@ -21,6 +21,7 @@ module Builders
         pull_request.owner = find_or_create_user(pull_request_data['user'])
         pull_request.project = Builders::Project.call(@payload['repository'])
         find_or_create_user_project(pull_request.project.id, pull_request.owner.id)
+        pull_request.pull_request_size = Builders::PullRequestSize.call(pull_request)
       end
     end
   end

--- a/app/services/builders/pull_request_size.rb
+++ b/app/services/builders/pull_request_size.rb
@@ -1,0 +1,22 @@
+module Builders
+  class PullRequestSize < BaseService
+    def initialize(pull_request)
+      @pull_request = pull_request
+    end
+
+    def call
+      ::PullRequestSize.find_or_initialize_by(pull_request: pull_request).tap do |pr_size|
+        pr_size.value = calculate_size
+        pr_size.save!
+      end
+    end
+
+    private
+
+    attr_reader :pull_request
+
+    def calculate_size
+      PullRequestSizeCalculator.call(pull_request)
+    end
+  end
+end

--- a/app/services/github_client/base.rb
+++ b/app/services/github_client/base.rb
@@ -1,11 +1,29 @@
 module GithubClient
   class Base
+    private
+
     def connection
       Faraday.new('https://api.github.com') do |conn|
         conn.basic_auth(ENV['GITHUB_ADMIN_USER'], ENV['GITHUB_ADMIN_TOKEN'])
         conn.headers['Accept'] = 'application/vnd.github.v3+json'
         conn.response :raise_error
       end
+    end
+
+    def get_all_paginated_items(url, max_per_page, accumulated_items = [], page_number = 1)
+      request_params = {
+        page: page_number,
+        per_page: max_per_page
+      }
+
+      response = connection.get(url) do |request|
+        request.params = request_params
+      end
+      new_items = JSON.parse(response.body).map(&:with_indifferent_access)
+
+      return accumulated_items if new_items.empty?
+
+      get_all_paginated_items(url, max_per_page, accumulated_items + new_items, page_number + 1)
     end
   end
 end

--- a/app/services/github_client/base.rb
+++ b/app/services/github_client/base.rb
@@ -10,7 +10,7 @@ module GithubClient
       end
     end
 
-    def get_all_paginated_items(url, max_per_page, accumulated_items = [], page_number = 1)
+    def get_all_paginated_items(url, max_per_page, accumulated_items: [], page_number: 1)
       request_params = {
         page: page_number,
         per_page: max_per_page
@@ -23,7 +23,12 @@ module GithubClient
 
       return accumulated_items if new_items.empty?
 
-      get_all_paginated_items(url, max_per_page, accumulated_items + new_items, page_number + 1)
+      get_all_paginated_items(
+        url,
+        max_per_page,
+        accumulated_items: accumulated_items + new_items,
+        page_number: page_number + 1
+      )
     end
   end
 end

--- a/app/services/github_client/organization.rb
+++ b/app/services/github_client/organization.rb
@@ -2,20 +2,8 @@ module GithubClient
   class Organization < GithubClient::Base
     MAX_REPOSITORIES_PER_PAGE = 100
 
-    def repositories(acc_repositories = [], page_number = 1)
-      request_params = {
-        page: page_number,
-        per_page: MAX_REPOSITORIES_PER_PAGE
-      }
-
-      response = connection.get('orgs/rootstrap/repos') do |request|
-        request.params = request_params
-      end
-      new_repositories = JSON.parse(response.body).map(&:with_indifferent_access)
-
-      return acc_repositories if new_repositories.empty?
-
-      repositories(acc_repositories + new_repositories, page_number + 1)
+    def repositories
+      get_all_paginated_items('orgs/rootstrap/repos', MAX_REPOSITORIES_PER_PAGE)
     end
   end
 end

--- a/app/services/github_client/pull_request.rb
+++ b/app/services/github_client/pull_request.rb
@@ -1,0 +1,20 @@
+module GithubClient
+  class PullRequest < GithubClient::Repository
+    MAX_FILES_PER_PAGE = 100
+
+    def initialize(project, pull_request)
+      super project
+
+      @pull_request = pull_request
+    end
+
+    def files
+      url = "repositories/#{project.github_id}/pulls/#{pull_request.number}/files"
+      get_all_paginated_items(url, MAX_FILES_PER_PAGE)
+    end
+
+    private
+
+    attr_reader :pull_request
+  end
+end

--- a/app/services/github_client/pull_request.rb
+++ b/app/services/github_client/pull_request.rb
@@ -2,8 +2,8 @@ module GithubClient
   class PullRequest < GithubClient::Repository
     MAX_FILES_PER_PAGE = 100
 
-    def initialize(project, pull_request)
-      super project
+    def initialize(pull_request)
+      super pull_request.project
 
       @pull_request = pull_request
     end

--- a/app/services/github_client/repository.rb
+++ b/app/services/github_client/repository.rb
@@ -18,7 +18,7 @@ module GithubClient
     end
 
     def views
-      response = connection.get("repositories/#{@project.github_id}/traffic/views") do |request|
+      response = connection.get("repositories/#{project.github_id}/traffic/views") do |request|
         request.params['per'] = 'week'
       end
       JSON.parse(response.body).with_indifferent_access
@@ -26,9 +26,11 @@ module GithubClient
 
     private
 
+    attr_reader :project
+
     def find_in_locations
       LOCATIONS.each do |location|
-        url = "repos/rootstrap/#{@project.name}/contents/#{location}"
+        url = "repos/rootstrap/#{project.name}/contents/#{location}"
         response = connection.get(url) do |request|
           request.headers['Accept'] = 'application/vnd.github.v3.raw'
         end

--- a/app/services/pull_request_size_calculator.rb
+++ b/app/services/pull_request_size_calculator.rb
@@ -1,0 +1,23 @@
+class PullRequestSizeCalculator < BaseService
+  def initialize(pull_request)
+    @pull_request = pull_request
+  end
+
+  def call
+    pull_request_additions
+  end
+
+  private
+
+  attr_reader :pull_request
+
+  def pull_request_additions
+    pull_request_files.sum do |pull_request_file|
+      pull_request_file[:additions]
+    end
+  end
+
+  def pull_request_files
+    GithubClient::PullRequest.new(pull_request).files
+  end
+end

--- a/db/migrate/20200901185355_create_pull_request_sizes.rb
+++ b/db/migrate/20200901185355_create_pull_request_sizes.rb
@@ -1,0 +1,10 @@
+class CreatePullRequestSizes < ActiveRecord::Migration[6.0]
+  def change
+    create_table :pull_request_sizes do |t|
+      t.references :pull_request, null: false, foreign_key: true
+      t.integer :value
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200901185355_create_pull_request_sizes.rb
+++ b/db/migrate/20200901185355_create_pull_request_sizes.rb
@@ -2,7 +2,7 @@ class CreatePullRequestSizes < ActiveRecord::Migration[6.0]
   def change
     create_table :pull_request_sizes do |t|
       t.references :pull_request, null: false, foreign_key: true
-      t.integer :value
+      t.integer :value, null: false
 
       t.timestamps
     end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -732,6 +732,38 @@ ALTER SEQUENCE public.projects_id_seq OWNED BY public.projects.id;
 
 
 --
+-- Name: pull_request_sizes; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.pull_request_sizes (
+    id bigint NOT NULL,
+    pull_request_id bigint NOT NULL,
+    value integer,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: pull_request_sizes_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.pull_request_sizes_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: pull_request_sizes_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.pull_request_sizes_id_seq OWNED BY public.pull_request_sizes.id;
+
+
+--
 -- Name: pull_requests; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -1139,6 +1171,13 @@ ALTER TABLE ONLY public.projects ALTER COLUMN id SET DEFAULT nextval('public.pro
 
 
 --
+-- Name: pull_request_sizes id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.pull_request_sizes ALTER COLUMN id SET DEFAULT nextval('public.pull_request_sizes_id_seq'::regclass);
+
+
+--
 -- Name: pull_requests id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -1336,6 +1375,14 @@ ALTER TABLE ONLY public.metrics
 
 ALTER TABLE ONLY public.projects
     ADD CONSTRAINT projects_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: pull_request_sizes pull_request_sizes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.pull_request_sizes
+    ADD CONSTRAINT pull_request_sizes_pkey PRIMARY KEY (id);
 
 
 --
@@ -1579,6 +1626,13 @@ CREATE INDEX index_projects_on_language_id ON public.projects USING btree (langu
 
 
 --
+-- Name: index_pull_request_sizes_on_pull_request_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_pull_request_sizes_on_pull_request_id ON public.pull_request_sizes USING btree (pull_request_id);
+
+
+--
 -- Name: index_pull_requests_on_github_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -1787,6 +1841,14 @@ ALTER TABLE ONLY public.reviews
 
 ALTER TABLE ONLY public.review_comments
     ADD CONSTRAINT fk_rails_4a92157916 FOREIGN KEY (owner_id) REFERENCES public.users(id);
+
+
+--
+-- Name: pull_request_sizes fk_rails_4bb5aaec06; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.pull_request_sizes
+    ADD CONSTRAINT fk_rails_4bb5aaec06 FOREIGN KEY (pull_request_id) REFERENCES public.pull_requests(id);
 
 
 --
@@ -2004,6 +2066,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20200819142237'),
 ('20200820180521'),
 ('20200824202901'),
-('20200825151321');
+('20200825151321'),
+('20200901185355');
 
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -738,7 +738,7 @@ ALTER SEQUENCE public.projects_id_seq OWNED BY public.projects.id;
 CREATE TABLE public.pull_request_sizes (
     id bigint NOT NULL,
     pull_request_id bigint NOT NULL,
-    value integer,
+    value integer NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL
 );

--- a/spec/factories/payloads/pull_request_file.rb
+++ b/spec/factories/payloads/pull_request_file.rb
@@ -1,0 +1,14 @@
+FactoryBot.define do
+  factory :pull_request_file_payload, class: Hash do
+    skip_create
+
+    sha { Faker::Alphanumeric.alphanumeric(number: 40) }
+    filename { Faker::File.file_name }
+    status { %w[added modified removed].sample }
+    additions { Faker::Number.within(range: 0..1000) }
+    deletions { Faker::Number.within(range: 0..1000) }
+    changes { Faker::Number.within(range: 0..1000) }
+
+    initialize_with { attributes.deep_stringify_keys }
+  end
+end

--- a/spec/factories/pull_request_sizes.rb
+++ b/spec/factories/pull_request_sizes.rb
@@ -3,7 +3,7 @@
 # Table name: pull_request_sizes
 #
 #  id              :bigint           not null, primary key
-#  value           :integer
+#  value           :integer          not null
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
 #  pull_request_id :bigint           not null

--- a/spec/factories/pull_request_sizes.rb
+++ b/spec/factories/pull_request_sizes.rb
@@ -1,0 +1,26 @@
+# == Schema Information
+#
+# Table name: pull_request_sizes
+#
+#  id              :bigint           not null, primary key
+#  value           :integer
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  pull_request_id :bigint           not null
+#
+# Indexes
+#
+#  index_pull_request_sizes_on_pull_request_id  (pull_request_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (pull_request_id => pull_requests.id)
+#
+
+FactoryBot.define do
+  factory :pull_request_size do
+    value { Faker::Number.within(range: 0..10_000) }
+
+    association :pull_request
+  end
+end

--- a/spec/models/pull_request_size_spec.rb
+++ b/spec/models/pull_request_size_spec.rb
@@ -1,0 +1,38 @@
+# == Schema Information
+#
+# Table name: pull_request_sizes
+#
+#  id              :bigint           not null, primary key
+#  value           :integer
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  pull_request_id :bigint           not null
+#
+# Indexes
+#
+#  index_pull_request_sizes_on_pull_request_id  (pull_request_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (pull_request_id => pull_requests.id)
+#
+
+require 'rails_helper'
+
+RSpec.describe PullRequestSize, type: :model do
+  subject { build :pull_request_size }
+
+  context 'validations' do
+    it 'is valid with valid attributes' do
+      expect(subject).to be_valid
+    end
+
+    it 'is not valid without value' do
+      subject.value = nil
+      expect(subject).to_not be_valid
+    end
+
+    it { is_expected.to validate_uniqueness_of(:pull_request_id) }
+    it { is_expected.to belong_to(:pull_request) }
+  end
+end

--- a/spec/models/pull_request_size_spec.rb
+++ b/spec/models/pull_request_size_spec.rb
@@ -3,7 +3,7 @@
 # Table name: pull_request_sizes
 #
 #  id              :bigint           not null, primary key
-#  value           :integer
+#  value           :integer          not null
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
 #  pull_request_id :bigint           not null

--- a/spec/services/builders/events/pull_request_spec.rb
+++ b/spec/services/builders/events/pull_request_spec.rb
@@ -1,0 +1,57 @@
+require 'rails_helper'
+
+RSpec.describe Builders::Events::PullRequest do
+  describe '.call' do
+    let(:payload) { create(:full_pull_request_payload) }
+    let(:pull_request_payload) { payload['pull_request'] }
+    let(:repository_payload) { payload['repository'] }
+    let(:user_payload) { pull_request_payload['user'] }
+
+    before { stub_pull_request_files_with_payload(payload) }
+
+    context 'when the pull request has not been created before' do
+      it 'creates a new one' do
+        expect { described_class.call(payload: payload) }
+          .to change { Events::PullRequest.count }
+          .by(1)
+      end
+
+      it 'assigns the correct attributes to it' do
+        built_pull_request = described_class.call(payload: payload)
+        expect(built_pull_request.number).to eq(pull_request_payload['number'])
+        expect(built_pull_request.state).to eq(pull_request_payload['state'])
+        expect(built_pull_request.node_id).to eq(pull_request_payload['node_id'])
+        expect(built_pull_request.title).to eq(pull_request_payload['title'])
+        expect(built_pull_request.locked).to eq(boolean_of(pull_request_payload['locked']))
+        expect(built_pull_request.draft).to eq(boolean_of(pull_request_payload['draft']))
+        expect(built_pull_request.html_url).to eq(pull_request_payload['html_url'])
+        expect(built_pull_request.opened_at).to eq(pull_request_payload['created_at'])
+      end
+
+      it 'creates or assigns the correct references to it' do
+        built_pull_request = described_class.call(payload: payload)
+        expect(built_pull_request.project.github_id).to eq(repository_payload['id'])
+        expect(built_pull_request.owner.github_id).to eq(user_payload['id'])
+        expect(built_pull_request.owner.projects).to include(built_pull_request.project)
+        expect(built_pull_request.pull_request_size).to be_present
+      end
+    end
+
+    context 'when the pull request has been created before' do
+      let!(:pull_request) { create(:pull_request, github_id: pull_request_payload['id']) }
+
+      it 'returns it' do
+        expect(described_class.call(payload: payload)).to eq pull_request
+      end
+
+      it 'does not create a new one' do
+        expect { described_class.call(payload: payload) }
+          .not_to change { Events::PullRequest.count }
+      end
+    end
+  end
+
+  def boolean_of(value)
+    ActiveModel::Type::Boolean.new.cast(value)
+  end
+end

--- a/spec/services/builders/pull_request_size_spec.rb
+++ b/spec/services/builders/pull_request_size_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+RSpec.describe Builders::PullRequestSize do
+  describe '.call' do
+    let(:pull_request) { create(:pull_request) }
+    let(:total_additions) { 500 }
+    let(:pull_request_file_payloads) do
+      [create(:pull_request_file_payload, additions: total_additions)]
+    end
+
+    before { stub_pull_request_files_with_pr(pull_request, pull_request_file_payloads) }
+
+    context 'when there is no pull request size created' do
+      it 'creates a new one' do
+        expect { described_class.call(pull_request) }
+          .to change { PullRequestSize.count }
+          .by(1)
+      end
+
+      it 'assigns the correct value to it' do
+        expect(described_class.call(pull_request).value).to eq total_additions
+      end
+    end
+
+    context 'when there is already a pull request size created' do
+      let(:previous_value) { total_additions }
+      let!(:pull_request_size) do
+        create(:pull_request_size, pull_request: pull_request, value: previous_value)
+      end
+
+      it 'does not create a new one' do
+        expect { described_class.call(pull_request) }
+          .not_to change { PullRequestSize.count }
+      end
+
+      it 'returns it' do
+        expect(described_class.call(pull_request)).to eq pull_request_size
+      end
+
+      context 'and has an outdated value' do
+        let(:previous_value) { 1 }
+
+        it 'updates it' do
+          expect(described_class.call(pull_request).value).to eq total_additions
+        end
+      end
+    end
+  end
+end

--- a/spec/services/github_client/pull_request_spec.rb
+++ b/spec/services/github_client/pull_request_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe GithubClient::PullRequest do
+  describe '#files' do
+    let(:project) { create(:project) }
+    let(:pull_request) { create(:pull_request, project: project) }
+    let(:pull_request_file_payload) { create(:pull_request_file_payload) }
+
+    subject(:client) { described_class.new(project, pull_request) }
+
+    before do
+      stub_pull_request_files(project, pull_request, [pull_request_file_payload])
+    end
+
+    it 'returns the pull request changes files' do
+      expect(client.files).to contain_exactly(pull_request_file_payload)
+    end
+
+    context 'when there is more than one page of results' do
+      let(:pull_request_file_payload_2) { create(:pull_request_file_payload) }
+      let(:pull_request_files_payloads) do
+        [pull_request_file_payload, pull_request_file_payload_2]
+      end
+
+      before do
+        stub_pull_request_files(
+          project,
+          pull_request,
+          pull_request_files_payloads,
+          results_per_page: 1
+        )
+      end
+
+      it 'returns the pull request files from all pages' do
+        expect(client.files).to match_array(pull_request_files_payloads)
+      end
+    end
+  end
+end

--- a/spec/services/github_client/pull_request_spec.rb
+++ b/spec/services/github_client/pull_request_spec.rb
@@ -8,9 +8,7 @@ RSpec.describe GithubClient::PullRequest do
 
     subject(:client) { described_class.new(pull_request) }
 
-    before do
-      stub_pull_request_files(project, pull_request, [pull_request_file_payload])
-    end
+    before { stub_pull_request_files_with_pr(pull_request, [pull_request_file_payload]) }
 
     it 'returns the pull request changes files' do
       expect(client.files).to contain_exactly(pull_request_file_payload)
@@ -23,8 +21,7 @@ RSpec.describe GithubClient::PullRequest do
       end
 
       before do
-        stub_pull_request_files(
-          project,
+        stub_pull_request_files_with_pr(
           pull_request,
           pull_request_files_payloads,
           results_per_page: 1

--- a/spec/services/github_client/pull_request_spec.rb
+++ b/spec/services/github_client/pull_request_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe GithubClient::PullRequest do
     let(:pull_request) { create(:pull_request, project: project) }
     let(:pull_request_file_payload) { create(:pull_request_file_payload) }
 
-    subject(:client) { described_class.new(project, pull_request) }
+    subject(:client) { described_class.new(pull_request) }
 
     before do
       stub_pull_request_files(project, pull_request, [pull_request_file_payload])

--- a/spec/services/github_service_spec.rb
+++ b/spec/services/github_service_spec.rb
@@ -10,6 +10,8 @@ RSpec.describe GithubService do
       let(:pull_request) { create :pull_request, github_id: payload['pull_request']['id'] }
       let(:review_request) { create :review_request }
 
+      before { stub_pull_request_files_with_payload(payload) }
+
       it 'creates a pull request' do
         expect { subject }.to change(Events::PullRequest, :count).by(1)
       end

--- a/spec/services/pull_request_size_calculator_spec.rb
+++ b/spec/services/pull_request_size_calculator_spec.rb
@@ -11,9 +11,7 @@ RSpec.describe PullRequestSizeCalculator do
     let(:pr_file_payloads) { [pr_file_1, pr_file_2] }
     let(:total_additions) { pr_file_1['additions'] + pr_file_2['additions'] }
 
-    before do
-      stub_pull_request_files(project, pull_request, pr_file_payloads)
-    end
+    before { stub_pull_request_files_with_pr(pull_request, pr_file_payloads) }
 
     it 'returns the total sum of the additions of each file of the PR' do
       expect(pull_request_size).to eq(total_additions)

--- a/spec/services/pull_request_size_calculator_spec.rb
+++ b/spec/services/pull_request_size_calculator_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe PullRequestSizeCalculator do
+  describe '.call' do
+    subject(:pull_request_size) { described_class.call(pull_request) }
+
+    let(:project) { create(:project) }
+    let(:pull_request) { create(:pull_request, project: project) }
+    let(:pr_file_1) { create(:pull_request_file_payload) }
+    let(:pr_file_2) { create(:pull_request_file_payload) }
+    let(:pr_file_payloads) { [pr_file_1, pr_file_2] }
+    let(:total_additions) { pr_file_1['additions'] + pr_file_2['additions'] }
+
+    before do
+      stub_pull_request_files(project, pull_request, pr_file_payloads)
+    end
+
+    it 'returns the total sum of the additions of each file of the PR' do
+      expect(pull_request_size).to eq(total_additions)
+    end
+  end
+end

--- a/spec/support/helpers/github_api_mocker.rb
+++ b/spec/support/helpers/github_api_mocker.rb
@@ -63,22 +63,33 @@ module GithubApiMock
     repository_payloads,
     results_per_page: GithubClient::Organization::MAX_REPOSITORIES_PER_PAGE
   )
-    stub_auth_envs
-
     url = 'https://api.github.com/orgs/rootstrap/repos'
-    groups_of_repositories = repository_payloads.in_groups_of(results_per_page, false)
 
-    groups_of_repositories.push([]).each.with_index do |repositories, index|
-      stub_request(:get, url)
-        .with(
-          basic_auth: [github_admin_user, github_admin_token],
-          query: {
-            page: index + 1,
-            per_page: GithubClient::Organization::MAX_REPOSITORIES_PER_PAGE
-          }
-        )
-        .to_return(body: JSON.generate(repositories), status: 200)
-    end
+    stub_paginated_items(
+      repository_payloads,
+      url,
+      results_per_page,
+      GithubClient::Organization::MAX_REPOSITORIES_PER_PAGE
+    )
+  end
+
+  # The results_per_page attribute is meant just for testing purposes
+  # The API will be stubbed anyway with the amount used in GithubClient::PullRequest#files
+  def stub_pull_request_files(
+    project,
+    pull_request,
+    file_payloads,
+    results_per_page: GithubClient::PullRequest::MAX_FILES_PER_PAGE
+  )
+    url = 'https://api.github.com/repositories/' \
+          "#{project.github_id}/pulls/#{pull_request.number}/files"
+
+    stub_paginated_items(
+      file_payloads,
+      url,
+      results_per_page,
+      GithubClient::PullRequest::MAX_FILES_PER_PAGE
+    )
   end
 
   private
@@ -98,5 +109,23 @@ module GithubApiMock
   def stub_auth_envs
     stub_env('GITHUB_ADMIN_USER', github_admin_user)
     stub_env('GITHUB_ADMIN_TOKEN', github_admin_token)
+  end
+
+  def stub_paginated_items(item_payloads, url, results_per_page, max_results_per_page)
+    stub_auth_envs
+
+    groups_of_items = item_payloads.in_groups_of(results_per_page, false)
+
+    groups_of_items.push([]).each.with_index do |items, index|
+      stub_request(:get, url)
+        .with(
+          basic_auth: [github_admin_user, github_admin_token],
+          query: {
+            page: index + 1,
+            per_page: max_results_per_page
+          }
+        )
+        .to_return(body: JSON.generate(items), status: 200)
+    end
   end
 end


### PR DESCRIPTION
## What does this PR do?
It creates the `PullRequestSize` model, which will contain the information about the PR Size metric.
It will be generated every time a new `PullRequest` is created.

Resolves [#146](https://rootstrap.atlassian.net/browse/EM-146)
