### PR TITLE
[EM-158] Make initializeSelect2 function idempotent

### DIFF
--- a/app/javascript/modules/sidebar/index.js
+++ b/app/javascript/modules/sidebar/index.js
@@ -48,7 +48,9 @@ export const handleChangeUser = () => {
 }
 
 export const initializeSelect2 = () => {
-  $('.project-selection, .department-selection, .user-selection').select2({
-    theme: 'bootstrap4',
-  })
+  if (!elementSelector('select2')) {
+    $('.project-selection, .department-selection, .user-selection').select2({
+      theme: 'bootstrap4',
+    })
+  }
 }


### PR DESCRIPTION
## What does this PR do?
It fixes the error that used to show up when navigating through the app with the dropdowns from the sidebar in the development metrics tab.
The error occurred every time a dropdown was visible in the page, the user then navigated away of that page and then when they clicked "back" in the browser (although other combinations could trigger it as well).
The problem is that we modify those dropdowns on every page load via the `initializeSelect2` function. But that function is not idempotent; applying it several times changes the result every time, so, if the function was already applied when loading the page (like when you get to the page using the "back" button), running it again would break the dropdown.
The proposed solution is to make the function idempotent, so that it does not matter how many times it is run, nothing will change beyond the first run.
The error and the solution are perfectly illustrated in the [turbolinks docs](https://github.com/turbolinks/turbolinks#making-transformations-idempotent).

![Screen-Recording-2020-09-07-at-3](https://user-images.githubusercontent.com/7276679/92412701-44e18080-f123-11ea-864f-a725269dc3b8.gif)

Resolves [#158](https://rootstrap.atlassian.net/browse/EM-158)
