### PR TITLE
[EM-165] Update pull request size on every push

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -19,7 +19,7 @@
 #
 
 class Event < ApplicationRecord
-  TYPES = %w[pull_request review review_comment].freeze
+  TYPES = %w[pull_request review review_comment push].freeze
 
   belongs_to :handleable, polymorphic: true, optional: true
   belongs_to :project

--- a/app/models/events/pull_request.rb
+++ b/app/models/events/pull_request.rb
@@ -4,6 +4,7 @@
 #
 #  id         :bigint           not null, primary key
 #  body       :text
+#  branch     :string
 #  closed_at  :datetime
 #  draft      :boolean          not null
 #  html_url   :string

--- a/app/models/events/pull_request.rb
+++ b/app/models/events/pull_request.rb
@@ -45,6 +45,7 @@ module Events
                                dependent: :destroy, inverse_of: :pull_request
     has_many :reviews, class_name: 'Events::Review', dependent: :destroy,
                        inverse_of: :pull_request
+    has_many :pushes, class_name: 'Events::Push', dependent: :destroy, inverse_of: :pull_request
     has_many :events, as: :handleable, dependent: :destroy
     has_one :merge_time, dependent: :destroy
     has_one :pull_request_size, dependent: :destroy

--- a/app/models/events/push.rb
+++ b/app/models/events/push.rb
@@ -1,0 +1,33 @@
+# == Schema Information
+#
+# Table name: pushes
+#
+#  id              :bigint           not null, primary key
+#  ref             :string
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  project_id      :bigint           not null
+#  pull_request_id :bigint
+#  sender_id       :bigint           not null
+#
+# Indexes
+#
+#  index_pushes_on_project_id       (project_id)
+#  index_pushes_on_pull_request_id  (pull_request_id)
+#  index_pushes_on_sender_id        (sender_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (project_id => projects.id)
+#  fk_rails_...  (pull_request_id => pull_requests.id)
+#  fk_rails_...  (sender_id => users.id)
+#
+
+module Events
+  class Push < ApplicationRecord
+    belongs_to :project
+    belongs_to :pull_request, class_name: 'Events::PullRequest', optional: true
+    belongs_to :sender, class_name: 'User', foreign_key: :sender_id, inverse_of: :pushes
+    has_one :event, as: :handleable, dependent: :destroy
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -51,6 +51,10 @@ class User < ApplicationRecord
            dependent: :destroy,
            foreign_key: :owner_id,
            inverse_of: :owner
+  has_many :pushes,
+           class_name: 'Events::Push',
+           dependent: :destroy,
+           inverse_of: :sender
   validates :github_id,
             :login,
             :node_id,

--- a/app/services/action_handler.rb
+++ b/app/services/action_handler.rb
@@ -13,6 +13,10 @@ class ActionHandler < BaseService
   private
 
   def handle_action
-    send(@payload['action'])
+    send(action)
+  end
+
+  def action
+    @payload['action'] || :created
   end
 end

--- a/app/services/action_handlers/push.rb
+++ b/app/services/action_handlers/push.rb
@@ -1,0 +1,17 @@
+module ActionHandlers
+  class Push < ActionHandler
+    private
+
+    def handleable?
+      true
+    end
+
+    def created
+      pull_request = @entity.pull_request
+
+      return unless pull_request
+
+      Builders::PullRequestSize.call(pull_request)
+    end
+  end
+end

--- a/app/services/builders/events/pull_request.rb
+++ b/app/services/builders/events/pull_request.rb
@@ -12,6 +12,7 @@ module Builders
           ATTR_PAYLOAD_MAP.each do |key, value|
             pull_request.public_send("#{key}=", pull_request_data.fetch(value))
           end
+          pull_request.branch = pull_request_data.dig('head', 'ref')
 
           assign_attrs(pull_request, pull_request_data)
         end

--- a/app/services/builders/events/push.rb
+++ b/app/services/builders/events/push.rb
@@ -1,0 +1,47 @@
+module Builders
+  module Events
+    class Push < Builders::Events::Base
+      private
+
+      def build
+        ::Events::Push.create! do |push|
+          push.ref = @payload['ref']
+          push.sender = find_or_create_user(@payload['sender'])
+          push.project = project
+          find_or_create_user_project(push.project.id, push.sender.id)
+          push.pull_request = pull_request
+        end
+      end
+
+      def pull_request
+        return if tag_ref?
+
+        ::Events::PullRequest.find_by(
+          project: project,
+          branch: ref_name,
+          state: ::Events::PullRequest.states[:open]
+        )
+      end
+
+      def project
+        @project ||= Builders::Project.call(@payload['repository'])
+      end
+
+      def tag_ref?
+        ref_type == 'tags'
+      end
+
+      def ref_type
+        parsed_ref.second
+      end
+
+      def ref_name
+        parsed_ref.third
+      end
+
+      def parsed_ref
+        @parsed_ref ||= @payload['ref'].split('/', 3)
+      end
+    end
+  end
+end

--- a/db/migrate/20200908121903_add_branch_to_pull_requests.rb
+++ b/db/migrate/20200908121903_add_branch_to_pull_requests.rb
@@ -1,0 +1,5 @@
+class AddBranchToPullRequests < ActiveRecord::Migration[6.0]
+  def change
+    add_column :pull_requests, :branch, :string
+  end
+end

--- a/db/migrate/20200908173642_create_pushes.rb
+++ b/db/migrate/20200908173642_create_pushes.rb
@@ -1,0 +1,12 @@
+class CreatePushes < ActiveRecord::Migration[6.0]
+  def change
+    create_table :pushes do |t|
+      t.references :project, null: false, foreign_key: true
+      t.references :pull_request, null: true, foreign_key: true
+      t.references :sender, null: false, foreign_key: { to_table: :users }
+      t.string :ref
+
+      t.timestamps
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -809,6 +809,40 @@ ALTER SEQUENCE public.pull_requests_id_seq OWNED BY public.pull_requests.id;
 
 
 --
+-- Name: pushes; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.pushes (
+    id bigint NOT NULL,
+    project_id bigint NOT NULL,
+    pull_request_id bigint,
+    sender_id bigint NOT NULL,
+    ref character varying,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: pushes_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.pushes_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: pushes_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.pushes_id_seq OWNED BY public.pushes.id;
+
+
+--
 -- Name: review_comments; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -1186,6 +1220,13 @@ ALTER TABLE ONLY public.pull_requests ALTER COLUMN id SET DEFAULT nextval('publi
 
 
 --
+-- Name: pushes id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.pushes ALTER COLUMN id SET DEFAULT nextval('public.pushes_id_seq'::regclass);
+
+
+--
 -- Name: review_comments id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -1392,6 +1433,14 @@ ALTER TABLE ONLY public.pull_request_sizes
 
 ALTER TABLE ONLY public.pull_requests
     ADD CONSTRAINT pull_requests_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: pushes pushes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.pushes
+    ADD CONSTRAINT pushes_pkey PRIMARY KEY (id);
 
 
 --
@@ -1662,6 +1711,27 @@ CREATE INDEX index_pull_requests_on_state ON public.pull_requests USING btree (s
 
 
 --
+-- Name: index_pushes_on_project_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_pushes_on_project_id ON public.pushes USING btree (project_id);
+
+
+--
+-- Name: index_pushes_on_pull_request_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_pushes_on_pull_request_id ON public.pushes USING btree (pull_request_id);
+
+
+--
+-- Name: index_pushes_on_sender_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_pushes_on_sender_id ON public.pushes USING btree (sender_id);
+
+
+--
 -- Name: index_review_comments_on_owner_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -1797,6 +1867,14 @@ ALTER TABLE ONLY public.completed_review_turnarounds
 
 
 --
+-- Name: pushes fk_rails_2981d8bb5a; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.pushes
+    ADD CONSTRAINT fk_rails_2981d8bb5a FOREIGN KEY (pull_request_id) REFERENCES public.pull_requests(id);
+
+
+--
 -- Name: blog_post_technologies fk_rails_2b02d61b04; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -1818,6 +1896,14 @@ ALTER TABLE ONLY public.external_pull_requests
 
 ALTER TABLE ONLY public.review_turnarounds
     ADD CONSTRAINT fk_rails_33c3053604 FOREIGN KEY (review_request_id) REFERENCES public.review_requests(id);
+
+
+--
+-- Name: pushes fk_rails_3f633d82fd; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.pushes
+    ADD CONSTRAINT fk_rails_3f633d82fd FOREIGN KEY (project_id) REFERENCES public.projects(id);
 
 
 --
@@ -1906,6 +1992,14 @@ ALTER TABLE ONLY public.code_owner_projects
 
 ALTER TABLE ONLY public.review_requests
     ADD CONSTRAINT fk_rails_9ece0f7518 FOREIGN KEY (owner_id) REFERENCES public.users(id);
+
+
+--
+-- Name: pushes fk_rails_bc14f07184; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.pushes
+    ADD CONSTRAINT fk_rails_bc14f07184 FOREIGN KEY (sender_id) REFERENCES public.users(id);
 
 
 --
@@ -2069,6 +2163,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20200824202901'),
 ('20200825151321'),
 ('20200901185355'),
-('20200908121903');
+('20200908121903'),
+('20200908173642');
 
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -784,7 +784,8 @@ CREATE TABLE public.pull_requests (
     opened_at timestamp without time zone,
     project_id bigint,
     owner_id bigint,
-    html_url character varying
+    html_url character varying,
+    branch character varying
 );
 
 
@@ -2067,6 +2068,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20200820180521'),
 ('20200824202901'),
 ('20200825151321'),
-('20200901185355');
+('20200901185355'),
+('20200908121903');
 
 

--- a/spec/factories/events/pull_requests.rb
+++ b/spec/factories/events/pull_requests.rb
@@ -4,6 +4,7 @@
 #
 #  id         :bigint           not null, primary key
 #  body       :text
+#  branch     :string
 #  closed_at  :datetime
 #  draft      :boolean          not null
 #  html_url   :string

--- a/spec/factories/events/pushes.rb
+++ b/spec/factories/events/pushes.rb
@@ -1,0 +1,36 @@
+# == Schema Information
+#
+# Table name: pushes
+#
+#  id              :bigint           not null, primary key
+#  ref             :string
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  project_id      :bigint           not null
+#  pull_request_id :bigint
+#  sender_id       :bigint           not null
+#
+# Indexes
+#
+#  index_pushes_on_project_id       (project_id)
+#  index_pushes_on_pull_request_id  (pull_request_id)
+#  index_pushes_on_sender_id        (sender_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (project_id => projects.id)
+#  fk_rails_...  (pull_request_id => pull_requests.id)
+#  fk_rails_...  (sender_id => users.id)
+#
+
+FactoryBot.define do
+  factory :push, class: Events::Push do
+    association :project
+    association :sender, factory: :user
+    ref { "refs/head/#{Faker::Company.bs.gsub(' ', '_').underscore}" }
+
+    trait :with_pull_request do
+      association :pull_request
+    end
+  end
+end

--- a/spec/factories/payloads/pull_request.rb
+++ b/spec/factories/payloads/pull_request.rb
@@ -5,6 +5,7 @@ FactoryBot.define do
     transient do
       created_at { Faker::Date.between(from: 1.month.ago, to: Time.zone.now) }
       updated_at { Faker::Date.between(from: created_at, to: Time.zone.now) }
+      branch { Faker::Company.bs.gsub(' ', '_').underscore }
     end
 
     action do
@@ -24,7 +25,10 @@ FactoryBot.define do
         draft: 'false',
         user: (attributes_for :user, id: generate(:user_id)).as_json,
         created_at: created_at.to_time.iso8601,
-        updated_at: updated_at.to_time.iso8601
+        updated_at: updated_at.to_time.iso8601,
+        head: {
+          ref: branch
+        }
       }
     end
     requested_reviewer do

--- a/spec/factories/payloads/push.rb
+++ b/spec/factories/payloads/push.rb
@@ -1,0 +1,16 @@
+FactoryBot.define do
+  factory :push_payload, class: Hash do
+    skip_create
+
+    transient do
+      branch { Faker::Company.bs.gsub(' ', '_').underscore }
+      repository_id { Faker::Number.number(digits: 4) }
+    end
+
+    ref { "refs/heads/#{branch}" }
+    repository { create(:repository_payload, id: repository_id) }
+    sender { (attributes_for :user, id: generate(:user_id)).as_json }
+
+    initialize_with { attributes.deep_stringify_keys }
+  end
+end

--- a/spec/models/events/pull_request_spec.rb
+++ b/spec/models/events/pull_request_spec.rb
@@ -4,6 +4,7 @@
 #
 #  id         :bigint           not null, primary key
 #  body       :text
+#  branch     :string
 #  closed_at  :datetime
 #  draft      :boolean          not null
 #  html_url   :string

--- a/spec/models/events/push_spec.rb
+++ b/spec/models/events/push_spec.rb
@@ -1,0 +1,41 @@
+# == Schema Information
+#
+# Table name: pushes
+#
+#  id              :bigint           not null, primary key
+#  ref             :string
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  project_id      :bigint           not null
+#  pull_request_id :bigint
+#  sender_id       :bigint           not null
+#
+# Indexes
+#
+#  index_pushes_on_project_id       (project_id)
+#  index_pushes_on_pull_request_id  (pull_request_id)
+#  index_pushes_on_sender_id        (sender_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (project_id => projects.id)
+#  fk_rails_...  (pull_request_id => pull_requests.id)
+#  fk_rails_...  (sender_id => users.id)
+#
+
+require 'rails_helper'
+
+RSpec.describe Events::Push, type: :model do
+  context 'validations' do
+    subject { build(:push) }
+
+    it { is_expected.to have_one(:event) }
+    it { is_expected.to belong_to(:sender) }
+    it { is_expected.to belong_to(:project) }
+
+    it 'is valid without a pull request' do
+      subject.pull_request = nil
+      expect(subject).to be_valid
+    end
+  end
+end

--- a/spec/services/builders/action_handlers/push_spec.rb
+++ b/spec/services/builders/action_handlers/push_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe ActionHandlers::Push do
+  describe '.call' do
+    let(:push_payload) { create(:push_payload) }
+    let(:push) { create(:push) }
+
+    subject(:handle_action) { described_class.call(payload: push_payload, entity: push) }
+
+    context 'when the push has an associated pull request' do
+      let!(:pull_request) { create(:pull_request, pushes: [push]) }
+      let(:pull_request_file_payload) { create(:pull_request_file_payload) }
+      let(:additions) { pull_request_file_payload['additions'] }
+
+      before { stub_pull_request_files_with_pr(pull_request, [pull_request_file_payload]) }
+
+      it 'creates or updates its pull request size metric' do
+        handle_action
+
+        expect(push.pull_request.pull_request_size.value).to eq(additions)
+      end
+    end
+
+    context 'when the push does not have an associated pull request' do
+      it 'does not update any Pull Request Size' do
+        expect(Builders::PullRequestSize).not_to receive(:call)
+
+        handle_action
+      end
+    end
+  end
+end

--- a/spec/services/builders/events/pull_request_spec.rb
+++ b/spec/services/builders/events/pull_request_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe Builders::Events::PullRequest do
         expect(built_pull_request.draft).to eq(boolean_of(pull_request_payload['draft']))
         expect(built_pull_request.html_url).to eq(pull_request_payload['html_url'])
         expect(built_pull_request.opened_at).to eq(pull_request_payload['created_at'])
+        expect(built_pull_request.branch).to eq(pull_request_payload['head']['ref'])
       end
 
       it 'creates or assigns the correct references to it' do

--- a/spec/services/builders/events/push_spec.rb
+++ b/spec/services/builders/events/push_spec.rb
@@ -1,0 +1,57 @@
+require 'rails_helper'
+
+RSpec.describe Builders::Events::Push do
+  describe '.call' do
+    let(:push_payload) { create(:push_payload) }
+    let(:repository_payload) { push_payload['repository'] }
+    let(:user_payload) { push_payload['sender'] }
+
+    subject(:build_push) { described_class.call(payload: push_payload) }
+
+    it 'creates a new Push' do
+      expect { build_push }.to change { Events::Push.count }.by(1)
+    end
+
+    it 'creates or assigns the correct references to it' do
+      built_push = build_push
+      expect(built_push.project.github_id).to eq(repository_payload['id'])
+      expect(built_push.sender.github_id).to eq(user_payload['id'])
+      expect(built_push.sender.projects).to include(built_push.project)
+    end
+
+    context 'when there is a pull request for the pushed branch' do
+      let(:branch) { 'add_super_feature' }
+      let(:push_payload) { create(:push_payload, branch: branch) }
+      let(:project) { create(:project, github_id: repository_payload['id']) }
+      let!(:pull_request) do
+        create(:pull_request, branch: branch, state: pr_status, project: project)
+      end
+
+      context 'and it is open' do
+        let(:pr_status) { Events::PullRequest.states[:open] }
+
+        it 'associates that pull request to the created push' do
+          expect(build_push.pull_request).to eq(pull_request)
+        end
+      end
+
+      context 'and it is closed' do
+        let(:pr_status) { Events::PullRequest.states[:closed] }
+
+        it 'does not associate any pull request to the push' do
+          expect(build_push.pull_request).not_to be_present
+        end
+      end
+    end
+
+    context 'when the push has a tag ref' do
+      let(:push_payload) { create(:push_payload, ref: 'refs/tags/1.0.0') }
+
+      it 'does not look for any pull request to associate to it' do
+        expect(Events::PullRequest).not_to receive(:find_by)
+
+        build_push
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What does this PR do?
It catches all `push` events and creates a `Push` record for each one, associating it to its project, user and pull request (if any). If there's a pull request, its pull request size metric is updated 

Resolves [#165](https://rootstrap.atlassian.net/browse/EM-165)
