### PR TITLE
[EM-166] Delete PR Size metric when PR is closed without merging

### DIFF
--- a/app/services/action_handlers/pull_request.rb
+++ b/app/services/action_handlers/pull_request.rb
@@ -20,7 +20,12 @@ module ActionHandlers
     end
 
     def closed
-      merged if @payload['pull_request']['merged'] == true
+      if @payload['pull_request']['merged']
+        merged
+      else
+        @entity.pull_request_size&.destroy!
+      end
+
       @entity.closed!
       @entity.update!(closed_at: Time.current)
     end

--- a/spec/factories/payloads/pull_request.rb
+++ b/spec/factories/payloads/pull_request.rb
@@ -6,6 +6,7 @@ FactoryBot.define do
       created_at { Faker::Date.between(from: 1.month.ago, to: Time.zone.now) }
       updated_at { Faker::Date.between(from: created_at, to: Time.zone.now) }
       branch { Faker::Company.bs.gsub(' ', '_').underscore }
+      merged { false }
     end
 
     action do
@@ -23,6 +24,7 @@ FactoryBot.define do
         state: 'open',
         locked: 'false',
         draft: 'false',
+        merged: merged,
         user: (attributes_for :user, id: generate(:user_id)).as_json,
         created_at: created_at.to_time.iso8601,
         updated_at: updated_at.to_time.iso8601,

--- a/spec/services/github_service_spec.rb
+++ b/spec/services/github_service_spec.rb
@@ -5,7 +5,9 @@ RSpec.describe GithubService do
 
   describe 'events' do
     context 'pull request' do
-      let!(:payload) { (create :full_pull_request_payload) }
+      let!(:payload) { (create :full_pull_request_payload, action: action, merged: merged) }
+      let(:action) { 'open' }
+      let(:merged) { false }
       let!(:event) { 'pull_request' }
       let(:pull_request) { create :pull_request, github_id: payload['pull_request']['id'] }
       let(:review_request) { create :review_request }
@@ -16,24 +18,45 @@ RSpec.describe GithubService do
         expect { subject }.to change(Events::PullRequest, :count).by(1)
       end
 
-      it 'sets state to open' do
-        change_action_to('open')
-        pull_request.closed!
-        expect { subject }.to change { pull_request.reload.open? }.from(false).to(true)
+      context 'when the action is open' do
+        let(:action) { 'open' }
+
+        before { pull_request.closed! }
+
+        it 'sets state to open' do
+          expect { subject }.to change { pull_request.reload.open? }.from(false).to(true)
+        end
       end
 
-      it 'sets state closed' do
-        change_action_to('closed')
-        expect {
-          subject
-        }.to change { pull_request.reload.closed? }.from(false).to(true)
-      end
+      context 'when the action is closed' do
+        let(:action) { 'closed' }
 
-      it 'sets state merged' do
-        change_action_to('closed')
-        payload['pull_request']['merged'] = true
+        it 'sets state closed' do
+          expect {
+            subject
+          }.to change { pull_request.reload.closed? }.from(false).to(true)
+        end
 
-        expect { subject }.to change { pull_request.reload.merged_at }.from(nil).to(Time)
+        context 'and the pull request is merged' do
+          let(:merged) { true }
+
+          it 'sets state merged' do
+            expect { subject }.to change { pull_request.reload.merged_at }.from(nil).to(Time)
+          end
+        end
+
+        context 'and the pull request is not merged' do
+          let(:merged) { false }
+
+          before { create(:pull_request_size, pull_request: pull_request) }
+
+          it 'deletes the pull request size metric from the pull request' do
+            expect { subject }
+              .to change { pull_request.reload.pull_request_size }
+              .from(PullRequestSize)
+              .to(nil)
+          end
+        end
       end
 
       describe '#review_request_removed' do


### PR DESCRIPTION
## What does this PR do?
It removes the PR Size metric of PRs that get closed without merging.

Resolves [#166](https://rootstrap.atlassian.net/browse/EM-166)
