### PR TITLE
[EM-147] Ignore files for PR Size metrics

### DIFF
--- a/app/admin/file_ignoring_rules.rb
+++ b/app/admin/file_ignoring_rules.rb
@@ -1,0 +1,44 @@
+ActiveAdmin.register FileIgnoringRule do
+  permit_params :language_id, :regex
+
+  index do
+    selectable_column
+    id_column
+    column :language_id do |r|
+      r.language.name
+    end
+    column :regex
+    actions
+  end
+
+  form do |f|
+    f.inputs do
+      f.input :language, prompt: 'all'
+      f.input :regex
+    end
+    f.actions
+  end
+
+  controller do
+    def create
+      file_ignoring_rule = params['file_ignoring_rule']
+
+      if file_ignoring_rule['language_id'].blank?
+        create_rule_for_all_languages(file_ignoring_rule['regex'])
+        flash[:notice] = 'File Ignoring Rules created successfully'
+        redirect_to admin_file_ignoring_rules_path
+      else
+        super
+      end
+    end
+
+    def create_rule_for_all_languages(regex)
+      Language.where.not(name: 'unassigned').each do |language|
+        FileIgnoringRule.create!(
+          language: language,
+          regex: regex
+        )
+      end
+    end
+  end
+end

--- a/app/models/file_ignoring_rule.rb
+++ b/app/models/file_ignoring_rule.rb
@@ -1,0 +1,24 @@
+# == Schema Information
+#
+# Table name: file_ignoring_rules
+#
+#  id          :bigint           not null, primary key
+#  regex       :string           not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  language_id :bigint           not null
+#
+# Indexes
+#
+#  index_file_ignoring_rules_on_language_id  (language_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (language_id => languages.id)
+#
+
+class FileIgnoringRule < ApplicationRecord
+  belongs_to :language
+
+  validates :regex, presence: true
+end

--- a/app/models/file_ignoring_rule.rb
+++ b/app/models/file_ignoring_rule.rb
@@ -21,4 +21,8 @@ class FileIgnoringRule < ApplicationRecord
   belongs_to :language
 
   validates :regex, presence: true
+
+  def matches?(filename)
+    filename.match?(regex)
+  end
 end

--- a/app/models/language.rb
+++ b/app/models/language.rb
@@ -20,6 +20,7 @@ class Language < ApplicationRecord
   has_many :projects, dependent: :destroy
   has_many :metrics, as: :ownable, dependent: :destroy
   has_many :projects_metrics, through: :projects, source: :metrics
+  has_many :file_ignoring_rules, dependent: :destroy
 
   def self.unassigned
     find_by(name: 'unassigned')

--- a/app/services/pull_request_size_calculator.rb
+++ b/app/services/pull_request_size_calculator.rb
@@ -12,12 +12,28 @@ class PullRequestSizeCalculator < BaseService
   attr_reader :pull_request
 
   def pull_request_additions
-    pull_request_files.sum do |pull_request_file|
+    whitelisted_pull_request_files.sum do |pull_request_file|
       pull_request_file[:additions]
+    end
+  end
+
+  def whitelisted_pull_request_files
+    pull_request_files.reject do |file|
+      ignore_file?(file)
+    end
+  end
+
+  def ignore_file?(file)
+    file_ignoring_rules.any? do |file_ignoring_rule|
+      file_ignoring_rule.matches?(file[:filename])
     end
   end
 
   def pull_request_files
     GithubClient::PullRequest.new(pull_request).files
+  end
+
+  def file_ignoring_rules
+    @file_ignoring_rules ||= pull_request.project.language.file_ignoring_rules
   end
 end

--- a/db/migrate/20200911143301_create_file_ignoring_rules.rb
+++ b/db/migrate/20200911143301_create_file_ignoring_rules.rb
@@ -1,0 +1,10 @@
+class CreateFileIgnoringRules < ActiveRecord::Migration[6.0]
+  def change
+    create_table :file_ignoring_rules do |t|
+      t.references :language, null: false, foreign_key: true
+      t.string :regex, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -598,6 +598,38 @@ ALTER SEQUENCE public.external_pull_requests_id_seq OWNED BY public.external_pul
 
 
 --
+-- Name: file_ignoring_rules; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.file_ignoring_rules (
+    id bigint NOT NULL,
+    language_id bigint NOT NULL,
+    regex character varying NOT NULL,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: file_ignoring_rules_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.file_ignoring_rules_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: file_ignoring_rules_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.file_ignoring_rules_id_seq OWNED BY public.file_ignoring_rules.id;
+
+
+--
 -- Name: languages; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -1178,6 +1210,13 @@ ALTER TABLE ONLY public.external_pull_requests ALTER COLUMN id SET DEFAULT nextv
 
 
 --
+-- Name: file_ignoring_rules id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.file_ignoring_rules ALTER COLUMN id SET DEFAULT nextval('public.file_ignoring_rules_id_seq'::regclass);
+
+
+--
 -- Name: languages id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -1385,6 +1424,14 @@ ALTER TABLE ONLY public.external_projects
 
 ALTER TABLE ONLY public.external_pull_requests
     ADD CONSTRAINT external_pull_requests_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: file_ignoring_rules file_ignoring_rules_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.file_ignoring_rules
+    ADD CONSTRAINT file_ignoring_rules_pkey PRIMARY KEY (id);
 
 
 --
@@ -1645,6 +1692,13 @@ CREATE INDEX index_external_pull_requests_on_external_project_id ON public.exter
 --
 
 CREATE INDEX index_external_pull_requests_on_owner_id ON public.external_pull_requests USING btree (owner_id);
+
+
+--
+-- Name: index_file_ignoring_rules_on_language_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_file_ignoring_rules_on_language_id ON public.file_ignoring_rules USING btree (language_id);
 
 
 --
@@ -2011,6 +2065,14 @@ ALTER TABLE ONLY public.reviews
 
 
 --
+-- Name: file_ignoring_rules fk_rails_c0f919d112; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.file_ignoring_rules
+    ADD CONSTRAINT fk_rails_c0f919d112 FOREIGN KEY (language_id) REFERENCES public.languages(id);
+
+
+--
 -- Name: external_pull_requests fk_rails_c13d1ac6a7; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -2164,6 +2226,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20200825151321'),
 ('20200901185355'),
 ('20200908121903'),
-('20200908173642');
+('20200908173642'),
+('20200911143301');
 
 

--- a/spec/factories/admin_users.rb
+++ b/spec/factories/admin_users.rb
@@ -19,5 +19,8 @@
 
 FactoryBot.define do
   factory :admin_user do
+    email { 'admin@example.com' }
+    password { 'password' }
+    password_confirmation { 'password' }
   end
 end

--- a/spec/factories/file_ignoring_rules.rb
+++ b/spec/factories/file_ignoring_rules.rb
@@ -1,0 +1,25 @@
+# == Schema Information
+#
+# Table name: file_ignoring_rules
+#
+#  id          :bigint           not null, primary key
+#  regex       :string           not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  language_id :bigint           not null
+#
+# Indexes
+#
+#  index_file_ignoring_rules_on_language_id  (language_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (language_id => languages.id)
+#
+
+FactoryBot.define do
+  factory :file_ignoring_rule do
+    language { Language.first }
+    regex { 'spec/' }
+  end
+end

--- a/spec/models/file_ignoring_rule_spec.rb
+++ b/spec/models/file_ignoring_rule_spec.rb
@@ -30,4 +30,23 @@ RSpec.describe FileIgnoringRule, type: :model do
       expect(subject).not_to be_valid
     end
   end
+
+  describe '#matches?' do
+    let(:pattern) { 'spec/' }
+    let(:rule) { create(:file_ignoring_rule, regex: pattern) }
+
+    subject { rule.matches?(filename) }
+
+    context 'when the filename matches the regex' do
+      let(:filename) { 'spec/models/file_ignoring_rule_spec.rb' }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when the filename does not match the regex' do
+      let(:filename) { 'app/models/file_ignoring_rule.rb' }
+
+      it { is_expected.to be false }
+    end
+  end
 end

--- a/spec/models/file_ignoring_rule_spec.rb
+++ b/spec/models/file_ignoring_rule_spec.rb
@@ -1,0 +1,33 @@
+# == Schema Information
+#
+# Table name: file_ignoring_rules
+#
+#  id          :bigint           not null, primary key
+#  regex       :string           not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  language_id :bigint           not null
+#
+# Indexes
+#
+#  index_file_ignoring_rules_on_language_id  (language_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (language_id => languages.id)
+#
+
+require 'rails_helper'
+
+RSpec.describe FileIgnoringRule, type: :model do
+  context 'validations' do
+    subject { build :file_ignoring_rule }
+
+    it { is_expected.to belong_to(:language) }
+
+    it 'is not valid without a regex' do
+      subject.regex = nil
+      expect(subject).not_to be_valid
+    end
+  end
+end

--- a/spec/requests/admin/file_ignoring_rules_spec.rb
+++ b/spec/requests/admin/file_ignoring_rules_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+RSpec.describe 'Admin::FileIgnoringRules', type: :request do
+  include Devise::Test::IntegrationHelpers
+
+  let!(:admin) { create(:admin_user) }
+
+  before { sign_in admin }
+
+  describe '#create' do
+    let(:regex) { 'spec/' }
+    let(:params) do
+      {
+        file_ignoring_rule: {
+          language_id: language_id,
+          regex: regex
+        }
+      }
+    end
+
+    context 'when a language has been specified' do
+      let(:language) { Language.first }
+      let(:language_id) { language.id }
+
+      it 'creates a new rule for that language' do
+        post admin_file_ignoring_rules_path, params: params
+
+        expect(language.file_ignoring_rules.first.regex).to eq regex
+      end
+    end
+
+    context 'when "all" has been specified' do
+      let(:language_id) { nil }
+      let(:all_languages) { Language.where.not(name: 'unassigned') }
+
+      it 'creates a new rule for every language except for unassigned' do
+        post admin_file_ignoring_rules_path, params: params
+
+        expect(all_languages.map { |language| language.file_ignoring_rules.first.regex })
+          .to all(eq(regex))
+        expect(Language.unassigned.file_ignoring_rules).to be_empty
+      end
+    end
+  end
+end

--- a/spec/services/pull_request_size_calculator_spec.rb
+++ b/spec/services/pull_request_size_calculator_spec.rb
@@ -16,5 +16,17 @@ RSpec.describe PullRequestSizeCalculator do
     it 'returns the total sum of the additions of each file of the PR' do
       expect(pull_request_size).to eq(total_additions)
     end
+
+    context 'when one of the files matches a file ignoring rule' do
+      let(:filename) { 'spec/services/pull_request_size_calculator_spec.rb' }
+      let(:pr_language) { pull_request.project.language }
+      let(:pr_file_2) { create(:pull_request_file_payload, filename: filename) }
+
+      before { create(:file_ignoring_rule, regex: 'spec/', language: pr_language) }
+
+      it 'does not count the additions of that file' do
+        expect(pull_request_size).to eq(pr_file_1['additions'])
+      end
+    end
   end
 end


### PR DESCRIPTION
## What does this PR do?
It adds the model `FileIgnoringRule`, which holds the regex that matches all the files that should be ignored when calculating the PR Size metric. Each is tied to a single language, so we can ignore certain files concerning only one language at a time.
A page in admin has been added as well to maintain these rules.

Resolves [#147](https://rootstrap.atlassian.net/browse/EM-147)
