### PR TITLE
[EM-178] Stop using created_at for time reference in merge time and PR size

### DIFF
--- a/app/services/builders/chartkick/department_distribution_data.rb
+++ b/app/services/builders/chartkick/department_distribution_data.rb
@@ -10,10 +10,7 @@ module Builders
       private
 
       def retrieve_records
-        metric
-          .records_with_departments
-          .where(departments: { id: @entity_id })
-          .where(created_at: @query[:value_timestamp])
+        metric.retrieve_records(entity_id: @entity_id, time_range: @query[:value_timestamp])
       end
 
       def metric_name

--- a/app/services/builders/chartkick/department_distribution_data_metrics/merge_time.rb
+++ b/app/services/builders/chartkick/department_distribution_data_metrics/merge_time.rb
@@ -2,8 +2,11 @@ module Builders
   module Chartkick
     module DepartmentDistributionDataMetrics
       class MergeTime
-        def records_with_departments
-          ::MergeTime.joins(pull_request: { project: { language: :department } })
+        def retrieve_records(entity_id:, time_range:)
+          ::MergeTime
+            .joins(pull_request: { project: { language: :department } })
+            .where(departments: { id: entity_id })
+            .where(pull_requests: { merged_at: time_range })
         end
 
         def resolve_interval(entity)

--- a/app/services/builders/chartkick/department_distribution_data_metrics/pull_request_size.rb
+++ b/app/services/builders/chartkick/department_distribution_data_metrics/pull_request_size.rb
@@ -2,8 +2,11 @@ module Builders
   module Chartkick
     module DepartmentDistributionDataMetrics
       class PullRequestSize
-        def records_with_departments
-          ::PullRequestSize.joins(pull_request: { project: { language: :department } })
+        def retrieve_records(entity_id:, time_range:)
+          ::PullRequestSize
+            .joins(pull_request: { project: { language: :department } })
+            .where(departments: { id: entity_id })
+            .where(pull_requests: { opened_at: time_range })
         end
 
         def resolve_interval(entity)

--- a/app/services/builders/chartkick/department_distribution_data_metrics/review_turnaround.rb
+++ b/app/services/builders/chartkick/department_distribution_data_metrics/review_turnaround.rb
@@ -2,8 +2,11 @@ module Builders
   module Chartkick
     module DepartmentDistributionDataMetrics
       class ReviewTurnaround
-        def records_with_departments
-          ::CompletedReviewTurnaround.joins(review_request: { project: { language: :department } })
+        def retrieve_records(entity_id:, time_range:)
+          ::CompletedReviewTurnaround
+            .joins(review_request: { project: { language: :department } })
+            .where(departments: { id: entity_id })
+            .where(created_at: time_range)
         end
 
         def resolve_interval(entity)

--- a/app/services/builders/chartkick/project_distribution_data.rb
+++ b/app/services/builders/chartkick/project_distribution_data.rb
@@ -16,7 +16,7 @@ module Builders
       def merge_times
         ::MergeTime.joins(pull_request: :project)
                    .where(projects: { id: @entity_id })
-                   .where(created_at: @query[:value_timestamp])
+                   .where(pull_requests: { merged_at: @query[:value_timestamp] })
       end
 
       def resolve_interval(entity)

--- a/spec/services/builders/chartkick/department_distribution_data_metrics/pull_request_size_spec.rb
+++ b/spec/services/builders/chartkick/department_distribution_data_metrics/pull_request_size_spec.rb
@@ -1,15 +1,44 @@
 require 'rails_helper'
 
 RSpec.describe Builders::Chartkick::DepartmentDistributionDataMetrics::PullRequestSize do
-  describe '#records_with_departments' do
-    let(:department) { Department.first }
-    let(:project) { create(:project, language: department.languages.first) }
-    let(:pull_request) { create(:pull_request, project: project) }
+  describe '#retrieve_records' do
+    let(:time_range) { Time.zone.today.beginning_of_week..Time.zone.today.end_of_week }
+    let(:old_timestamp) { time_range.first.yesterday }
+    let(:backend_department) { Department.find_by(name: 'backend') }
+    let(:frontend_department) { Department.find_by(name: 'frontend') }
 
-    before { create(:pull_request_size, pull_request: pull_request) }
+    let(:backend_project) { create(:project, language: backend_department.languages.first) }
+    let(:frontend_project) { create(:project, language: frontend_department.languages.first) }
 
-    it 'returns PullRequestSize entities joined with Department' do
-      expect(subject.records_with_departments.pluck(:department_id)).to be_present
+    let(:frontend_pr) do
+      create(:pull_request, project: frontend_project, opened_at: Time.zone.now)
+    end
+    let(:last_week_backend_pr) do
+      create(:pull_request, project: backend_project, opened_at: old_timestamp)
+    end
+    let(:this_week_backend_pr) do
+      create(:pull_request, project: backend_project, opened_at: Time.zone.now)
+    end
+
+    let!(:frontend_pr_size) do
+      create(:pull_request_size, pull_request: frontend_pr)
+    end
+    let!(:last_week_backend_pr_size) do
+      create(:pull_request_size, pull_request: last_week_backend_pr)
+    end
+    let!(:this_week_backend_pr_size) do
+      create(:pull_request_size, pull_request: this_week_backend_pr)
+    end
+
+    subject(:records_retrieved) do
+      described_class.new.retrieve_records(
+        entity_id: backend_department.id,
+        time_range: time_range
+      )
+    end
+
+    it 'returns only records with the requested department and in the requested time range' do
+      expect(records_retrieved).to contain_exactly(this_week_backend_pr_size)
     end
   end
 

--- a/spec/services/builders/chartkick/department_distribution_data_spec.rb
+++ b/spec/services/builders/chartkick/department_distribution_data_spec.rb
@@ -74,13 +74,25 @@ RSpec.describe Builders::Chartkick::DepartmentDistributionData do
 
         before do
           sizes_values.each do |size_value|
-            pull_request = create(:pull_request, project: project)
+            pull_request = create(:pull_request, project: project, opened_at: Time.zone.now)
             create(:pull_request_size, value: size_value, pull_request: pull_request)
           end
         end
 
         it 'counts and classifies each pr size in the correct intervals and returns the data' do
           expect(subject.first[:data]).to eq(expected_data)
+        end
+
+        context 'when some pull requests have been created outside of the requested period' do
+          before do
+            old_timestamp = range.first.yesterday
+            pull_request = create(:pull_request, project: project, opened_at: old_timestamp)
+            create(:pull_request_size, value: 3, pull_request: pull_request)
+          end
+
+          it 'does not count them' do
+            expect(subject.first[:data]).to eq(expected_data)
+          end
         end
       end
     end

--- a/spec/support/shared_examples/merge_time_distribution_data.rb
+++ b/spec/support/shared_examples/merge_time_distribution_data.rb
@@ -8,7 +8,7 @@ RSpec.shared_examples 'merge time data distribution' do
   context 'when name is merge time' do
     before do
       values_in_seconds.each do |value|
-        pull_request = create(:pull_request, project: project)
+        pull_request = create(:pull_request, project: project, merged_at: Time.zone.now)
         create(:merge_time, pull_request: pull_request, value: value)
       end
       query.merge!(name: :merge_time)
@@ -34,6 +34,20 @@ RSpec.shared_examples 'merge time data distribution' do
 
     it 'returns an array with filled value' do
       expect(subject.first[:data]).not_to be_empty
+    end
+
+    context 'when there are pull requests merged outside of the requested period' do
+      before do
+        old_timestamp = range.first.yesterday
+        pull_request = create(:pull_request, project: project, merged_at: old_timestamp)
+        create(:merge_time, pull_request: pull_request, value: 90_000)
+      end
+
+      it 'does not count them' do
+        subject.first[:data].each do |data_array|
+          expect(data_array.second).to eq(1)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## What does this PR do?
`MergeTime` and `PullRequestSize` metrics use their own `created_at` attribute to reference the time those metrics apply to. But that attribute may not always reflect that time accurately, and it's not its primary purpose to do it either.
This PR makes them use better references:
- `MergeTime` uses now `merged_at` in `PullRequest`
- `PullRequestSize` uses now `opened_at` in `PullRequest`

Resolves [#178](https://rootstrap.atlassian.net/browse/EM-178)
