### PR TITLE
Metrics for merge time 

### DIFF
--- a/app/services/metrics/merge_time/per_department.rb
+++ b/app/services/metrics/merge_time/per_department.rb
@@ -4,26 +4,21 @@ module Metrics
       private
 
       def process
-        project_metrics_per_department.each do |department_id, amount, metrics_value|
-          turnaround = calculate_average(metrics_value, amount)
-          create_or_update_metric(department_id, Department.name, metric_interval,
-                                  turnaround, :merge_time)
+        project_metrics_per_department.each do |department_id, merge_times_value|
+          create_or_update_metric(department_id, Department.name, merge_time_interval,
+                                  merge_times_value, :merge_time)
         end
       end
 
       def project_metrics_per_department
-        Department.joins(languages: { projects: :metrics })
-                  .where(metrics: { name: :merge_time, created_at: metric_interval })
+        Department.joins(languages: { projects: { pull_requests: :merge_time } })
+                  .where(merge_times: { created_at: merge_time_interval })
                   .group(:id)
-                  .pluck(:id, Arel.sql('COUNT(*), SUM(metrics.value)'))
+                  .pluck(:id, Arel.sql('AVG(merge_times.value)'))
       end
 
-      def calculate_average(metrics_value, amount)
-        metrics_value / amount
-      end
-
-      def metric_interval
-        @metric_interval ||= @interval || Time.zone.today.all_day
+      def merge_time_interval
+        @merge_time_interval ||= @interval || Time.zone.today.all_day
       end
     end
   end

--- a/app/services/metrics/merge_time/per_department.rb
+++ b/app/services/metrics/merge_time/per_department.rb
@@ -12,7 +12,7 @@ module Metrics
 
       def project_metrics_per_department
         Department.joins(languages: { projects: { pull_requests: :merge_time } })
-                  .where(merge_times: { created_at: merge_time_interval })
+                  .where(pull_requests: { merged_at: merge_time_interval })
                   .group(:id)
                   .pluck(:id, Arel.sql('AVG(merge_times.value)'))
       end

--- a/app/services/metrics/merge_time/per_language.rb
+++ b/app/services/metrics/merge_time/per_language.rb
@@ -4,26 +4,21 @@ module Metrics
       private
 
       def process
-        project_metrics_per_language.each do |language_id, amount, metrics_value|
-          turnaround = calculate_average(metrics_value, amount)
-          create_or_update_metric(language_id, Language.name, metric_interval,
-                                  turnaround, :merge_time)
+        project_metrics_per_language.each do |language_id, merge_times_value|
+          create_or_update_metric(language_id, Language.name, merge_time_interval,
+                                  merge_times_value, :merge_time)
         end
       end
 
       def project_metrics_per_language
-        Language.joins(projects: :metrics)
-                .where(metrics: { name: :merge_time, created_at: metric_interval })
+        Language.joins(projects: { pull_requests: :merge_time })
+                .where(merge_times: { created_at: merge_time_interval })
                 .group(:id)
-                .pluck(:id, Arel.sql('COUNT(*), SUM(metrics.value)'))
+                .pluck(:id, Arel.sql('AVG(merge_times.value)'))
       end
 
-      def calculate_average(metrics_value, amount)
-        metrics_value / amount
-      end
-
-      def metric_interval
-        @metric_interval ||= @interval || Time.zone.today.all_day
+      def merge_time_interval
+        @merge_time_interval ||= @interval || Time.zone.today.all_day
       end
     end
   end

--- a/app/services/metrics/merge_time/per_language.rb
+++ b/app/services/metrics/merge_time/per_language.rb
@@ -12,7 +12,7 @@ module Metrics
 
       def project_metrics_per_language
         Language.joins(projects: { pull_requests: :merge_time })
-                .where(merge_times: { created_at: merge_time_interval })
+                .where(pull_requests: { merged_at: merge_time_interval })
                 .group(:id)
                 .pluck(:id, Arel.sql('AVG(merge_times.value)'))
       end

--- a/app/services/metrics/merge_time/per_project.rb
+++ b/app/services/metrics/merge_time/per_project.rb
@@ -4,30 +4,21 @@ module Metrics
       private
 
       def process
-        filtered_projects.each do |project|
-          turnaround = calculate_turnaround(project)
-          create_or_update_metric(project.id, Project.name, metric_interval,
-                                  turnaround, :merge_time)
+        metrics_per_project.each do |project_id, merge_times_value|
+          create_or_update_metric(project_id, Project.name, merge_time_interval,
+                                  merge_times_value, :merge_time)
         end
       end
 
-      def filtered_projects
-        Project.includes(:pull_requests).where(pull_requests: { merged_at: metric_interval })
+      def metrics_per_project
+        Project.joins(pull_requests: :merge_time)
+               .where(merge_times: { created_at: merge_time_interval })
+               .group(:id)
+               .pluck(:id, Arel.sql('AVG(merge_times.value)'))
       end
 
-      def pull_requests_count
-        @pull_requests_count ||= Project.joins(:pull_requests).group(:id).count('pull_requests.id')
-      end
-
-      def calculate_turnaround(project)
-        total = project.pull_requests.inject(0) do |sum, pr|
-          sum + (pr.merged_at.to_i - pr.opened_at.to_i)
-        end
-        total / pull_requests_count.fetch(project.id)
-      end
-
-      def metric_interval
-        @metric_interval ||= @interval || Time.zone.today.all_day
+      def merge_time_interval
+        @merge_time_interval ||= @interval || Time.zone.today.all_day
       end
     end
   end

--- a/app/services/metrics/merge_time/per_project.rb
+++ b/app/services/metrics/merge_time/per_project.rb
@@ -12,7 +12,7 @@ module Metrics
 
       def metrics_per_project
         Project.joins(pull_requests: :merge_time)
-               .where(merge_times: { created_at: merge_time_interval })
+               .where(pull_requests: { merged_at: merge_time_interval })
                .group(:id)
                .pluck(:id, Arel.sql('AVG(merge_times.value)'))
       end

--- a/app/services/metrics/merge_time/per_user_project.rb
+++ b/app/services/metrics/merge_time/per_user_project.rb
@@ -21,7 +21,7 @@ module Metrics
 
       def filtered_merge_times
         ::MergeTime.joins(:pull_request)
-                   .where(created_at: merge_time_interval)
+                   .where(pull_requests: { merged_at: merge_time_interval })
                    .group(:project_id, :owner_id)
                    .pluck(:project_id, :owner_id, Arel.sql('AVG(merge_times.value)'))
       end

--- a/app/services/metrics/merge_time/per_user_project.rb
+++ b/app/services/metrics/merge_time/per_user_project.rb
@@ -5,17 +5,11 @@ module Metrics
 
       def process
         ActiveRecord::Base.transaction do
-          merge_times_in_batches do |project_id, owner_id, merge_time_value|
+          filtered_merge_times.each do |project_id, owner_id, merge_time_value|
             entity = find_user_project(owner_id, project_id)
             create_or_update_metric(entity.id, UsersProject.name,
                                     merge_time_interval, merge_time_value, :merge_time)
           end
-        end
-      end
-
-      def merge_times_in_batches
-        filtered_merge_times.each do |project_id, owner_id, merge_time_value|
-          yield(project_id, owner_id, merge_time_value)
         end
       end
 

--- a/app/services/metrics/merge_time/per_user_project.rb
+++ b/app/services/metrics/merge_time/per_user_project.rb
@@ -1,42 +1,38 @@
 module Metrics
   module MergeTime
     class PerUserProject < Metrics::BaseDevelopmentMetrics
-      BATCH_SIZE = 500
-
       private
 
       def process
         ActiveRecord::Base.transaction do
-          entities = Hash.new(0)
-          pull_requests_in_batches do |pull_request|
-            entity = find_user_project(pull_request.owner, pull_request.project)
-            entities[entity] += 1
-            merge_time = calculate_merge_time(pull_request)
-
+          merge_times_in_batches do |project_id, owner_id, merge_time_value|
+            entity = find_user_project(owner_id, project_id)
             create_or_update_metric(entity.id, UsersProject.name,
-                                    metric_interval, merge_time, :merge_time)
+                                    merge_time_interval, merge_time_value, :merge_time)
           end
-          calculate_metrics_avg(entities, :merge_time)
         end
       end
 
-      def pull_requests_in_batches
-        filtered_pull_requests.find_each(batch_size: BATCH_SIZE).lazy.each do |pull_request|
-          yield(pull_request)
+      def merge_times_in_batches
+        filtered_merge_times.each do |project_id, owner_id, merge_time_value|
+          yield(project_id, owner_id, merge_time_value)
         end
       end
 
-      def filtered_pull_requests
-        Events::PullRequest.includes(:project, owner: :users_projects)
-                           .where(merged_at: metric_interval)
+      def filtered_merge_times
+        ::MergeTime.joins(:pull_request)
+                   .where(created_at: merge_time_interval)
+                   .group(:project_id, :owner_id)
+                   .pluck(:project_id, :owner_id, Arel.sql('AVG(merge_times.value)'))
       end
 
-      def calculate_merge_time(pull_request)
-        pull_request.merged_at.to_i - pull_request.opened_at.to_i
+      def merge_time_interval
+        @merge_time_interval ||= @interval || Time.zone.today.all_day
       end
 
-      def metric_interval
-        @metric_interval ||= @interval || Time.zone.today.all_day
+      def find_user_project(user_id, project_id)
+        user = User.find(user_id)
+        user.users_projects.detect { |user_project| user_project.project_id == project_id }
       end
     end
   end

--- a/spec/services/metrics/merge_time/per_department_spec.rb
+++ b/spec/services/metrics/merge_time/per_department_spec.rb
@@ -2,44 +2,90 @@ require 'rails_helper'
 
 RSpec.describe Metrics::MergeTime::PerDepartment do
   describe '.call' do
-    before { travel_to(Time.zone.today.beginning_of_day) }
+    before { travel_to(Time.zone.today.end_of_day) }
 
     let(:ruby_lang)  { Language.find_by(name: 'ruby')  }
     let(:react_lang) { Language.find_by(name: 'react') }
     let!(:first_project)  { create(:project, language: ruby_lang)  }
     let!(:second_project) { create(:project, language: react_lang) }
 
-    context 'when there are two project metrics from different departments' do
+    context 'when there are two merged pull request from different departments' do
+      let!(:first_project_pull_request) do
+        create(:pull_request,
+               project: first_project,
+               opened_at: Time.zone.today.beginning_of_day)
+      end
+
+      let!(:second_project_pull_request) do
+        create(:pull_request,
+               project: second_project,
+               opened_at: Time.zone.today.beginning_of_day)
+      end
+
       before do
-        create(:metric, value: 30.minutes, ownable: first_project, name: :merge_time)
-        create(:metric, value: 25.minutes, ownable: second_project, name: :merge_time)
+        first_project_pull_request.update!(merged_at: Time.zone.today.beginning_of_day + 1.hour)
+        second_project_pull_request.update!(merged_at: Time.zone.today.beginning_of_day + 2.hours)
       end
 
       it 'creates two metrics' do
-        expect { described_class.call }.to change { Metric.count }.from(2).to(4)
+        expect { described_class.call }.to change { Metric.count }.from(0).to(2)
       end
 
-      it 'should has value of 30 minutes' do
+      it 'saves one hour as value for merge time metric in backend department ' do
         described_class.call
-        expect(Metric.third.value.seconds).to eq(30.minutes)
+        expect(Metric.first.value.seconds).to eq(1.hour)
+      end
+
+      it 'saves two hours as value for merge time metric in frontend department ' do
+        described_class.call
+        expect(Metric.second.value.seconds).to eq(2.hours)
       end
     end
 
     context 'when there are two project metrics per department' do
+      let!(:first_pull_first_project) do
+        create(:pull_request,
+               project: first_project,
+               opened_at: Time.zone.today.beginning_of_day)
+      end
+
+      let!(:second_pull_first_project) do
+        create(:pull_request,
+               project: first_project,
+               opened_at: Time.zone.today.beginning_of_day)
+      end
+
+      let!(:first_pull_second_project) do
+        create(:pull_request,
+               project: second_project,
+               opened_at: Time.zone.today.beginning_of_day)
+      end
+
+      let!(:second_pull_second_project) do
+        create(:pull_request,
+               project: second_project,
+               opened_at: Time.zone.today.beginning_of_day)
+      end
+
       before do
-        create(:metric, value: 15.minutes, ownable: first_project, name: :merge_time)
-        create(:metric, value: 25.minutes, ownable: first_project, name: :merge_time)
-        create(:metric, value: 45.minutes, ownable: second_project, name: :merge_time)
-        create(:metric, value: 15.minutes, ownable: second_project, name: :merge_time)
+        first_pull_first_project.update!(merged_at: Time.zone.today.beginning_of_day + 30.minutes)
+        second_pull_first_project.update!(merged_at: Time.zone.today.beginning_of_day + 50.minutes)
+        first_pull_second_project.update!(merged_at: Time.zone.today.beginning_of_day + 10.minutes)
+        second_pull_second_project.update!(merged_at: Time.zone.today.beginning_of_day + 2.hours)
       end
 
       it 'creates two metrics' do
-        expect { described_class.call }.to change { Metric.count }.from(4).to(6)
+        expect { described_class.call }.to change { Metric.count }.by(2)
       end
 
-      it 'should has value of 20 minutes' do
+      it 'saves forty minutes as average for merge time backend department' do
         described_class.call
-        expect(Metric.fifth.value.seconds).to eq(20.minutes)
+        expect(Metric.first.value.seconds).to eq(40.minutes)
+      end
+
+      it 'saves sixty five minutes as average for merge time backend department' do
+        described_class.call
+        expect(Metric.second.value.seconds).to eq(65.minutes)
       end
     end
   end

--- a/spec/services/metrics/merge_time/per_department_spec.rb
+++ b/spec/services/metrics/merge_time/per_department_spec.rb
@@ -4,41 +4,44 @@ RSpec.describe Metrics::MergeTime::PerDepartment do
   describe '.call' do
     before { travel_to(Time.zone.today.end_of_day) }
 
+    let(:backend_department) { ruby_lang.department }
+    let(:frontend_department) { react_lang.department }
     let(:ruby_lang)  { Language.find_by(name: 'ruby')  }
     let(:react_lang) { Language.find_by(name: 'react') }
     let!(:first_project)  { create(:project, language: ruby_lang)  }
     let!(:second_project) { create(:project, language: react_lang) }
+    let(:beginning_of_day) { Time.zone.today.beginning_of_day }
 
     context 'when there are two merged pull request from different departments' do
       let!(:first_project_pull_request) do
         create(:pull_request,
                project: first_project,
-               opened_at: Time.zone.today.beginning_of_day)
+               opened_at: beginning_of_day)
       end
 
       let!(:second_project_pull_request) do
         create(:pull_request,
                project: second_project,
-               opened_at: Time.zone.today.beginning_of_day)
+               opened_at: beginning_of_day)
       end
 
       before do
-        first_project_pull_request.update!(merged_at: Time.zone.today.beginning_of_day + 1.hour)
-        second_project_pull_request.update!(merged_at: Time.zone.today.beginning_of_day + 2.hours)
+        first_project_pull_request.update!(merged_at: beginning_of_day + 1.hour)
+        second_project_pull_request.update!(merged_at: beginning_of_day + 2.hours)
       end
 
       it 'creates two metrics' do
         expect { described_class.call }.to change { Metric.count }.from(0).to(2)
       end
 
-      it 'saves one hour as value for merge time metric in backend department ' do
+      it 'saves one hour as value for merge time metric in backend department' do
         described_class.call
-        expect(Metric.first.value.seconds).to eq(1.hour)
+        expect(backend_department.metrics.first.value.seconds).to eq(1.hour)
       end
 
-      it 'saves two hours as value for merge time metric in frontend department ' do
+      it 'saves two hours as value for merge time metric in frontend department' do
         described_class.call
-        expect(Metric.second.value.seconds).to eq(2.hours)
+        expect(frontend_department.metrics.first.value.seconds).to eq(2.hours)
       end
     end
 
@@ -46,32 +49,32 @@ RSpec.describe Metrics::MergeTime::PerDepartment do
       let!(:first_pull_first_project) do
         create(:pull_request,
                project: first_project,
-               opened_at: Time.zone.today.beginning_of_day)
+               opened_at: beginning_of_day)
       end
 
       let!(:second_pull_first_project) do
         create(:pull_request,
                project: first_project,
-               opened_at: Time.zone.today.beginning_of_day)
+               opened_at: beginning_of_day)
       end
 
       let!(:first_pull_second_project) do
         create(:pull_request,
                project: second_project,
-               opened_at: Time.zone.today.beginning_of_day)
+               opened_at: beginning_of_day)
       end
 
       let!(:second_pull_second_project) do
         create(:pull_request,
                project: second_project,
-               opened_at: Time.zone.today.beginning_of_day)
+               opened_at: beginning_of_day)
       end
 
       before do
-        first_pull_first_project.update!(merged_at: Time.zone.today.beginning_of_day + 30.minutes)
-        second_pull_first_project.update!(merged_at: Time.zone.today.beginning_of_day + 50.minutes)
-        first_pull_second_project.update!(merged_at: Time.zone.today.beginning_of_day + 10.minutes)
-        second_pull_second_project.update!(merged_at: Time.zone.today.beginning_of_day + 2.hours)
+        first_pull_first_project.update!(merged_at: beginning_of_day + 30.minutes)
+        second_pull_first_project.update!(merged_at: beginning_of_day + 50.minutes)
+        first_pull_second_project.update!(merged_at: beginning_of_day + 10.minutes)
+        second_pull_second_project.update!(merged_at: beginning_of_day + 2.hours)
       end
 
       it 'creates two metrics' do
@@ -80,12 +83,12 @@ RSpec.describe Metrics::MergeTime::PerDepartment do
 
       it 'saves forty minutes as average for merge time backend department' do
         described_class.call
-        expect(Metric.first.value.seconds).to eq(40.minutes)
+        expect(backend_department.metrics.first.value.seconds).to eq(40.minutes)
       end
 
-      it 'saves sixty five minutes as average for merge time backend department' do
+      it 'saves sixty five minutes as average for merge time frontend department' do
         described_class.call
-        expect(Metric.second.value.seconds).to eq(65.minutes)
+        expect(frontend_department.metrics.first.value.seconds).to eq(65.minutes)
       end
     end
   end

--- a/spec/services/metrics/merge_time/per_language_spec.rb
+++ b/spec/services/metrics/merge_time/per_language_spec.rb
@@ -2,44 +2,90 @@ require 'rails_helper'
 
 RSpec.describe Metrics::MergeTime::PerLanguage do
   describe '.call' do
-    before { travel_to(Time.zone.today.beginning_of_day) }
+    before { travel_to(Time.zone.today.end_of_day) }
 
     let(:ruby_lang)  { Language.find_by(name: 'ruby')  }
     let(:react_lang) { Language.find_by(name: 'react') }
     let!(:first_project)  { create(:project, language: ruby_lang)  }
     let!(:second_project) { create(:project, language: react_lang) }
 
-    context 'when there are two project metrics with different languages' do
+    context 'when there are two merged pull request with different languages' do
+      let!(:first_project_pull_request) do
+        create(:pull_request,
+               project: first_project,
+               opened_at: Time.zone.today.beginning_of_day)
+      end
+
+      let!(:second_project_pull_request) do
+        create(:pull_request,
+               project: second_project,
+               opened_at: Time.zone.today.beginning_of_day)
+      end
+
       before do
-        create(:metric, value: 30.minutes, ownable: first_project, name: :merge_time)
-        create(:metric, value: 25.minutes, ownable: second_project, name: :merge_time)
+        first_project_pull_request.update!(merged_at: Time.zone.today.beginning_of_day + 1.hour)
+        second_project_pull_request.update!(merged_at: Time.zone.today.beginning_of_day + 2.hours)
       end
 
       it 'creates two metrics' do
-        expect { described_class.call }.to change { Metric.count }.from(2).to(4)
+        expect { described_class.call }.to change { Metric.count }.by(2)
       end
 
-      it 'should has value of 30 minutes' do
+      it 'saves one hour as value for merge time metric in backend language' do
         described_class.call
-        expect(Metric.third.value.seconds).to eq(30.minutes)
+        expect(Metric.first.value.seconds).to eq(1.hour)
+      end
+
+      it 'saves two hours as value for merge time metric in frontend language' do
+        described_class.call
+        expect(Metric.second.value.seconds).to eq(2.hours)
       end
     end
 
     context 'when there are two project metrics per language' do
+      let!(:first_pull_first_project) do
+        create(:pull_request,
+               project: first_project,
+               opened_at: Time.zone.today.beginning_of_day)
+      end
+
+      let!(:second_pull_first_project) do
+        create(:pull_request,
+               project: first_project,
+               opened_at: Time.zone.today.beginning_of_day)
+      end
+
+      let!(:first_pull_second_project) do
+        create(:pull_request,
+               project: second_project,
+               opened_at: Time.zone.today.beginning_of_day)
+      end
+
+      let!(:second_pull_second_project) do
+        create(:pull_request,
+               project: second_project,
+               opened_at: Time.zone.today.beginning_of_day)
+      end
+
       before do
-        create(:metric, value: 15.minutes, ownable: first_project, name: :merge_time)
-        create(:metric, value: 25.minutes, ownable: first_project, name: :merge_time)
-        create(:metric, value: 45.minutes, ownable: second_project, name: :merge_time)
-        create(:metric, value: 15.minutes, ownable: second_project, name: :merge_time)
+        first_pull_first_project.update!(merged_at: Time.zone.today.beginning_of_day + 30.minutes)
+        second_pull_first_project.update!(merged_at: Time.zone.today.beginning_of_day + 50.minutes)
+        first_pull_second_project.update!(merged_at: Time.zone.today.beginning_of_day + 10.minutes)
+        second_pull_second_project.update!(merged_at: Time.zone.today.beginning_of_day + 2.hours)
       end
 
       it 'creates two metrics' do
-        expect { described_class.call }.to change { Metric.count }.from(4).to(6)
+        expect { described_class.call }.to change { Metric.count }.by(2)
       end
 
-      it 'should has value of 20 minutes' do
+      it 'saves forty minutes as average for merge time backend department' do
         described_class.call
-        expect(Metric.fifth.value.seconds).to eq(20.minutes)
+        expect(Metric.first.value.seconds).to eq(40.minutes)
+      end
+
+      it 'saves sixty five minutes as average for merge time backend department' do
+        described_class.call
+        expect(Metric.second.value.seconds).to eq(65.minutes)
       end
     end
   end

--- a/spec/services/metrics/merge_time/per_language_spec.rb
+++ b/spec/services/metrics/merge_time/per_language_spec.rb
@@ -8,37 +8,38 @@ RSpec.describe Metrics::MergeTime::PerLanguage do
     let(:react_lang) { Language.find_by(name: 'react') }
     let!(:first_project)  { create(:project, language: ruby_lang)  }
     let!(:second_project) { create(:project, language: react_lang) }
+    let(:beginning_of_day) { Time.zone.today.beginning_of_day }
 
     context 'when there are two merged pull request with different languages' do
       let!(:first_project_pull_request) do
         create(:pull_request,
                project: first_project,
-               opened_at: Time.zone.today.beginning_of_day)
+               opened_at: beginning_of_day)
       end
 
       let!(:second_project_pull_request) do
         create(:pull_request,
                project: second_project,
-               opened_at: Time.zone.today.beginning_of_day)
+               opened_at: beginning_of_day)
       end
 
       before do
-        first_project_pull_request.update!(merged_at: Time.zone.today.beginning_of_day + 1.hour)
-        second_project_pull_request.update!(merged_at: Time.zone.today.beginning_of_day + 2.hours)
+        first_project_pull_request.update!(merged_at: beginning_of_day + 1.hour)
+        second_project_pull_request.update!(merged_at: beginning_of_day + 2.hours)
       end
 
       it 'creates two metrics' do
         expect { described_class.call }.to change { Metric.count }.by(2)
       end
 
-      it 'saves one hour as value for merge time metric in backend language' do
+      it 'saves one hour as value for merge time metric in ruby language' do
         described_class.call
-        expect(Metric.first.value.seconds).to eq(1.hour)
+        expect(ruby_lang.metrics.first.value.seconds).to eq(1.hour)
       end
 
-      it 'saves two hours as value for merge time metric in frontend language' do
+      it 'saves two hours as value for merge time metric in react language' do
         described_class.call
-        expect(Metric.second.value.seconds).to eq(2.hours)
+        expect(react_lang.metrics.first.value.seconds).to eq(2.hours)
       end
     end
 
@@ -46,46 +47,46 @@ RSpec.describe Metrics::MergeTime::PerLanguage do
       let!(:first_pull_first_project) do
         create(:pull_request,
                project: first_project,
-               opened_at: Time.zone.today.beginning_of_day)
+               opened_at: beginning_of_day)
       end
 
       let!(:second_pull_first_project) do
         create(:pull_request,
                project: first_project,
-               opened_at: Time.zone.today.beginning_of_day)
+               opened_at: beginning_of_day)
       end
 
       let!(:first_pull_second_project) do
         create(:pull_request,
                project: second_project,
-               opened_at: Time.zone.today.beginning_of_day)
+               opened_at: beginning_of_day)
       end
 
       let!(:second_pull_second_project) do
         create(:pull_request,
                project: second_project,
-               opened_at: Time.zone.today.beginning_of_day)
+               opened_at: beginning_of_day)
       end
 
       before do
-        first_pull_first_project.update!(merged_at: Time.zone.today.beginning_of_day + 30.minutes)
-        second_pull_first_project.update!(merged_at: Time.zone.today.beginning_of_day + 50.minutes)
-        first_pull_second_project.update!(merged_at: Time.zone.today.beginning_of_day + 10.minutes)
-        second_pull_second_project.update!(merged_at: Time.zone.today.beginning_of_day + 2.hours)
+        first_pull_first_project.update!(merged_at: beginning_of_day + 30.minutes)
+        second_pull_first_project.update!(merged_at: beginning_of_day + 50.minutes)
+        first_pull_second_project.update!(merged_at: beginning_of_day + 10.minutes)
+        second_pull_second_project.update!(merged_at: beginning_of_day + 2.hours)
       end
 
       it 'creates two metrics' do
         expect { described_class.call }.to change { Metric.count }.by(2)
       end
 
-      it 'saves forty minutes as average for merge time backend department' do
+      it 'saves forty minutes as average for merge time ruby department' do
         described_class.call
-        expect(Metric.first.value.seconds).to eq(40.minutes)
+        expect(ruby_lang.metrics.first.value.seconds).to eq(40.minutes)
       end
 
-      it 'saves sixty five minutes as average for merge time backend department' do
+      it 'saves sixty five minutes as average for merge time react department' do
         described_class.call
-        expect(Metric.second.value.seconds).to eq(65.minutes)
+        expect(react_lang.metrics.first.value.seconds).to eq(65.minutes)
       end
     end
   end

--- a/spec/services/metrics/merge_time/per_project_spec.rb
+++ b/spec/services/metrics/merge_time/per_project_spec.rb
@@ -4,96 +4,111 @@ RSpec.describe Metrics::MergeTime::PerProject do
   describe '.call' do
     let(:project) { create(:project) }
     let(:current_time) { Time.zone.now }
+    let(:beginning_of_day) { Time.zone.today.beginning_of_day }
 
     before { travel_to(Time.zone.today.end_of_day) }
 
     context 'when processing a collection containing no pull request events' do
-      it 'does not create a metric' do
+      it 'does not create any metric' do
         expect { described_class.call }.not_to change { Metric.count }
       end
     end
 
-    context 'Generating metrics values' do
-      context 'when a project has 30 minutes of merge time' do
-        let!(:first_pull_request) do
+    context 'when a project has pull requests' do
+      let!(:first_pull_request) do
+        create(:pull_request,
+               state: :open,
+               project_id: project.id,
+               opened_at: beginning_of_day)
+      end
+
+      let!(:second_pull_request) do
+        create(:pull_request,
+               state: :open,
+               project_id: project.id,
+               opened_at: beginning_of_day)
+      end
+
+      before do
+        first_pull_request.update!(merged_at: beginning_of_day + 20.minutes)
+        second_pull_request.update!(merged_at: beginning_of_day + 40.minutes)
+      end
+
+      it 'generates a metric with the average value of each pull request merge times' do
+        described_class.call
+        expect(Metric.first.value.seconds).to eq(30.minutes)
+      end
+
+      it 'generates only that metric' do
+        expect { described_class.call }.to change { Metric.count }.from(0).to(1)
+      end
+
+      context 'having some pull requests still open' do
+        let!(:open_pull_request) do
           create(:pull_request,
                  state: :open,
                  project_id: project.id,
-                 opened_at: Time.zone.today.beginning_of_day)
+                 opened_at: beginning_of_day)
         end
 
-        let!(:second_pull_request) do
-          create(:pull_request,
-                 state: :open,
-                 project_id: project.id,
-                 opened_at: Time.zone.today.beginning_of_day)
-        end
-
-        before do
-          first_pull_request.update!(merged_at: Time.zone.today.beginning_of_day + 30.minutes)
-          second_pull_request.update!(merged_at: Time.zone.today.beginning_of_day + 30.minutes)
-        end
-
-        it 'generates a metric with value expressed as decimal equal to 30 minutes' do
+        it 'does not count them' do
           described_class.call
           expect(Metric.first.value.seconds).to eq(30.minutes)
         end
-
-        it 'generates only that metric' do
-          expect { described_class.call }.to change { Metric.count }.from(0).to(1)
-        end
       end
 
-      context 'when there are multiple projects with pull requests' do
-        let(:second_project) { create(:project) }
-
-        let!(:first_pull_request) do
+      context 'having some pull requests merged another day' do
+        let!(:old_pull_request) do
           create(:pull_request,
                  state: :open,
                  project_id: project.id,
-                 opened_at: Time.zone.today.beginning_of_day)
+                 opened_at: beginning_of_day.last_week)
         end
 
-        let!(:second_pull_request) do
-          create(:pull_request,
-                 state: :open,
-                 project_id: second_project.id,
-                 opened_at: Time.zone.today.beginning_of_day)
+        before do
+          old_pull_request.update!(merged_at: beginning_of_day.last_week + 10.minutes)
         end
+
+        it 'does not count them' do
+          described_class.call
+          expect(Metric.first.value.seconds).to eq(30.minutes)
+        end
+      end
+
+      context 'when there are more projects with pull requests' do
+        let(:second_project) { create(:project) }
 
         let!(:third_pull_request) do
           create(:pull_request,
                  state: :open,
-                 project_id: project.id,
-                 opened_at: Time.zone.today.beginning_of_day)
+                 project_id: second_project.id,
+                 opened_at: beginning_of_day)
         end
 
         let!(:fourth_pull_request) do
           create(:pull_request,
                  state: :open,
                  project_id: second_project.id,
-                 opened_at: Time.zone.today.beginning_of_day)
+                 opened_at: beginning_of_day)
         end
 
         before do
-          first_pull_request.update!(merged_at: Time.zone.today.beginning_of_day + 30.minutes)
-          second_pull_request.update!(merged_at: Time.zone.today.beginning_of_day + 30.minutes)
-          third_pull_request.update!(merged_at: Time.zone.today.beginning_of_day + 30.minutes)
-          fourth_pull_request.update!(merged_at: Time.zone.today.beginning_of_day + 30.minutes)
+          third_pull_request.update!(merged_at: beginning_of_day + 30.minutes)
+          fourth_pull_request.update!(merged_at: beginning_of_day + 50.minutes)
         end
 
         it 'creates two metrics' do
           expect { described_class.call }.to change { Metric.count }.by(2)
         end
 
-        it 'saves thirty minutes as value for first project' do
+        it 'correctly generates the metric for the first project' do
           described_class.call
-          expect(Metric.first.value.seconds).to eq(30.minutes)
+          expect(project.metrics.first.value.seconds).to eq(30.minutes)
         end
 
-        it 'saves thirty minutes as value for first project' do
+        it 'correctly generates the metric for the second project' do
           described_class.call
-          expect(Metric.second.value.seconds).to eq(30.minutes)
+          expect(second_project.metrics.first.value.seconds).to eq(40.minutes)
         end
       end
     end

--- a/spec/services/metrics/merge_time/per_user_project_spec.rb
+++ b/spec/services/metrics/merge_time/per_user_project_spec.rb
@@ -9,23 +9,24 @@ RSpec.describe Metrics::MergeTime::PerUserProject do
                             owner_id: user_project.user_id)
     end
 
-    before { travel_to(Time.zone.today.beginning_of_day) }
+    before { travel_to(Time.zone.today.end_of_day) }
 
-    context 'when processing a collection containing no pull request events' do
+    context 'when processing a collection containing no merged pull requests' do
       it 'does not create a metric' do
         expect { described_class.call }.not_to change { Metric.count }
       end
     end
 
     context 'when the user has pull requests in one project' do
-      context 'when merge ocurred in a 30 minutes interval' do
+      context 'and the merge ocurred in a 30 minutes interval' do
         let!(:pull_request) do
           create(:pull_request,
-                 opened_at: Time.zone.now,
-                 merged_at: Time.zone.now + 30.minutes,
+                 opened_at: Time.zone.today.beginning_of_day,
                  project_id: user_project.project_id,
                  owner_id: user_project.user_id)
         end
+
+        before { pull_request.update(merged_at: Time.zone.today.beginning_of_day + 30.minutes) }
 
         it 'generates a metric with value expressed as decimal equal to 30 minutes' do
           described_class.call
@@ -41,26 +42,29 @@ RSpec.describe Metrics::MergeTime::PerUserProject do
         context 'and a user made more than one pull request' do
           let!(:pull_request) do
             create(:pull_request,
-                   opened_at: Time.zone.now,
-                   merged_at: Time.zone.now + 30.minutes,
+                   opened_at: Time.zone.today.beginning_of_day,
                    project_id: user_project.project_id,
                    owner_id: user_project.user_id)
           end
 
           let!(:second_pull_request) do
             create(:pull_request,
-                   opened_at: Time.zone.now,
-                   merged_at: Time.zone.now + 45.minutes,
+                   opened_at: Time.zone.today.beginning_of_day,
                    project_id: user_project.project_id,
                    owner_id: user_project.user_id)
           end
 
           let!(:third_pull_request) do
             create(:pull_request,
-                   opened_at: Time.zone.now,
-                   merged_at: Time.zone.now + 2.hours,
+                   opened_at: Time.zone.today.beginning_of_day,
                    project_id: user_project.project_id,
                    owner_id: user_project.user_id)
+          end
+
+          before do
+            pull_request.update!(merged_at: Time.zone.today.beginning_of_day + 30.minutes)
+            second_pull_request.update!(merged_at: Time.zone.today.beginning_of_day + 45.minutes)
+            third_pull_request.update!(merged_at: Time.zone.today.beginning_of_day + 2.hours)
           end
 
           it 'creates just one metric' do
@@ -75,49 +79,54 @@ RSpec.describe Metrics::MergeTime::PerUserProject do
       end
     end
 
-    context 'when a user has pull requests in more than one project' do
+    context 'when a user has merged pull requests in more than one project' do
       let(:same_user_for_second_project) { create(:users_project, user_id: user_project.user_id) }
 
       let!(:pull_request) do
         create(:pull_request,
-               opened_at: Time.zone.now,
-               merged_at: Time.zone.now + 30.minutes,
+               opened_at: Time.zone.today.beginning_of_day,
                project_id: user_project.project_id,
                owner_id: user_project.user_id)
       end
 
       let!(:second_pull_request) do
         create(:pull_request,
-               opened_at: Time.zone.now,
-               merged_at: Time.zone.now + 2.hours,
+               opened_at: Time.zone.today.beginning_of_day,
                project_id: same_user_for_second_project.project_id,
                owner_id: user_project.user_id)
       end
 
-      before { described_class.call }
+      before do
+        pull_request.update!(merged_at: Time.zone.today.beginning_of_day + 30.minutes)
+        second_pull_request.update!(merged_at: Time.zone.today.beginning_of_day + 2.hours)
+      end
 
       it 'it generates the metric for the first project' do
+        described_class.call
         expect(Metric.first.value.seconds).to eq(30.minutes)
       end
 
       it 'it generates the metric for the second project' do
+        described_class.call
         expect(Metric.second.value.seconds).to eq(2.hours)
+      end
+
+      it 'creates two metrics' do
+        expect { described_class.call }.to change { Metric.count }.from(0).to(2)
       end
     end
 
     context 'when has a pull request in another project' do
       let!(:pull_request) do
         create(:pull_request,
-               opened_at: Time.zone.now,
-               merged_at: Time.zone.now + 15.minutes,
+               opened_at: Time.zone.today.beginning_of_day,
                project_id: user_project.project_id,
                owner_id: user_project.user_id)
       end
 
       let!(:second_pull_request) do
         create(:pull_request,
-               opened_at: Time.zone.now,
-               merged_at: Time.zone.now + 25.minutes,
+               opened_at: Time.zone.today.beginning_of_day,
                project_id: user_project.project_id,
                owner_id: user_project.user_id)
       end
@@ -128,20 +137,29 @@ RSpec.describe Metrics::MergeTime::PerUserProject do
 
       let!(:third_pull_request) do
         create(:pull_request,
-               opened_at: Time.zone.now,
-               merged_at: Time.zone.now + 20.minutes,
+               opened_at: Time.zone.today.beginning_of_day,
                project_id: second_user_project.project_id,
                owner_id: user_project.user_id)
+      end
+
+      before do
+        pull_request.update!(merged_at: Time.zone.today.beginning_of_day + 20.minutes)
+        second_pull_request.update!(merged_at: Time.zone.today.beginning_of_day + 30.minutes)
+        third_pull_request.update!(merged_at: Time.zone.today.beginning_of_day + 20.minutes)
       end
 
       it 'generates two metrics' do
         expect { described_class.call }.to change { Metric.count }.from(0).to(2)
       end
 
-      it 'calculates average' do
+      it 'generates a metric with 25 minutes as value' do
         described_class.call
-        metric = Metric.find_by!(ownable: user_project)
-        expect(metric.value).to eq(20.minutes)
+        expect(Metric.first.value.seconds).to eq(25.minutes)
+      end
+
+      it 'generates a second metric with 20 minutes as value' do
+        described_class.call
+        expect(Metric.second.value.seconds).to eq(20.minutes)
       end
     end
 
@@ -152,10 +170,14 @@ RSpec.describe Metrics::MergeTime::PerUserProject do
 
       let!(:review_with_invalid_user_project) do
         create(:pull_request,
-               opened_at: Time.zone.now,
-               merged_at: Time.zone.now + 20.minutes,
+               opened_at: Time.zone.today.beginning_of_day,
                project_id: second_user_project.project_id,
                owner_id: user_project.user_id)
+      end
+
+      before do
+        review_with_invalid_user_project
+          .update(merged_at: Time.zone.today.beginning_of_day + 20.minutes)
       end
 
       it 'creates one metric and then rollbacks the transaction' do


### PR DESCRIPTION
## What does this PR do?
It uses MergeTime model as parameter to calculate metrics for every entity. This fixes the merge time average metrics bug. 

## Hosward notes
* this branch was initially created to resolve the issue for week metrics values but i could not finish it
* the main idea was to refactor the calculation because i thought the independency between de distribution and the metric calculation was the problem but it was not.
* after the refactor all the information i collected is in this [Jira](https://rootstrap.atlassian.net/browse/EM-155), i hope it be helpful