### PR TITLE
Fix/EM 170 nil exception

### DIFF
--- a/app/services/action_handlers/pull_request.rb
+++ b/app/services/action_handlers/pull_request.rb
@@ -31,15 +31,21 @@ module ActionHandlers
     end
 
     def review_request_removed
+      validate_requested_team!
+
       removed_reviewer = find_or_create_user(@payload['requested_reviewer'])
       @entity.review_requests.find_by(reviewer: removed_reviewer, state: 'active')
                              &.removed!
     end
 
     def review_requested
-      raise PullRequests::RequestTeamAsReviewerError if @payload['requested_team']
+      validate_requested_team!
 
       Builders::ReviewRequest.call(@entity, @payload)
+    end
+
+    def validate_requested_team!
+      raise PullRequests::RequestTeamAsReviewerError if @payload['requested_team']
     end
   end
 end

--- a/app/services/action_handlers/pull_request.rb
+++ b/app/services/action_handlers/pull_request.rb
@@ -31,7 +31,7 @@ module ActionHandlers
     end
 
     def review_request_removed
-      validate_requested_team!
+      validate_requested_team
 
       removed_reviewer = find_or_create_user(@payload['requested_reviewer'])
       @entity.review_requests.find_by(reviewer: removed_reviewer, state: 'active')
@@ -39,12 +39,12 @@ module ActionHandlers
     end
 
     def review_requested
-      validate_requested_team!
+      validate_requested_team
 
       Builders::ReviewRequest.call(@entity, @payload)
     end
 
-    def validate_requested_team!
+    def validate_requested_team
       raise PullRequests::RequestTeamAsReviewerError if @payload['requested_team']
     end
   end

--- a/spec/services/github_service_spec.rb
+++ b/spec/services/github_service_spec.rb
@@ -59,13 +59,9 @@ RSpec.describe GithubService do
         end
       end
 
-      describe '#review_request_removed' do
-        let!(:pull_request) { create :pull_request, github_id: payload['pull_request']['id'] }
+      describe 'when the action is review_request_removed' do
         let!(:reviewer) do
           create :user, github_id: payload['requested_reviewer']['id']
-        end
-        let!(:second_reviewer) do
-          create :user
         end
         let!(:owner) do
           create :user, github_id: payload['pull_request']['user']['id']
@@ -74,13 +70,6 @@ RSpec.describe GithubService do
           create :review_request,
                  owner: owner,
                  reviewer: reviewer,
-                 pull_request: pull_request
-        end
-
-        before do
-          create :review_request,
-                 owner: owner,
-                 reviewer: second_reviewer,
                  pull_request: pull_request
         end
 

--- a/spec/services/github_service_spec.rb
+++ b/spec/services/github_service_spec.rb
@@ -60,6 +60,8 @@ RSpec.describe GithubService do
       end
 
       describe 'when the action is review_request_removed' do
+        let(:action) { 'review_request_removed' }
+
         describe 'with an exiting review_request' do
           let!(:reviewer) do
             create :user, github_id: payload['requested_reviewer']['id']
@@ -75,7 +77,6 @@ RSpec.describe GithubService do
           end
 
           it 'sets state to removed' do
-            change_action_to('review_request_removed')
             subject
             expect(ReviewRequest.where(state: 'removed').count).to eq(1)
           end
@@ -84,7 +85,6 @@ RSpec.describe GithubService do
         describe 'with a missing review_request because the requested reviewer is a team' do
           before do
             payload['requested_team'] = payload.delete('requested_reviewer')
-            change_action_to('review_request_removed')
           end
 
           it 'raises an error' do


### PR DESCRIPTION
## What does this PR do?

It resolves [EM-170](https://rootstrap.atlassian.net/jira/software/projects/EM/boards/42?selectedIssue=EM-170)

### Description

The exception described in EM-170 occurs when an `review_request_removed` event is received and it contains a `requested_team` instead of the expected requested_reviewer

To make it behave like `review_requested` this PR makes `review_request_removed` to raise a RequestTeamAsReviewerError

### Details

- Make `ActionHandlers::PullRequest` to raise a `RequestTeamAsReviewerError` on a `review_request_removed` event with a `requested_team`
- Extract the validation of the presence of the attribute `requested_team` to a `validate_requested_team` method
- Remove unused code from the test
- Test that a `RequestTeamAsReviewerError ` is raised