### PR TITLE
Fix/em 169 validation error

### DIFF
--- a/app/services/builders/pull_request_size.rb
+++ b/app/services/builders/pull_request_size.rb
@@ -20,8 +20,10 @@ module Builders
 
     def create_pull_request_size
       ::PullRequestSize.create!(pull_request: pull_request, value: pull_request_size_value)
-    rescue ::ActiveRecord::RecordInvalid
-      nil
+    rescue ::ActiveRecord::RecordInvalid => exception
+      if exception.message != 'Validation failed: Pull request has already been taken'
+        raise exception
+      end
     end
 
     def update_pull_request_size
@@ -32,10 +34,10 @@ module Builders
     end
 
     def pull_request_size_value
-      @pull_request_size_value ||= calculate_size
+      @pull_request_size_value ||= calculate_pull_request_size
     end
 
-    def calculate_size
+    def calculate_pull_request_size
       PullRequestSizeCalculator.call(pull_request)
     end
   end

--- a/app/services/builders/pull_request_size.rb
+++ b/app/services/builders/pull_request_size.rb
@@ -20,10 +20,14 @@ module Builders
 
     def create_pull_request_size
       ::PullRequestSize.create!(pull_request: pull_request, value: pull_request_size_value)
+    rescue ::ActiveRecord::RecordNotUnique
+      nil
     rescue ::ActiveRecord::RecordInvalid => exception
       if exception.message != 'Validation failed: Pull request has already been taken'
         raise exception
       end
+
+      nil
     end
 
     def update_pull_request_size

--- a/app/services/builders/pull_request_size.rb
+++ b/app/services/builders/pull_request_size.rb
@@ -25,7 +25,7 @@ module Builders
     end
 
     def update_pull_request_size
-      ::PullRequestSize.find_by(pull_request: pull_request).tap do |pull_request_size|
+      ::PullRequestSize.find_by!(pull_request: pull_request).tap do |pull_request_size|
         pull_request_size.value = pull_request_size_value
         pull_request_size.save!
       end

--- a/app/services/builders/pull_request_size.rb
+++ b/app/services/builders/pull_request_size.rb
@@ -5,9 +5,9 @@ module Builders
     end
 
     def call
-      ::PullRequestSize.find_or_initialize_by(pull_request: pull_request).tap do |pr_size|
-        pr_size.value = calculate_size
-        pr_size.save!
+      ::PullRequestSize.find_or_initialize_by(pull_request: pull_request).tap do |pull_request_size|
+        pull_request_size.value = calculate_size
+        pull_request_size.save!
       end
     rescue Faraday::Error => exception
       ExceptionHunter.track(exception)

--- a/spec/services/builders/pull_request_size_spec.rb
+++ b/spec/services/builders/pull_request_size_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.describe Builders::PullRequestSize do
   describe '.call' do
     let(:pull_request) { create(:pull_request) }
+    let(:called_pull_request_size) { described_class.call(pull_request) }
 
     context 'when the request to get the PR files fails' do
       let(:total_additions) { 500 }
@@ -14,13 +15,13 @@ RSpec.describe Builders::PullRequestSize do
 
       context 'when there is no pull request size created' do
         it 'creates a new one' do
-          expect { described_class.call(pull_request) }
+          expect { called_pull_request_size }
             .to change { PullRequestSize.count }
             .by(1)
         end
 
         it 'assigns the correct value to it' do
-          expect(described_class.call(pull_request).value).to eq total_additions
+          expect(called_pull_request_size.value).to eq total_additions
         end
       end
 
@@ -31,19 +32,19 @@ RSpec.describe Builders::PullRequestSize do
         end
 
         it 'does not create a new one' do
-          expect { described_class.call(pull_request) }
+          expect { called_pull_request_size }
             .not_to change { PullRequestSize.count }
         end
 
         it 'returns it' do
-          expect(described_class.call(pull_request)).to eq pull_request_size
+          expect(called_pull_request_size).to eq pull_request_size
         end
 
         context 'and has an outdated value' do
           let(:previous_value) { 1 }
 
           it 'updates it' do
-            expect(described_class.call(pull_request).value).to eq total_additions
+            expect(called_pull_request_size.value).to eq total_additions
           end
         end
       end
@@ -55,7 +56,7 @@ RSpec.describe Builders::PullRequestSize do
       it 'notifies the error to exception hunter' do
         expect(ExceptionHunter).to receive(:track).with(kind_of(Faraday::Error))
 
-        described_class.call(pull_request)
+        called_pull_request_size
       end
     end
   end


### PR DESCRIPTION
## What does this PR do?

It addresses [EM-169 - ActiveRecord::RecordNotUnique in pull_request_size](https://rootstrap.atlassian.net/browse/EM-169)

## Description

[ExceptionHunter](http://engineering-metrics.herokuapp.com/exception_hunter/errors/4) reported the error `ActiveRecord::RecordNotUnique` during the execution of PullRequestSize.call

The source of the error may be 2 concurrent processes making an update on the same pull request at the same time as shown in
```ruby
::PullRequestSize.find_or_initialize_by(pull_request: pull_request).tap do |pr_size|		         
  pr_size.value = calculate_size
  # --> another process creates a PullRequestSize record at this point <--
  pr_size.save! # <-- this save fails because of the unique pull_request_id constraint
end
```

The simplest solution seems to split the create_or_update into 2 different operations

```ruby
def update_or_create_pull_request_size
  create_pull_request_size || update_pull_request_size
end
```

where the create_pull_request_size is almost atomic and in the case if fails because the record already exists the update is executed

## Details
- Split `find_or_initialize_by` into an atomic `create` or a `find_by / save!` to avoid concurrency of creation and update
- Refactor - Extract duplicated code in pull_request_size_spec.rb