### PR TITLE
[EM-174] Update pull request size when base branch changes

### DIFF
--- a/app/services/action_handlers/pull_request.rb
+++ b/app/services/action_handlers/pull_request.rb
@@ -1,7 +1,7 @@
 module ActionHandlers
   class PullRequest < ActionHandler
     ACTIONS = %w[open review_requested closed \
-                 review_request_removed].freeze
+                 review_request_removed edited].freeze
     private_constant :ACTIONS
 
     private
@@ -28,6 +28,10 @@ module ActionHandlers
 
       @entity.closed!
       @entity.update!(closed_at: Time.current)
+    end
+
+    def edited
+      Builders::PullRequestSize.call(@entity) if @payload['changes']['base'].present?
     end
 
     def review_request_removed

--- a/spec/factories/payloads/pull_request.rb
+++ b/spec/factories/payloads/pull_request.rb
@@ -40,6 +40,34 @@ FactoryBot.define do
     end
     initialize_with { attributes.deep_stringify_keys }
 
+    trait :edited do
+      transient do
+        changed { 'title' }
+        from { 'Old PR Title' }
+      end
+
+      action { 'edited' }
+      changes do
+        {
+          changed => {
+            from: from
+          }
+        }
+      end
+    end
+
+    trait :edited_base do
+      action { 'edited' }
+      changes do
+        {
+          base: {
+            ref: { from: 'old_branch_name' },
+            sha: { from: Faker::Crypto.sha1 }
+          }
+        }
+      end
+    end
+
     factory :full_pull_request_payload do
       after(:build) do |pull_request_payload|
         pull_request_payload['repository'] = create(:repository_payload)


### PR DESCRIPTION
## What does this PR do?
It updates the value of the PR size metric every time the base branch of the PR changes.

Resolves [#174](https://rootstrap.atlassian.net/browse/EM-174)
