### PR TITLE
Enhancement/split into different jobs

### DIFF
--- a/app/jobs/external_pull_requests_processor_job.rb
+++ b/app/jobs/external_pull_requests_processor_job.rb
@@ -1,0 +1,7 @@
+class ExternalPullRequestsProcessorJob < ApplicationJob
+  queue_as :default
+
+  def perform(username)
+    Processors::External::PullRequests.call(username)
+  end
+end

--- a/app/services/processors/external/contributions.rb
+++ b/app/services/processors/external/contributions.rb
@@ -3,7 +3,7 @@ module Processors
     class Contributions < BaseService
       def call
         usernames.each do |username|
-          Processors::External::PullRequests.call(username)
+          ExternalPullRequestsProcessorJob.perform_later(username)
         end
       end
 

--- a/spec/jobs/external_pull_requests_processor_job_spec.rb
+++ b/spec/jobs/external_pull_requests_processor_job_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+RSpec.describe ExternalPullRequestsProcessorJob do
+  it 'executes external contributions processor' do
+    expect(Processors::External::PullRequests).to receive(:call).with('someuser')
+
+    described_class.perform_now('someuser')
+  end
+
+  let!(:user) { create(:user, login: 'hvilloria') }
+
+  context 'when there are repos for the given username' do
+    let!(:pull_requests_events_payload) do
+      create(:gitub_api_client_pull_requests_events_payload, actor: { login: user.login })
+    end
+
+    before do
+      stub_get_pull_requests_events(user.login, pull_requests_events_payload)
+    end
+
+    it 'saves the repository' do
+      expect { described_class.perform_now('hvilloria') }
+        .to change { ExternalProject.count }.by(1)
+    end
+
+    it 'saves the pull request for that user' do
+      expect { described_class.perform_now('hvilloria') }
+        .to change { ExternalPullRequest.count }.by(1)
+    end
+  end
+
+  context 'when there are no repos for the given username' do
+    before do
+      stub_get_pull_requests_events(user.login)
+    end
+
+    it 'does not save any project' do
+      expect { described_class.perform_now('hvilloria') }
+        .not_to change { ExternalPullRequest.count }
+    end
+
+    it 'does not save any pull request' do
+      expect { described_class.perform_now('hvilloria') }
+        .not_to change { ExternalPullRequest.count }
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -40,6 +40,8 @@ end
 
 RSpec.configure do |config|
   include ActionHelper
+  include ActiveJob::TestHelper
+
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
 


### PR DESCRIPTION
This way the recollection of external contributions wont be interrupted if some user fail for some reason