### PR TITLE
break does not accumulate results

### DIFF
--- a/app/services/github_client/user.rb
+++ b/app/services/github_client/user.rb
@@ -9,7 +9,7 @@ module GithubClient
     def pull_request_events
       events = retrieve_events
 
-      events.select { |event| event[:type] == 'PullRequestEvent' }
+      events.flatten.select { |event| event[:type] == 'PullRequestEvent' }
     rescue URI::InvalidURIError => exception
       ExceptionHunter.track(exception)
       []
@@ -18,22 +18,21 @@ module GithubClient
     private
 
     def older_than(created_at)
-      DateTime.parse(created_at) < ENV.fetch('SCHEDULE_EXTERNAL_PULL_REQUESTS', 1).to_i.days.ago
+      DateTime.parse(created_at) < ENV.fetch('SCHEDULE_EXTERNAL_PULL_REQUESTS', 2).to_i.days.ago
     end
 
     def retrieve_events
-      (1..10).flat_map do |page|
+      (1..10).each_with_object([]) do |page, collected_results|
         response = connection.get("/users/#{@username}/events/public") do |request|
           request.params['page'] = page
         end
 
         results = JSON.parse(response.body, symbolize_names: true)
+        collected_results << results
 
         if results.empty? || older_than(results.last[:created_at]) || results.size < PAGE_SIZE
-          break results
+          break collected_results
         end
-
-        results
       end
     end
   end


### PR DESCRIPTION
This PR fix the issue where the pull_contributions_events doesn't accumulate events on the `map` if the `break` line is executed
 