### PR TITLE
removed wordpress get blog endpoint call that was not working

### DIFF
--- a/app/services/processors/blog_posts_updater.rb
+++ b/app/services/processors/blog_posts_updater.rb
@@ -7,7 +7,9 @@ module Processors
         blog_post.slug = blog_post_payload[:slug]
         blog_post.status = blog_post_payload[:status]
         blog_post.url = blog_post_payload[:URL]
-        blog_post.technologies = technologies_for(blog_post)
+        if blog_post.technologies.empty?
+          blog_post.technologies = technologies_for(blog_post_payload)
+        end
 
         blog_post.save!
       end
@@ -23,12 +25,8 @@ module Processors
       @categorizer ||= BlogPostCategorizer.new
     end
 
-    def technologies_for(blog_post)
-      blog_post_payload = wordpress_service.blog_post(blog_post.blog_id)
+    def technologies_for(blog_post_payload)
       categorizer.technologies_for(blog_post_payload)
-    rescue Faraday::Error => exception
-      ExceptionHunter.track(exception)
-      blog_post.technologies
     end
   end
 end

--- a/spec/services/processors/blog_posts_updater_spec.rb
+++ b/spec/services/processors/blog_posts_updater_spec.rb
@@ -28,19 +28,5 @@ RSpec.describe Processors::BlogPostsUpdater do
         end
       end
     end
-
-    context 'when the request to get a blog post full payload fails' do
-      before { stub_failed_blog_post_response(blog_post_payload['ID']) }
-
-      it 'creates the blog post anyway' do
-        expect { subject }.to change(BlogPost, :count).by(1)
-      end
-
-      it 'notifies the error to exception hunter' do
-        expect(ExceptionHunter).to receive(:track).with(kind_of(Faraday::Error))
-
-        subject
-      end
-    end
   end
 end


### PR DESCRIPTION
## What does this PR do?
Tech blog posts count was 0 for some months which have blog posts. That was because BlogPost were loaded without technologies because of an external endpoint failure. We already had that info so that call was removed.



Resolves https://rootstrap.atlassian.net/browse/EM-186
