### PR TITLE
Org Users Updater Job created

### DIFF
--- a/app/jobs/org_users_updater_job.rb
+++ b/app/jobs/org_users_updater_job.rb
@@ -1,0 +1,7 @@
+class OrgUsersUpdaterJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    Processors::OrgUsersUpdater.call
+  end
+end

--- a/app/services/github_client/base.rb
+++ b/app/services/github_client/base.rb
@@ -30,5 +30,27 @@ module GithubClient
         page_number: page_number + 1
       )
     end
+
+    def get_all_members(url, max_per_page, accumulated_users: [], page_number: 1)
+      request_params = {
+        page: page_number,
+        per_page: max_per_page
+      }
+
+      response = connection.get(url) do |request|
+        request.params = request_params
+      end
+
+      new_users = JSON.parse(response.body).map { |user| user['login'] }
+
+      return accumulated_users if new_users.empty?
+
+      get_all_members(
+        url,
+        max_per_page,
+        accumulated_users: accumulated_users + new_users,
+        page_number: page_number + 1
+      )
+    end
   end
 end

--- a/app/services/github_client/organization.rb
+++ b/app/services/github_client/organization.rb
@@ -1,9 +1,14 @@
 module GithubClient
   class Organization < GithubClient::Base
     MAX_REPOSITORIES_PER_PAGE = 100
+    MAX_USERS_PER_PAGE = 30
 
     def repositories
       get_all_paginated_items('orgs/rootstrap/repos', MAX_REPOSITORIES_PER_PAGE)
+    end
+
+    def members
+      get_all_members('/orgs/rootstrap/members', MAX_USERS_PER_PAGE)
     end
   end
 end

--- a/app/services/processors/org_users_updater.rb
+++ b/app/services/processors/org_users_updater.rb
@@ -1,0 +1,14 @@
+module Processors
+  class OrgUsersUpdater < BaseService
+    def call
+      User.where(login: current_members).find_each { |user| user.update(company_member: true) }
+      User.where.not(login: current_members).find_each { |user| user.update(company_member: false) }
+    end
+
+    private
+
+    def current_members
+      @current_members ||= GithubClient::Organization.new.members
+    end
+  end
+end

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -57,3 +57,8 @@ external_contributions_processor:
   cron: '00 5 * * 1-5'
   class: 'ExternalContributionsProcessorJob'
   active_job: true
+
+external_contributions_processor:
+  cron: '0 0 * * 0'
+  class: 'OrgUsersUpdaterJob'
+  active_job: true

--- a/spec/factories/payloads/members.rb
+++ b/spec/factories/payloads/members.rb
@@ -1,0 +1,11 @@
+# Project payload
+FactoryBot.define do
+  factory :members_payload, class: Hash do
+    skip_create
+
+    id { Faker::Number.number(digits: 4) }
+    login { Faker::App.name }
+
+    initialize_with { attributes.deep_stringify_keys }
+  end
+end

--- a/spec/jobs/org_users_updater_job_spec.rb
+++ b/spec/jobs/org_users_updater_job_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+describe OrgUsersUpdaterJob do
+  describe '#perform' do
+    it 'correctly initializes the OrgUsersUpdater processor and calls it' do
+      expect_any_instance_of(Processors::OrgUsersUpdater)
+        .to receive(:call)
+        .once
+
+      described_class.perform_now
+    end
+  end
+end

--- a/spec/services/github_client/organization_spec.rb
+++ b/spec/services/github_client/organization_spec.rb
@@ -25,4 +25,29 @@ RSpec.describe GithubClient::Organization do
       end
     end
   end
+
+  describe '#members' do
+    let(:members_payload) { create(:members_payload) }
+
+    before do
+      stub_organization_members([members_payload])
+    end
+
+    it 'returns rootstrap members' do
+      expect(subject.members).to contain_exactly(members_payload['login'])
+    end
+
+    context 'when there is more than one page of results' do
+      let(:members_payload_2) { create(:members_payload) }
+      let(:members_payloads) { [members_payload, members_payload_2] }
+
+      before do
+        stub_organization_members(members_payloads, results_per_page: 1)
+      end
+
+      it 'returns the members from all pages' do
+        expect(subject.members).to match_array(members_payloads.map { |user| user['login'] })
+      end
+    end
+  end
 end

--- a/spec/services/processors/org_users_updater_spec.rb
+++ b/spec/services/processors/org_users_updater_spec.rb
@@ -1,0 +1,27 @@
+describe Processors::OrgUsersUpdater do
+  subject { Processors::OrgUsersUpdater }
+  let(:update_all_org_users) { subject.call }
+  let(:members_payload) { create(:members_payload) }
+
+  before do
+    stub_organization_members([members_payload])
+  end
+
+  context 'when a non-org user becomes an org member' do
+    let(:user) { create(:user, login: members_payload['login'], company_member: false) }
+
+    it('sets company_member boolean as true') do
+      expect { update_all_org_users }.to change { user.reload.company_member }.from(false).to(true)
+    end
+  end
+
+  context 'when an org user becomes an non-org member' do
+    let(:non_org_user) { create(:user) }
+
+    it('sets company_member boolean as false for that user') do
+      expect { update_all_org_users }.to change {
+        non_org_user.reload.company_member
+      }.from(true).to(false)
+    end
+  end
+end

--- a/spec/support/helpers/github_api_mocker.rb
+++ b/spec/support/helpers/github_api_mocker.rb
@@ -84,6 +84,20 @@ module GithubApiMock
     )
   end
 
+  def stub_organization_members(
+    repository_members,
+    results_per_page: GithubClient::Organization::MAX_USERS_PER_PAGE
+  )
+    url = 'https://api.github.com/orgs/rootstrap/members'
+
+    stub_paginated_items(
+      repository_members,
+      url,
+      results_per_page,
+      GithubClient::Organization::MAX_USERS_PER_PAGE
+    )
+  end
+
   def stub_pull_request_files_with_payload(
     pull_request_payload,
     file_payloads = [create(:pull_request_file_payload)],


### PR DESCRIPTION
## What does this PR do?
Once a week runs a job that pulls current Rootstrap github members and updates `company_member` attribute on `Users` table accordingly. That attribute is already used in a scope when displaying external contribution prs.


Resolves https://rootstrap.atlassian.net/jira/software/projects/EM/boards/42?selectedIssue=EM-189