### PR TITLE
Department overview details

### DIFF
--- a/app/controllers/projects/by_relevance_controller.rb
+++ b/app/controllers/projects/by_relevance_controller.rb
@@ -1,0 +1,22 @@
+module Projects
+  class ByRelevanceController < ApplicationController
+    layout 'sidebar_metrics'
+
+    def index
+      @projects = Builders::Departments::Projects::ByRelevance.call(
+        department: department,
+        from: metric_params[:period].to_i.weeks.ago
+      )
+    end
+
+    private
+
+    def department
+      @department ||= Department.find_by(name: params[:department_name])
+    end
+
+    def metric_params
+      params.require(:metric).permit(:period)
+    end
+  end
+end

--- a/app/services/builders/departments/projects/by_relevance.rb
+++ b/app/services/builders/departments/projects/by_relevance.rb
@@ -1,0 +1,50 @@
+module Builders
+  module Departments
+    module Projects
+      class ByRelevance < BaseService
+        include ModelsNamesHelper
+
+        def initialize(department:, from:)
+          @department = department
+          @from = from
+        end
+
+        def call
+          language_names.each_with_object({}) { |language, overview|
+            overview[language] = language_overview(language)
+          }.with_indifferent_access
+        end
+
+        private
+
+        attr_reader :department, :from
+
+        def language_names
+          all_languages_names(department)
+        end
+
+        def language_overview(language)
+          relevances_overview(language)
+        end
+
+        def relevances_overview(language)
+          project_relevances.index_with do |relevance|
+            ::Project.joins(:language)
+                     .relevant.with_activity_after(from)
+                     .where(relevance: relevance)
+                     .where('languages.name = ?', language)
+                     .distinct
+          end
+        end
+
+        def project_relevances
+          relevances = ::Project.relevances
+          [
+            relevances[:internal],
+            relevances[:commercial]
+          ]
+        end
+      end
+    end
+  end
+end

--- a/app/views/development_metrics/_department_overview.erb
+++ b/app/views/development_metrics/_department_overview.erb
@@ -15,6 +15,12 @@
             <% end %>
           </div>
         <% end %>
+        <div>
+          <%= link_to 'See report',
+                      department_projects_by_relevance_index_path(params[:department_name], { metric: { period: params&.dig(:metric, :period) } }),
+                      class: 'btn btn-secondary'
+          %>
+        </div>
       </div>
     </div>
   </div>

--- a/app/views/projects/by_relevance/index.erb
+++ b/app/views/projects/by_relevance/index.erb
@@ -1,0 +1,57 @@
+<%=  render 'development_metrics/development_metrics_sidebar' %>
+
+<div class="container-fluid">
+  <div class="row">
+    <div class="col-md-10 offset-1">
+      <%= simple_form_for :metric, url: department_projects_by_relevance_index_path, method: 'GET', html: {
+                                                        class: 'nav-filter p-3 shadow-box', id: 'nav-filter-form' } do |f|%>
+            <h4 class="text-center"><%= params[:department_name].capitalize %> Overview</h4>
+            <div class="row justify-content-center mt-3 mb-3">
+              <%= f.input :period,
+                label: 'Last Updated (Weeks)',
+                wrapper_html: { class: 'period-selection d-flex flex-column mb-0 col-md-4' },
+                input_html: { class: 'margin-left input-height', value: chosen_period },
+                required: false,
+                as: :numeric
+              %>
+            </div>
+            <div class="row">
+              <div class="col-md-12 d-flex justify-content-center">
+                <%= f.button :submit, 'Submit', class: 'btn-secondary ml-1', id: 'submitButton' %>
+              </div>
+            </div>
+      <% end %>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-md-10 offset-1 mt-5">
+      <div class="table-responsive">
+        <table class="table table-striped table-bordered table-hover">
+          <tbody>
+            <% @projects.each do |technology,projects_by_relevance| %>
+              <thead class="thead-dark"><th colspan="4">Technology: <%= technology.capitalize %></th></thead>
+              <thead class="thead-light">
+                <th>Relevance</th>
+                <th>Name</th>
+                <th>Is Private</th>
+                <th></th>
+              </thead>
+              <% projects_by_relevance.each do |relevance,projects| %>
+                <% projects.each do |project| %>
+                  <tr>
+                    <td class="align-middle"><%= relevance %></td>
+                    <td class="align-middle"><%= project[:name] %></td>
+                    <td class="align-middle"><%= project[:is_private] %></td>
+                    <td class="align-middle text-center">
+                      <a class="btn btn-primary" href="<%= projects_development_metrics_path({project_name: project[:name], metric: { period: params&.dig(:metric, :period) }}) %>" role="button">See details</a>
+                    </td>
+                  </tr>
+                <% end %>
+              <% end %>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,6 +27,11 @@ Rails.application.routes.draw do
       end
     end
   end
+  resources :departments, only: [], param: :name do
+    namespace :projects do
+      resources :by_relevance, only: :index, param: :department_name
+    end
+  end
   resources :open_source, only: :index do
     collection do
       resources :users, only: [] do

--- a/spec/requests/projects/by_relevance/index_spec.rb
+++ b/spec/requests/projects/by_relevance/index_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+RSpec.describe 'By Relevance' do
+  let(:ruby_project_1) do
+    create(:project, relevance: 'internal', language: Language.find_by(name: 'ruby'))
+  end
+  let(:ruby_project_2) do
+    create(:project, relevance: 'commercial', language: Language.find_by(name: 'ruby'))
+  end
+  let(:node_project_1) do
+    create(:project, relevance: 'internal', language: Language.find_by(name: 'nodejs'))
+  end
+  let(:node_project_2) do
+    create(:project, relevance: 'commercial', language: Language.find_by(name: 'nodejs'))
+  end
+  let(:python_project_1) do
+    create(:project, relevance: 'internal', language: Language.find_by(name: 'python'))
+  end
+  let(:python_project_2) do
+    create(:project, relevance: 'commercial', language: Language.find_by(name: 'python'))
+  end
+  let(:subject) do
+    get department_projects_by_relevance_index_path(department_name: 'backend'), params: params
+  end
+
+  context 'when lang param is not present' do
+    let(:params) do
+      {
+        metric: {
+          period: 4
+        }
+      }
+    end
+
+    before do
+      subject
+    end
+
+    it 'renders index view' do
+      expect(response).to render_template(:index)
+    end
+
+    it 'returns pull requests variable with data' do
+      expect(assigns(:projects)).not_to be_empty
+    end
+  end
+end

--- a/spec/services/builders/departments/projects/by_relevance_spec.rb
+++ b/spec/services/builders/departments/projects/by_relevance_spec.rb
@@ -1,0 +1,73 @@
+require 'rails_helper'
+
+RSpec.describe Builders::Departments::Projects::ByRelevance do
+  describe '.call' do
+    let(:ruby_project_1) do
+      create(:project, relevance: 'internal', language: Language.find_by(name: 'ruby'))
+    end
+    let(:ruby_project_2) do
+      create(:project, relevance: 'commercial', language: Language.find_by(name: 'ruby'))
+    end
+    let(:node_project_1) do
+      create(:project, relevance: 'internal', language: Language.find_by(name: 'nodejs'))
+    end
+    let(:node_project_2) do
+      create(:project, relevance: 'commercial', language: Language.find_by(name: 'nodejs'))
+    end
+    let(:python_project_1) do
+      create(:project, relevance: 'internal', language: Language.find_by(name: 'python'))
+    end
+    let(:python_project_2) do
+      create(:project, relevance: 'commercial', language: Language.find_by(name: 'python'))
+    end
+
+    context 'when projects are filtered by activity' do
+      subject do
+        described_class.call(
+          department: Department.find_by(name: 'backend'),
+          from: 4
+        )
+      end
+
+      it 'returns ruby projects' do
+        expect(subject).to have_key('ruby')
+      end
+
+      it 'returns nodejs projects' do
+        expect(subject).to have_key('nodejs')
+      end
+
+      it 'returns python projects' do
+        expect(subject).to have_key('python')
+      end
+
+      context 'when there are internal projects' do
+        it 'returns ruby projects' do
+          expect(subject[:ruby]).to have_key('internal')
+        end
+
+        it 'returns ruby projects' do
+          expect(subject[:nodejs]).to have_key('internal')
+        end
+
+        it 'returns ruby projects' do
+          expect(subject[:python]).to have_key('internal')
+        end
+      end
+
+      context 'when there are commercial projects' do
+        it 'returns ruby projects' do
+          expect(subject[:ruby]).to have_key('commercial')
+        end
+
+        it 'returns ruby projects' do
+          expect(subject[:nodejs]).to have_key('commercial')
+        end
+
+        it 'returns ruby projects' do
+          expect(subject[:python]).to have_key('commercial')
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What does this PR do?
- Added `Builders::Departments::Projects::ByRelevance` in order to return projects grouped by technology and relevance (internal - commercial).
- Added `See details` button for each project in order to open its metrics page.
- Added tests.

### Preview:
![ezgif com-gif-maker (2)](https://user-images.githubusercontent.com/27789496/99992025-897ccf80-2d94-11eb-845c-6854ea92dd16.gif)

Resolves [See details of overview (list of projects for each technology)](https://rootstrap.atlassian.net/browse/EM-190?atlOrigin=eyJpIjoiMjU5MGUwNDhjNjhjNDYyYzlmMWZlOGIyODFkZTk0N2UiLCJwIjoiaiJ9)
