### PR TITLE
Added timestamps when user enters and leaves org

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -115,3 +115,7 @@ Style/ReturnNil:
 
 Style/BlockComments:
   Enabled: false
+
+SkipsModelValidations:
+  Exclude:
+    - app/services/processors/org_users_updater.rb

--- a/app/controllers/users/external_pull_requests_controller.rb
+++ b/app/controllers/users/external_pull_requests_controller.rb
@@ -3,8 +3,10 @@ module Users
     layout 'sidebar_metrics'
 
     def index
+      date = from.weeks.ago
       @external_pull_requests = ExternalPullRequest
-                                .where(opened_at: from.weeks.ago..Time.zone.now)
+                                .joins(:owner).merge(User.members_since(date))
+                                .where(opened_at: date..Time.zone.now)
                                 .group_by { |pull_request| pull_request.owner.login }
     end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,13 +2,14 @@
 #
 # Table name: users
 #
-#  id             :bigint           not null, primary key
-#  company_member :boolean          default(TRUE)
-#  login          :string           not null
-#  created_at     :datetime         not null
-#  updated_at     :datetime         not null
-#  github_id      :bigint           not null
-#  node_id        :string           not null
+#  id                   :bigint           not null, primary key
+#  company_member_since :date
+#  company_member_until :date
+#  login                :string           not null
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
+#  github_id            :bigint           not null
+#  node_id              :string           not null
 #
 # Indexes
 #
@@ -66,5 +67,10 @@ class User < ApplicationRecord
     login
   end
 
-  scope :company_member, -> { where(company_member: true) }
+  scope :company_member, -> { where.not(company_member_since: nil) }
+
+  scope :members_since, lambda { |date|
+    company_member.where(company_member_until: nil)
+                  .or(where(company_member_until: date..Time.current))
+  }
 end

--- a/app/services/processors/org_users_updater.rb
+++ b/app/services/processors/org_users_updater.rb
@@ -1,8 +1,13 @@
 module Processors
   class OrgUsersUpdater < BaseService
     def call
-      User.where(login: current_members).find_each { |user| user.update(company_member: true) }
-      User.where.not(login: current_members).find_each { |user| user.update(company_member: false) }
+      current_time = Time.current
+      User.where(login: current_members, company_member_since: nil)
+          .update_all(company_member_since: current_time)
+
+      User.where.not(login: current_members)
+          .where.not(company_member_since: nil)
+          .update_all(company_member_until: current_time)
     end
 
     private

--- a/db/migrate/20201201184505_add_member_timestamps_to_users.rb
+++ b/db/migrate/20201201184505_add_member_timestamps_to_users.rb
@@ -1,0 +1,15 @@
+class AddMemberTimestampsToUsers < ActiveRecord::Migration[6.0]
+  def up
+    add_column :users, :company_member_since, :date
+    add_column :users, :company_member_until, :date
+
+    User.where(company_member: true).find_each do |user|
+      user.update(company_member_since: Date.parse('1960-10-30'))
+    end
+  end
+
+  def down
+    remove_column :users, :company_member_since
+    remove_column :users, :company_member_until
+  end
+end

--- a/db/migrate/20201201193101_remove_company_member_from_user.rb
+++ b/db/migrate/20201201193101_remove_company_member_from_user.rb
@@ -1,0 +1,5 @@
+class RemoveCompanyMemberFromUser < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :users, :company_member, :boolean
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -142,7 +142,20 @@ CREATE TYPE public.review_state AS ENUM (
 );
 
 
+--
+-- Name: state; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.state AS ENUM (
+    'open',
+    'closed',
+    'merged'
+);
+
+
 SET default_tablespace = '';
+
+SET default_table_access_method = heap;
 
 --
 -- Name: active_admin_comments; Type: TABLE; Schema: public; Owner: -
@@ -584,9 +597,9 @@ CREATE TABLE public.external_pull_requests (
     external_project_id bigint NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
-    number integer,
     opened_at timestamp without time zone,
-    state public.external_pull_request_state
+    state public.external_pull_request_state,
+    number integer
 );
 
 
@@ -1078,7 +1091,8 @@ CREATE TABLE public.users (
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
     github_id bigint NOT NULL,
-    company_member boolean DEFAULT true
+    company_member_since date,
+    company_member_until date
 );
 
 
@@ -2245,4 +2259,6 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20200925174541'),
 ('20200929205630'),
 ('20201029141417'),
-('20201102203739');
+('20201102203739'),
+('20201201184505'),
+('20201201193101');

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -2,13 +2,14 @@
 #
 # Table name: users
 #
-#  id             :bigint           not null, primary key
-#  company_member :boolean          default(TRUE)
-#  login          :string           not null
-#  created_at     :datetime         not null
-#  updated_at     :datetime         not null
-#  github_id      :bigint           not null
-#  node_id        :string           not null
+#  id                   :bigint           not null, primary key
+#  company_member_since :date
+#  company_member_until :date
+#  login                :string           not null
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
+#  github_id            :bigint           not null
+#  node_id              :string           not null
 #
 # Indexes
 #
@@ -22,6 +23,5 @@ FactoryBot.define do
     github_id { generate(:user_id) }
     login { "octocat#{Faker::Number.number}" }
     node_id { "#{Faker::Alphanumeric.alphanumeric}=" }
-    company_member { true }
   end
 end

--- a/spec/jobs/external_contibutions_processor_job_spec.rb
+++ b/spec/jobs/external_contibutions_processor_job_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe ExternalContributionsProcessorJob do
   end
 
   context 'for a rootstrap member working on external repositories' do
-    let(:user) { create(:user) }
+    let(:user) { create(:user, company_member_since: 1.day.ago) }
 
     context 'with pull requests made for the first project' do
       let!(:pull_requests_events_payload) do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2,13 +2,14 @@
 #
 # Table name: users
 #
-#  id             :bigint           not null, primary key
-#  company_member :boolean          default(TRUE)
-#  login          :string           not null
-#  created_at     :datetime         not null
-#  updated_at     :datetime         not null
-#  github_id      :bigint           not null
-#  node_id        :string           not null
+#  id                   :bigint           not null, primary key
+#  company_member_since :date
+#  company_member_until :date
+#  login                :string           not null
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
+#  github_id            :bigint           not null
+#  node_id              :string           not null
 #
 # Indexes
 #
@@ -51,6 +52,30 @@ RSpec.describe User, type: :model do
   describe '.name' do
     it 'returns the login attribute' do
       expect(subject.login).to eq(subject.name)
+    end
+  end
+
+  describe 'scopes' do
+    describe '.company_member' do
+      context 'when there is a member user' do
+        let!(:member_user) { create(:user, company_member_since: Time.current) }
+
+        it 'includes member_user' do
+          expect(User.company_member).to include(member_user)
+        end
+      end
+    end
+
+    describe '.members_since' do
+      context 'when there is a current member user' do
+        let!(:member_user) do
+          create(:user, company_member_since: 3.days.ago, company_member_until: 1.day.ago)
+        end
+
+        it 'includes member_user' do
+          expect(User.members_since(2.days.ago)).to include(member_user)
+        end
+      end
     end
   end
 end

--- a/spec/requests/users/external_pull_request/index_spec.rb
+++ b/spec/requests/users/external_pull_request/index_spec.rb
@@ -1,0 +1,52 @@
+require 'rails_helper'
+
+RSpec.describe 'External Pull Requests' do
+  let!(:non_org_user) { create(:user) }
+  let!(:current_org_user) { create(:user, company_member_since: 1.week.ago) }
+  let!(:former_org_user) do
+    create(:user, company_member_since: 5.weeks.ago, company_member_until: 3.weeks.ago)
+  end
+  let!(:non_org_user_pull_request) do
+    create(:external_pull_request, state: 'open', owner: non_org_user, opened_at: Time.current)
+  end
+  let!(:current_org_user_pull_request) do
+    create(:external_pull_request, state: 'open', owner: current_org_user, opened_at: Time.current)
+  end
+  let!(:former_org_user_pull_request) do
+    create(:external_pull_request, state: 'open', owner: former_org_user, opened_at: Time.current)
+  end
+  let(:subject) do
+    get external_pull_requests_path, params: params
+  end
+
+  before do
+    subject
+  end
+
+  context 'when there is only 1 org member in given dates' do
+    let(:params) do
+      {
+        from: 2
+      }
+    end
+
+    it 'returns current_org_user_pull_request' do
+      assert_equal({ current_org_user.login => [current_org_user_pull_request] },
+                   assigns(:external_pull_requests))
+    end
+  end
+
+  context 'when there are 2 org members in given dates' do
+    let(:params) do
+      {
+        from: 4
+      }
+    end
+
+    it 'returns current_org_user_pull_request and former_org_user_pull_request' do
+      assert_equal({ current_org_user.login => [current_org_user_pull_request],
+                     former_org_user.login => [former_org_user_pull_request] },
+                   assigns(:external_pull_requests))
+    end
+  end
+end

--- a/spec/services/processors/org_users_updater_spec.rb
+++ b/spec/services/processors/org_users_updater_spec.rb
@@ -8,20 +8,20 @@ describe Processors::OrgUsersUpdater do
   end
 
   context 'when a non-org user becomes an org member' do
-    let(:user) { create(:user, login: members_payload['login'], company_member: false) }
+    let!(:user) { create(:user, login: members_payload['login']) }
 
-    it('sets company_member boolean as true') do
-      expect { update_all_org_users }.to change { user.reload.company_member }.from(false).to(true)
+    it('sets company_member_since date') do
+      update_all_org_users
+      expect(user.reload.company_member_since).not_to be(nil)
     end
   end
 
   context 'when an org user becomes an non-org member' do
-    let(:non_org_user) { create(:user) }
+    let!(:non_org_user) { create(:user, company_member_since: Time.current) }
 
-    it('sets company_member boolean as false for that user') do
-      expect { update_all_org_users }.to change {
-        non_org_user.reload.company_member
-      }.from(true).to(false)
+    it('sets company_member_until date') do
+      update_all_org_users
+      expect(non_org_user.reload.company_member_until).not_to be(nil)
     end
   end
 end


### PR DESCRIPTION
## What does this PR do?
Saves dates for users whenever they enter and/or leave the organization.
Also changed scopes for external pull requests, in order to show only the ones with owners that are/were members of Rootstrap given the time period.


Resolves https://rootstrap.atlassian.net/jira/software/projects/EM/boards/42?selectedIssue=EM-192
