### PR TITLE
Change filters

### DIFF
--- a/app/models/code_climate_project_metric.rb
+++ b/app/models/code_climate_project_metric.rb
@@ -25,4 +25,8 @@
 
 class CodeClimateProjectMetric < ApplicationRecord
   belongs_to :project
+
+  scope :with_rates, lambda {
+    where.not(code_climate_rate: nil)
+  }
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -84,11 +84,6 @@ class Project < ApplicationRecord
     joins(language: :department).where(departments: { id: department.id })
   }
 
-  scope :by_metrics_time, lambda { |from|
-    joins(:code_climate_project_metric)
-      .where(code_climate_project_metrics: { snapshot_time: from.weeks.ago..Time.zone.now })
-  }
-
   scope :by_language, lambda { |languages|
     joins(:language).where(languages: { name: languages })
   }

--- a/app/services/code_climate/projects_details_service.rb
+++ b/app/services/code_climate/projects_details_service.rb
@@ -42,7 +42,9 @@ module CodeClimate
 
     def metrics_in_time_period
       if from.positive?
-        metrics_in_department.where(snapshot_time: from.weeks.ago..Time.zone.now)
+        metrics_in_department.merge(Project.with_activity_after(from.weeks.ago))
+                             .group('code_climate_project_metrics.id')
+                             .group('projects.id')
       else
         metrics_in_department
       end
@@ -50,6 +52,7 @@ module CodeClimate
 
     def metrics_in_department
       CodeClimateProjectMetric
+        .with_rates
         .joins(project: { language: :department })
         .where(departments: { id: department.id })
         .order('LOWER(projects.name)')

--- a/app/services/code_climate/projects_without_c_c.rb
+++ b/app/services/code_climate/projects_without_c_c.rb
@@ -9,28 +9,26 @@ module CodeClimate
     end
 
     def call
-      projects_in_given_languages(projects_in_department)
-        .where.not(id: projects_with_cc_ids)
-        .order('LOWER(projects.name)')
+      projects_in_given_languages
+        .without_cc_or_cc_rate
+        .distinct
+        .relevant
+        .order('projects.name')
     end
 
     private
 
-    def projects_with_cc_ids
-      projects_in_given_languages(projects_in_time_period).distinct.pluck(:id)
-    end
-
-    def projects_in_given_languages(scope)
+    def projects_in_given_languages
       if languages.present?
-        scope.by_language(languages)
+        projects_in_time_period.by_language(languages)
       else
-        scope
+        projects_in_time_period
       end
     end
 
     def projects_in_time_period
       if from.positive?
-        projects_in_department.by_metrics_time(from)
+        projects_in_department.with_activity_after(from.weeks.ago)
       else
         projects_in_department
       end

--- a/spec/factories/projects.rb
+++ b/spec/factories/projects.rb
@@ -25,10 +25,25 @@ FactoryBot.define do
     language { Language.unassigned }
     is_private { false }
 
+    transient do
+      last_activity_in_weeks { 2 }
+    end
+
     trait :open_source do
       language { Language.find_by(name: 'ruby') }
       relevance { Project.relevances[:internal] }
       is_private { false }
+    end
+
+    trait :with_activity do
+      after(:build) do |project, evaluator|
+        create(:pull_request, project: project,
+                              opened_at: evaluator.last_activity_in_weeks.weeks.ago)
+      end
+    end
+
+    trait :internal do
+      relevance { Project.relevances[:internal] }
     end
   end
 end

--- a/spec/requests/code_climate/departments_spec.rb
+++ b/spec/requests/code_climate/departments_spec.rb
@@ -4,8 +4,8 @@ describe 'CodeClimate department projects report page ', type: :request do
   describe '#index' do
     let(:ruby_lang) { Language.find_by(name: 'ruby') }
     let(:department) { project.language.department }
-    let(:project) { create :project, language: ruby_lang }
-    let!(:project_with_no_cc) { create :project, language: ruby_lang }
+    let(:project) { create :project, :with_activity, language: ruby_lang }
+    let!(:project_with_no_cc) { create :project, :with_activity, :internal, language: ruby_lang }
     let(:test_coverage) { 97.832 }
 
     before do


### PR DESCRIPTION
## What does this PR do?
- This PR unifies CodeClimate metrics. Now, the week selector filters projects by their activity and relevance, instead of the metrics snapshot time.


Resolves [#EM-195](https://rootstrap.atlassian.net/browse/EM-195?atlOrigin=eyJpIjoiZDUwODkzNzUzOTZmNDZmMDlkMjNhZDJmZGI2ODQzZjkiLCJwIjoiaiJ9)
