### PR TITLE
Add Time to 2nd review distribution graph

### DIFF
--- a/app/services/builders/chartkick/development_metrics.rb
+++ b/app/services/builders/chartkick/development_metrics.rb
@@ -36,7 +36,7 @@ module Builders
 
         def entities_by_metric
           {
-            review_turnaround: %w[project users_project],
+            review_turnaround: %w[project users_project project_distribution],
             merge_time: %w[project users_project project_distribution]
           }
         end

--- a/app/services/builders/chartkick/project_distribution_data.rb
+++ b/app/services/builders/chartkick/project_distribution_data.rb
@@ -10,17 +10,19 @@ module Builders
       private
 
       def retrieve_records
-        merge_times
+        metric.retrieve_records(entity_id: @entity_id, time_range: @query[:value_timestamp])
       end
 
-      def merge_times
-        ::MergeTime.joins(pull_request: :project)
-                   .where(projects: { id: @entity_id })
-                   .where(pull_requests: { merged_at: @query[:value_timestamp] })
+      def metric_name
+        @query[:name]
+      end
+
+      def metric
+        @metric ||= ProjectDistributionDataMetrics.const_get(metric_name.to_s.camelize).new
       end
 
       def resolve_interval(entity)
-        Metrics::IntervalResolver::Time.call(entity.value_as_hours)
+        metric.resolve_interval(entity)
       end
     end
   end

--- a/app/services/builders/chartkick/project_distribution_data_metrics/merge_time.rb
+++ b/app/services/builders/chartkick/project_distribution_data_metrics/merge_time.rb
@@ -1,0 +1,18 @@
+module Builders
+  module Chartkick
+    module ProjectDistributionDataMetrics
+      class MergeTime
+        def retrieve_records(entity_id:, time_range:)
+          ::MergeTime
+            .joins(pull_request: :project)
+            .where(projects: { id: entity_id })
+            .where(pull_requests: { merged_at: time_range })
+        end
+
+        def resolve_interval(entity)
+          Metrics::IntervalResolver::Time.call(entity.value_as_hours)
+        end
+      end
+    end
+  end
+end

--- a/app/services/builders/chartkick/project_distribution_data_metrics/review_turnaround.rb
+++ b/app/services/builders/chartkick/project_distribution_data_metrics/review_turnaround.rb
@@ -1,0 +1,18 @@
+module Builders
+  module Chartkick
+    module ProjectDistributionDataMetrics
+      class ReviewTurnaround
+        def retrieve_records(entity_id:, time_range:)
+          ::CompletedReviewTurnaround
+            .joins(review_request: :project)
+            .where(projects: { id: entity_id })
+            .where(created_at: time_range)
+        end
+
+        def resolve_interval(entity)
+          Metrics::IntervalResolver::Time.call(entity.value_as_hours)
+        end
+      end
+    end
+  end
+end

--- a/app/views/development_metrics/review_turnaround/_main_metric.erb
+++ b/app/views/development_metrics/review_turnaround/_main_metric.erb
@@ -7,6 +7,5 @@
             locals: {
               metric_name: 'Distribution',
               suffix: " reviews",
-              metric: review_turnaround[:per_department_distribution]
-            } if review_turnaround && review_turnaround[:per_department_distribution] %>
-
+              metric: review_turnaround[:per_project_distribution] || review_turnaround[:per_department_distribution]
+            } if review_turnaround && (review_turnaround[:per_project_distribution] || review_turnaround[:per_department_distribution]) %>

--- a/spec/services/builders/chartkick/department_distribution_data_spec.rb
+++ b/spec/services/builders/chartkick/department_distribution_data_spec.rb
@@ -29,34 +29,7 @@ RSpec.describe Builders::Chartkick::DepartmentDistributionData do
       context 'when name is review turnaround' do
         let(:metric_name) { :review_turnaround }
 
-        before do
-          values_in_seconds.each do |value|
-            review_request = create :review_request, project: project
-            create(:completed_review_turnaround, review_request: review_request, value: value)
-          end
-        end
-
-        it 'returns an array with name key' do
-          expect(subject.first).to have_key(:name)
-        end
-
-        it 'returns an array with size of number of values' do
-          expect(subject.first[:data]).to have_exactly(6).items
-        end
-
-        it 'returns an array with one value matched in every position' do
-          subject.first[:data].each do |data_array|
-            expect(data_array.second).to eq(1)
-          end
-        end
-
-        it 'returns an array with name data' do
-          expect(subject.first).to have_key(:data)
-        end
-
-        it 'returns an array with filled value' do
-          expect(subject.first[:data].empty?).to be false
-        end
+        it_behaves_like 'review turnaround data distribution'
       end
 
       context 'when name is pull request size' do

--- a/spec/services/builders/chartkick/development_metrics_spec.rb
+++ b/spec/services/builders/chartkick/development_metrics_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Builders::Chartkick::DevelopmentMetrics do
   describe Builders::Chartkick::DevelopmentMetrics::Project do
     let(:project) { create(:project) }
     let(:period) { 4 }
-    let(:review_turnaround_entities) { %i[per_project per_users_project] }
+    let(:review_turnaround_entities) { %i[per_project per_users_project per_project_distribution] }
     let(:merge_time_entities) { %i[per_project per_users_project per_project_distribution] }
 
     describe '.call' do

--- a/spec/services/builders/chartkick/project_distribution_data_spec.rb
+++ b/spec/services/builders/chartkick/project_distribution_data_spec.rb
@@ -13,14 +13,24 @@ RSpec.describe Builders::Chartkick::ProjectDistributionData do
       let(:values_in_seconds) { [108_00, 900_00, 144_000, 198_000, 226_800, 270_000] }
 
       let(:query) do
-        { value_timestamp: range }
+        { value_timestamp: range, name: metric_name }
       end
 
       subject do
         described_class.call(entity_id, query)
       end
 
-      it_behaves_like 'merge time data distribution'
+      context 'when name is merge time' do
+        let(:metric_name) { :merge_time }
+
+        it_behaves_like 'merge time data distribution'
+      end
+
+      context 'when name is review turnaround' do
+        let(:metric_name) { :review_turnaround }
+
+        it_behaves_like 'review turnaround data distribution'
+      end
     end
   end
 end

--- a/spec/support/shared_examples/review_turnaround.rb
+++ b/spec/support/shared_examples/review_turnaround.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.shared_examples 'review turnaround data distribution' do
+  context 'when name is review turnaround' do
+    before do
+      values_in_seconds.each do |value|
+        review_request = create :review_request, project: project
+        create(:completed_review_turnaround, review_request: review_request, value: value)
+      end
+    end
+
+    it 'returns an array with name key' do
+      expect(subject.first).to have_key(:name)
+    end
+
+    it 'returns an array with size of number of values' do
+      expect(subject.first[:data]).to have_exactly(6).items
+    end
+
+    it 'returns an array with one value matched in every position' do
+      subject.first[:data].each do |data_array|
+        expect(data_array.second).to eq(1)
+      end
+    end
+
+    it 'returns an array with name data' do
+      expect(subject.first).to have_key(:data)
+    end
+
+    it 'returns an array with filled value' do
+      expect(subject.first[:data].empty?).to be false
+    end
+  end
+end


### PR DESCRIPTION
## What does this PR do?
- Add Time to 2nd review distribution graph.
- Refactored & added tests.

Preview:
![ezgif com-gif-maker](https://user-images.githubusercontent.com/27789496/101529837-de613e00-396f-11eb-9fa3-3322e711382d.gif)


Resolves [#EM-154](https://rootstrap.atlassian.net/browse/EM-154?atlOrigin=eyJpIjoiYmI1NzhhMjEyNmUxNDRjMTlhZDdiM2FhNzY3OWRiZjkiLCJwIjoiaiJ9)
