### PR TITLE
Make success rates configurable in admin

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,13 @@ This project comes with:
 1. `rspec` and make sure all tests pass
 1. `rails s`
 
+## Settings
+
+### Success Rates Department Settings
+
+- In order to change Department Success Rates time limit setting, create a new `Setting` with key prefix `success_rate`, followed by the department name and the metric name.
+- Example: `Setting.create!(key: 'success_rate_backend_merge_time', value: '12')`
+
 ## Code quality
 
 With `rake code_analysis` you can run the code analysis tool, you can omit rules with:

--- a/app/admin/settings.rb
+++ b/app/admin/settings.rb
@@ -1,0 +1,3 @@
+ActiveAdmin.register Setting do
+  permit_params :key, :value, :description
+end

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -1,0 +1,23 @@
+# == Schema Information
+#
+# Table name: settings
+#
+#  id          :bigint           not null, primary key
+#  description :string           default("")
+#  key         :string           not null
+#  value       :string
+#
+# Indexes
+#
+#  index_settings_on_key  (key) UNIQUE
+#
+
+class Setting < ApplicationRecord
+  SUCCESS_PREFIX = 'success_rate'.freeze
+
+  validates :key, uniqueness: true, presence: true
+
+  scope :success_rate, lambda { |department_name, metric_name|
+    where(key: "#{SUCCESS_PREFIX}_#{department_name}_#{metric_name}")
+  }
+end

--- a/app/services/builders/chartkick/base.rb
+++ b/app/services/builders/chartkick/base.rb
@@ -23,19 +23,6 @@ module Builders
         end
         entities_by_interval.sort_by { |key, _| key.slice(/[0-9]*[+-]/).to_i }
       end
-
-      def build_success_rate(entities)
-        intervals = build_distribution_data(entities)
-        total = intervals.map { |interval| interval[1] }
-                         .reduce(0) { |sum, num| sum + num }
-        return if total.zero?
-
-        successful = intervals
-                     .select { |tuple| %w[1-12 12-24].include?(tuple[0]) }
-                     .reduce(0) { |sum, tuple| sum + tuple[1] }
-        rate = (successful * 100) / total
-        { rate: rate, successful: successful, total: total }
-      end
     end
   end
 end

--- a/app/services/builders/chartkick/department_distribution_data.rb
+++ b/app/services/builders/chartkick/department_distribution_data.rb
@@ -2,14 +2,29 @@ module Builders
   module Chartkick
     class DepartmentDistributionData < Builders::Chartkick::Base
       def call
-        department_name = ::Department.find(@entity_id).name
-
         [{ name: department_name,
            data: build_distribution_data(records),
            success_rate: build_success_rate(records) }]
       end
 
       private
+
+      def build_success_rate(entities)
+        intervals = build_distribution_data(entities)
+        detail = Builders::Chartkick::Helpers::SuccessRate.call(department_name,
+                                                                metric_name,
+                                                                intervals)
+        return unless detail
+
+        { rate: detail.rate,
+          successful: detail.successful,
+          total: detail.total,
+          metric_detail: detail.metric_detail }
+      end
+
+      def department_name
+        @department_name ||= ::Department.find(@entity_id).name
+      end
 
       def records
         @records ||= metric.retrieve_records(entity_id: @entity_id,

--- a/app/services/builders/chartkick/helpers/success_rate.rb
+++ b/app/services/builders/chartkick/helpers/success_rate.rb
@@ -1,0 +1,62 @@
+module Builders
+  module Chartkick
+    module Helpers
+      class SuccessRate < BaseService
+        attr_reader :department_name, :metric_name, :intervals
+
+        RateDetails = Struct.new(:rate, :successful, :total, :metric_detail)
+        MetricSetting = Struct.new(:name, :value)
+
+        def initialize(department_name, metric_name, intervals)
+          @department_name = department_name
+          @metric_name = metric_name.to_s
+          @intervals = intervals
+        end
+
+        def call
+          return if total.zero?
+
+          RateDetails.new(rate, successful, total, metric_detail)
+        end
+
+        private
+
+        def metric_detail
+          MetricSetting.new(metric_key, metric_setting)
+        end
+
+        def total
+          @total ||= intervals.map { |interval| interval[1] }.sum
+        end
+
+        def successful
+          @successful ||= intervals
+                          .select { |tuple| time_interval_range.include?(tuple[0]) }
+                          .sum { |_range, value| value }
+        end
+
+        def time_interval_range
+          intervals.map { |tuple| tuple[0] }
+                   .reject { |range| range.include?('+') }
+                   .select { |range| range.split('-')[1].to_i <= metric_setting }
+        end
+
+        def metric_setting
+          @metric_setting ||= setting&.value&.to_i || 24
+        end
+
+        def setting
+          @setting ||= Setting.success_rate(department_name, metric_name).first
+        end
+
+        def metric_key
+          @metric_key ||= Setting::SUCCESS_PREFIX + '_' + department_name + '_' + metric_name
+        end
+
+        def rate
+          @rate ||= (successful * 100) / total
+        end
+      end
+    end
+  end
+end

--- a/app/views/development_metrics/departments.erb
+++ b/app/views/development_metrics/departments.erb
@@ -27,17 +27,16 @@
           department: @department, code_climate: @code_climate %>
         </div>
         <% if @department %>
-          <div class="metrics shadow-box">
+          <div class="container metrics shadow-box">
             <h4 class="p-3">
               Time to second review
               <% if @review_turnaround_success_rate.present? %>
                 <span class="badge badge-info success_rate_btn">
-                  <%= @review_turnaround_success_rate[:rate] %>% success rate |
-                  <%= @review_turnaround_success_rate[:successful] %> /
-                  <%= @review_turnaround_success_rate[:total] %> reviews
+                  <%= @review_turnaround_success_rate[:rate] %>% success rate
                 </span>
               <% end %>
             </h4>
+            <%= render 'development_metrics/review_turnaround/success_rate_detail', review_turnaround_success_rate: @review_turnaround_success_rate %>
             <div class="distribution-report-button mr-5 mb-2">
               <%= link_to 'See report',
                           department_time_to_second_review_prs_path(params[:department_name], { metric: { period: params&.dig(:metric, :period) } }),
@@ -51,17 +50,16 @@
               <%= render 'development_metrics/review_turnaround/details_metric', review_turnaround: @review_turnaround %>
             </div>
           </div>
-          <div class="metrics shadow-box">
+          <div class="container metrics shadow-box">
             <h4 class="p-3">
               Time to merge
               <% if @merge_time_success_rate.present? %>
                 <span class="badge badge-info success_rate_btn">
-                  <%= @merge_time_success_rate[:rate] %>% success rate |
-                  <%= @merge_time_success_rate[:successful] %> /
-                  <%= @merge_time_success_rate[:total] %> pull requests
+                  <%= @merge_time_success_rate[:rate] %>% success rate
                 </span>
               <% end %>
             </h4>
+            <%= render 'development_metrics/merge_time/success_rate_detail', merge_time_success_rate: @merge_time_success_rate %>
             <div class="distribution-report-button mr-5 mb-2">
               <%= link_to 'See report',
                           department_time_to_merge_prs_path(params[:department_name], { metric: { period: params&.dig(:metric, :period) } }),
@@ -72,7 +70,7 @@
               <%= render 'development_metrics/merge_time/main_metric', merge_time: @merge_time %>
             </div>
           </div>
-          <div class="metrics shadow-box">
+          <div class="container metrics shadow-box">
             <h4 class="p-3">PR Size</h4>
             <div class="graph">
               <%= render 'development_metrics/pull_request_size/main_metric', pull_request_size: @pull_request_size %>

--- a/app/views/development_metrics/merge_time/_success_rate_detail.erb
+++ b/app/views/development_metrics/merge_time/_success_rate_detail.erb
@@ -1,0 +1,10 @@
+<% if merge_time_success_rate.present? %>
+  <p>
+    Out of <%= merge_time_success_rate[:total] %> reviews,
+    <%= merge_time_success_rate[:successful] %> were completed in the first
+    <%= merge_time_success_rate[:metric_detail][:value] %> hours.
+    <a href='<%= admin_settings_path(q: { key_eq: merge_time_success_rate[:metric_detail][:name] }) %>'>
+      Change this setting here.
+    </a>
+  </p>
+<% end %>

--- a/app/views/development_metrics/review_turnaround/_success_rate_detail.erb
+++ b/app/views/development_metrics/review_turnaround/_success_rate_detail.erb
@@ -1,0 +1,10 @@
+<% if review_turnaround_success_rate.present? %>
+  <p>
+    Out of <%= review_turnaround_success_rate[:total] %> reviews,
+    <%= review_turnaround_success_rate[:successful] %> were completed in the first
+    <%= review_turnaround_success_rate[:metric_detail][:value] %> hours.
+    <a href='<%= admin_settings_path(q: { key_eq: review_turnaround_success_rate[:metric_detail][:name] }) %>'>
+      Change this setting here.
+    </a>
+  </p>
+<% end %>

--- a/db/migrate/20201211133046_add_settings.rb
+++ b/db/migrate/20201211133046_add_settings.rb
@@ -1,0 +1,11 @@
+class AddSettings < ActiveRecord::Migration[6.0]
+  def change
+    create_table :settings do |t|
+      t.string :key, null: false
+      t.string :value
+      t.string :description, default: ''
+    end
+
+    add_index :settings, :key, unique: true
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -142,17 +142,6 @@ CREATE TYPE public.review_state AS ENUM (
 );
 
 
---
--- Name: state; Type: TYPE; Schema: public; Owner: -
---
-
-CREATE TYPE public.state AS ENUM (
-    'open',
-    'closed',
-    'merged'
-);
-
-
 SET default_tablespace = '';
 
 SET default_table_access_method = heap;
@@ -1049,6 +1038,37 @@ CREATE TABLE public.schema_migrations (
 
 
 --
+-- Name: settings; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.settings (
+    id bigint NOT NULL,
+    key character varying NOT NULL,
+    value character varying,
+    description character varying DEFAULT ''::character varying
+);
+
+
+--
+-- Name: settings_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.settings_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: settings_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.settings_id_seq OWNED BY public.settings.id;
+
+
+--
 -- Name: technologies; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -1321,6 +1341,13 @@ ALTER TABLE ONLY public.reviews ALTER COLUMN id SET DEFAULT nextval('public.revi
 
 
 --
+-- Name: settings id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.settings ALTER COLUMN id SET DEFAULT nextval('public.settings_id_seq'::regclass);
+
+
+--
 -- Name: technologies id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -1555,6 +1582,14 @@ ALTER TABLE ONLY public.reviews
 
 ALTER TABLE ONLY public.schema_migrations
     ADD CONSTRAINT schema_migrations_pkey PRIMARY KEY (version);
+
+
+--
+-- Name: settings settings_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.settings
+    ADD CONSTRAINT settings_pkey PRIMARY KEY (id);
 
 
 --
@@ -1911,6 +1946,13 @@ CREATE INDEX index_reviews_on_state ON public.reviews USING btree (state);
 
 
 --
+-- Name: index_settings_on_key; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_settings_on_key ON public.settings USING btree (key);
+
+
+--
 -- Name: index_users_on_github_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -2260,5 +2302,11 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20200929205630'),
 ('20201029141417'),
 ('20201102203739'),
+('20201130132325'),
+('20201130132521'),
+('20201130135001'),
 ('20201201184505'),
-('20201201193101');
+('20201201193101'),
+('20201211133046');
+
+

--- a/spec/factories/settings.rb
+++ b/spec/factories/settings.rb
@@ -1,0 +1,20 @@
+# == Schema Information
+#
+# Table name: settings
+#
+#  id          :bigint           not null, primary key
+#  description :string           default("")
+#  key         :string           not null
+#  value       :string
+#
+# Indexes
+#
+#  index_settings_on_key  (key) UNIQUE
+#
+
+FactoryBot.define do
+  factory :setting do
+    key   { Faker::Lorem.word }
+    value { Faker::Lorem.word }
+  end
+end

--- a/spec/models/setting_spec.rb
+++ b/spec/models/setting_spec.rb
@@ -1,0 +1,43 @@
+# == Schema Information
+#
+# Table name: settings
+#
+#  id          :bigint           not null, primary key
+#  description :string           default("")
+#  key         :string           not null
+#  value       :string
+#
+# Indexes
+#
+#  index_settings_on_key  (key) UNIQUE
+#
+
+require 'rails_helper'
+
+RSpec.describe Setting, type: :model do
+  subject { build :setting }
+
+  it { is_expected.to validate_presence_of(:key) }
+  it { is_expected.to validate_uniqueness_of(:key) }
+
+  describe 'scopes' do
+    describe 'success_rate' do
+      let(:department_name) { 'backend' }
+      let(:metric_name) { 'merge_time' }
+      let!(:success_rate_setting) do
+        create(:setting, key: Setting::SUCCESS_PREFIX + '_' + department_name + '_' + metric_name)
+      end
+      let!(:setting) { create(:setting) }
+
+      it 'returns setting' do
+        query = Setting.success_rate(department_name, metric_name)
+        expect(query.first).to eq success_rate_setting
+      end
+
+      it 'returns matching settings only' do
+        query = Setting.success_rate(department_name, metric_name)
+        expect(query.count).to eq 1
+      end
+    end
+  end
+end

--- a/spec/services/builders/chartkick/department_distribution_data_spec.rb
+++ b/spec/services/builders/chartkick/department_distribution_data_spec.rb
@@ -30,35 +30,7 @@ RSpec.describe Builders::Chartkick::DepartmentDistributionData do
       context 'when name is review turnaround' do
         let(:metric_name) { :review_turnaround }
 
-        before do
-          values_in_seconds.each do |value|
-            review_request = create :review_request, project: project
-            create(:completed_review_turnaround, review_request: review_request, value: value)
-          end
-        end
-
-        it 'returns an array with name key' do
-          expect(subject.first).to have_key(:name)
-        end
-
-        it 'returns an array with size of number of values' do
-          expect(subject.first[:data]).to have_exactly(6).items
-        end
-
-        it 'returns an array with one value matched in every position' do
-          subject.first[:data].each do |data_array|
-            expect(data_array.second).to eq(1)
-          end
-        end
-
-        it 'returns an array with name data' do
-          expect(subject.first).to have_key(:data)
-        end
-
-        it 'returns an array with filled value' do
-          expect(subject.first[:data].empty?).to be false
-        end
-
+        it_behaves_like 'review turnaround data distribution'
         it_behaves_like 'success rate'
       end
 

--- a/spec/services/builders/chartkick/helpers/success_rate_spec.rb
+++ b/spec/services/builders/chartkick/helpers/success_rate_spec.rb
@@ -1,0 +1,58 @@
+require 'rails_helper'
+
+RSpec.describe Builders::Chartkick::Helpers::SuccessRate do
+  describe '.call' do
+    let(:department_name) { 'backend' }
+    let(:metric_name) { 'merge_time' }
+    let(:setting_name) { Setting::SUCCESS_PREFIX + '_' + department_name + '_' + metric_name }
+    let(:intervals) do
+      [['1-12', 1], ['12-24', 1], ['24-36', 1], ['36-48', 1],
+       ['48-60', 1], ['60-72', 1], ['72+', 1]]
+    end
+
+    let(:subject) { described_class.call(department_name, metric_name, intervals) }
+
+    it 'returns total of items' do
+      expect(subject[:total]).to eq 7
+    end
+
+    context 'when success rate time limit is set for given metric and department' do
+      let(:setting_value) { '36' }
+      let!(:success_rate_setting) do
+        create(:setting,
+               key: setting_name,
+               value: setting_value)
+      end
+
+      it 'returns items matching time limit' do
+        expect(subject[:successful]).to eq 3
+      end
+
+      it 'returns metric setting name' do
+        expect(subject[:metric_detail][:name]).to eq setting_name
+      end
+
+      it 'returns metric setting value' do
+        expect(subject[:metric_detail][:value]).to eq setting_value.to_i
+      end
+    end
+
+    context 'when success rate time limit is not set for given metric and department' do
+      it 'returns items matching default time limit of 24 hours' do
+        expect(subject[:successful]).to eq 2
+      end
+
+      it 'returns metric setting name' do
+        expect(subject[:metric_detail][:name]).to eq setting_name
+      end
+
+      it 'returns time limit default value' do
+        expect(subject[:metric_detail][:value]).to eq 24
+      end
+    end
+
+    it 'returns successful rate' do
+      expect(subject[:rate]).to eq 28
+    end
+  end
+end

--- a/spec/support/shared_examples/success_rate.rb
+++ b/spec/support/shared_examples/success_rate.rb
@@ -28,4 +28,8 @@ RSpec.shared_examples 'success rate' do
   it 'returns total of items' do
     expect(subject.first[:success_rate][:total]).to be_present
   end
+
+  it 'returns metric settings' do
+    expect(subject.first[:success_rate][:metric_detail]).to be_present
+  end
 end


### PR DESCRIPTION
## What does this PR do?
- Add `Setting` model.
- Add `Setting` section on the admin.
- In order to make success rate time limit configurable based on department and metric, it now takes the value from a setting or the default value (24 hours).
- Add tests.

## Preview
![ezgif com-gif-maker (3)](https://user-images.githubusercontent.com/27789496/102119477-edd50100-3e1f-11eb-8189-455bf00ec8a0.gif)


## Notes:
- Create the following settings after deploying with value `24`: `success_rate_backend_review_turnaround`, `success_rate_backend_merge_time`, `success_rate_frontend_review_turnaround`, `success_rate_frontend_merge_time`, `success_rate_mobile_review_turnaround`, `success_rate_mobile_merge_time`.

Resolves [Make success rates configurable in admin](https://rootstrap.atlassian.net/browse/EM-204?atlOrigin=eyJpIjoiY2YyNjBmOGU1YWZlNDA4YTkzZGQ3MWQ4NTEzZmMxOWQiLCJwIjoiaiJ9)
