### PR TITLE
Update projects Code Climate repository ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ This project comes with:
 1. `rspec` and make sure all tests pass
 1. `rails s`
 
+## Tasks
+- `rake code_climate:link` is run only to update projects' Code Climate repository ids.
+
 ## Settings
 
 ### Success Rates Department Settings

--- a/app/services/code_climate/link.rb
+++ b/app/services/code_climate/link.rb
@@ -1,0 +1,54 @@
+module CodeClimate
+  class Link < BaseService
+    CODE_CLIMATE_API_ORG_NAME = ENV['CODE_CLIMATE_API_ORG_NAME']
+
+    def initialize(project)
+      @project = project
+    end
+
+    def call
+      return if code_climate_project_metric.blank? || !ids_differ?
+
+      code_climate_project_metric.update!(cc_repository_id: external_cc_repository_id)
+
+      Rails.logger.info { message }
+    end
+
+    private
+
+    attr_reader :project
+
+    def code_climate_project_metric
+      @code_climate_project_metric ||= CodeClimateProjectMetric.find_by(project_id: project.id)
+    end
+
+    def ids_differ?
+      external_cc_repository_id.present? && local_cc_repository_id != external_cc_repository_id
+    end
+
+    def local_cc_repository_id
+      @local_cc_repository_id ||= code_climate_project_metric.cc_repository_id
+    end
+
+    def external_cc_repository_id
+      @external_cc_repository_id ||= respository_by_slug.json['id']
+    end
+
+    def respository_by_slug
+      CodeClimate::Api::Client.new.repository_by_slug(github_slug: github_slug)
+    end
+
+    def github_slug
+      "#{CODE_CLIMATE_API_ORG_NAME}/#{project.name}"
+    end
+
+    def message
+      <<-MESSAGE
+      PROJECT #{code_climate_project_metric.project_id}
+       updated CodeClimateProjectMetric (#{code_climate_project_metric.id})
+       cc_repository_id from #{local_cc_repository_id}
+       to #{code_climate_project_metric.cc_repository_id}
+      MESSAGE
+    end
+  end
+end

--- a/app/services/processors/code_climate_updater.rb
+++ b/app/services/processors/code_climate_updater.rb
@@ -1,0 +1,9 @@
+module Processors
+  class CodeClimateUpdater < BaseService
+    def call
+      Project.find_each do |project|
+        CodeClimate::Link.call(project)
+      end
+    end
+  end
+end

--- a/lib/tasks/update_code_climate_projects.rake
+++ b/lib/tasks/update_code_climate_projects.rake
@@ -1,0 +1,6 @@
+namespace :code_climate do
+  desc 'Updates CodeClimateProjectMetric cc_repository_id for each project'
+  task link: :environment do
+    Processors::CodeClimateUpdater.call
+  end
+end

--- a/spec/services/code_climate/link_spec.rb
+++ b/spec/services/code_climate/link_spec.rb
@@ -1,0 +1,80 @@
+require 'rails_helper'
+
+describe CodeClimate::Link do
+  let(:subject) { described_class.call(project) }
+  let(:code_climate_repository_json) { create(:code_climate_repository_by_slug_payload) }
+  let(:new_cc_repo_id) { code_climate_repository_json['data'].first['id'] }
+
+  context 'when project has Code Climate' do
+    let(:code_climate_project_metric) do
+      create(:code_climate_project_metric, cc_repository_id: local_cc_repo_id)
+    end
+    let(:project) { create(:project, code_climate_project_metric: code_climate_project_metric) }
+
+    context "when project has OUTDATED code climate project metric's cc_repository_id" do
+      let(:local_cc_repo_id) { 'outdated_id' }
+
+      before do
+        on_request_repository_by_slug(
+          project_name: project.name,
+          respond: { status: 200, body: code_climate_repository_json }
+        )
+      end
+
+      it 'calls CodeClimate API' do
+        subject
+        expect(WebMock).to have_requested(:get, %r{https://api.codeclimate.com/v1/.*})
+      end
+
+      it 'updates cc_repository_id' do
+        expect {
+          subject
+        }.to change {
+          project.code_climate_project_metric.reload.cc_repository_id
+        }.from(local_cc_repo_id)
+          .to(new_cc_repo_id)
+      end
+    end
+
+    context "when project has code climate project metric's cc_repository_id UP TO DATE" do
+      let(:local_cc_repo_id) { new_cc_repo_id }
+
+      before do
+        on_request_repository_by_slug(
+          project_name: project.name,
+          respond: { status: 200, body: code_climate_repository_json }
+        )
+      end
+
+      it 'calls CodeClimate API' do
+        subject
+        expect(WebMock).to have_requested(:get, %r{https://api.codeclimate.com/v1/.*})
+      end
+
+      it 'does not update cc_repository_id' do
+        expect {
+          subject
+        }.not_to change {
+          project.code_climate_project_metric.reload.cc_repository_id
+        }
+      end
+    end
+  end
+
+  context 'when project does not have Code Climate' do
+    let(:project) { create(:project) }
+
+    it 'does not call CodeClimate API' do
+      subject
+      expect(WebMock).not_to have_requested(:get, %r{https://api.codeclimate.com/v1/.*})
+    end
+
+    it 'does not change the project' do
+      expect { subject }.not_to change { project }
+    end
+
+    it 'does not change code climate project metric count' do
+      expect { subject }.not_to change { CodeClimateProjectMetric.count }
+    end
+  end
+end

--- a/spec/services/processors/code_climate_updater_spec.rb
+++ b/spec/services/processors/code_climate_updater_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+describe Processors::CodeClimateUpdater do
+  describe '#call' do
+    let!(:first_project) { create :project }
+    let!(:second_project) { create :project }
+    let(:subject) { described_class.call }
+
+    it('calls UpdateProjectService on each project') do
+      expect(CodeClimate::Link).to receive(:call).once.with(first_project)
+      expect(CodeClimate::Link).to receive(:call).once.with(second_project)
+      subject
+    end
+  end
+end


### PR DESCRIPTION
## What does this PR do?
- Solves http://engineering-metrics.herokuapp.com/exception_hunter/errors/22.
- There are some projects with Code Climate repository id outdated, so this PR adds a task to update each project's info.


Resolves [#EM-200](https://rootstrap.atlassian.net/browse/EM-200?atlOrigin=eyJpIjoiOWY5ZDVhZWIwZWVlNGZhM2I3Y2RhYmEzZWI3NTIwZGIiLCJwIjoiaiJ9)
