### PR TITLE
Fix

### DIFF
--- a/app/services/code_climate/link.rb
+++ b/app/services/code_climate/link.rb
@@ -23,7 +23,7 @@ module CodeClimate
     end
 
     def ids_differ?
-      external_cc_repository_id.present? && local_cc_repository_id != external_cc_repository_id
+      local_cc_repository_id != external_cc_repository_id
     end
 
     def local_cc_repository_id
@@ -31,7 +31,7 @@ module CodeClimate
     end
 
     def external_cc_repository_id
-      @external_cc_repository_id ||= respository_by_slug.json['id']
+      @external_cc_repository_id ||= respository_by_slug&.json&.dig('id')
     end
 
     def respository_by_slug


### PR DESCRIPTION
## What does this PR do?
- Fixes case when locally a project has an associated CodeClimate ID, but in fact, the project doesn't exist at CodeClimate.
- Now, those IDs were erased and this prevents `Faraday::ResourceNotFound: the server responded with status 404` to be raised when running `CodeClimateMetricsUpdaterJob`.

List of projects that used to have CodeClimate linked:
- react-base
- skillzz-web
- apple_auth
- node-ts-api-base-legacy

Resolves [#EM-200](https://rootstrap.atlassian.net/browse/EM-200?atlOrigin=eyJpIjoiY2ZmOTY5MDM4ZTFmNDk2Yjk5MDMxYTZjZWY3M2M5YTkiLCJwIjoiaiJ9)
