### PR TITLE
Refactor PART I

### DIFF
--- a/app/models/events/pull_request.rb
+++ b/app/models/events/pull_request.rb
@@ -12,6 +12,7 @@
 #  merged_at  :datetime
 #  number     :integer          not null
 #  opened_at  :datetime
+#  size       :integer
 #  state      :enum
 #  title      :text             not null
 #  created_at :datetime         not null

--- a/app/models/external_project.rb
+++ b/app/models/external_project.rb
@@ -4,7 +4,7 @@
 #
 #  id          :bigint           not null, primary key
 #  description :string
-#  enabled     :boolean          default(TRUE)
+#  enabled     :boolean          default(TRUE), not null
 #  full_name   :string           not null
 #  name        :string
 #  created_at  :datetime         not null

--- a/app/services/builders/chartkick/department_distribution_data_metrics/pull_request_size.rb
+++ b/app/services/builders/chartkick/department_distribution_data_metrics/pull_request_size.rb
@@ -3,14 +3,15 @@ module Builders
     module DepartmentDistributionDataMetrics
       class PullRequestSize
         def retrieve_records(entity_id:, time_range:)
-          ::PullRequestSize
-            .joins(pull_request: { project: { language: :department } })
+          ::Events::PullRequest
+            .joins(project: { language: :department })
             .where(departments: { id: entity_id })
-            .where(pull_requests: { opened_at: time_range })
+            .where(opened_at: time_range)
+            .where.not(size: nil)
         end
 
         def resolve_interval(entity)
-          Metrics::IntervalResolver::PrSize.call(entity.value)
+          Metrics::IntervalResolver::PrSize.call(entity.size)
         end
       end
     end

--- a/db/migrate/20210115132729_add_pull_request_size.rb
+++ b/db/migrate/20210115132729_add_pull_request_size.rb
@@ -1,0 +1,5 @@
+class AddPullRequestSize < ActiveRecord::Migration[6.0]
+  def change
+    add_column :pull_requests, :size, :integer
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -550,7 +550,7 @@ CREATE TABLE public.external_projects (
     language_id bigint,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
-    enabled boolean DEFAULT true
+    enabled boolean DEFAULT true NOT NULL
 );
 
 
@@ -587,9 +587,9 @@ CREATE TABLE public.external_pull_requests (
     external_project_id bigint NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
+    number integer,
     opened_at timestamp without time zone,
-    state public.external_pull_request_state,
-    number integer
+    state public.external_pull_request_state
 );
 
 
@@ -832,7 +832,8 @@ CREATE TABLE public.pull_requests (
     project_id bigint,
     owner_id bigint,
     html_url character varying,
-    branch character varying
+    branch character varying,
+    size integer
 );
 
 
@@ -2303,10 +2304,10 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20200929205630'),
 ('20201029141417'),
 ('20201102203739'),
-('20201130132325'),
-('20201130132521'),
-('20201130135001'),
 ('20201201184505'),
 ('20201201193101'),
 ('20201211133046'),
-('20201214192048');
+('20201214192048'),
+('20210115132729');
+
+

--- a/lib/tasks/fill_pull_request_size.rake
+++ b/lib/tasks/fill_pull_request_size.rake
@@ -1,0 +1,17 @@
+namespace :pull_requests do
+  desc 'Pull requests sizes migration'
+  task fill_size: :environment do
+    PullRequestSize.find_each do |pull_request_size|
+      value = pull_request_size.value
+      pull_request_size.pull_request.update!(size: value)
+    end
+    Rails.logger { 'MIGRATION DONE' }
+  end
+
+  desc 'Fill missing pull requests sizes'
+  task update_missing_sizes: :environment do
+    Events::PullRequest.where(size: nil).find_each do |pull_request|
+      Builders::PullRequestSize.call(pull_request)
+    end
+  end
+end

--- a/spec/factories/events/pull_requests.rb
+++ b/spec/factories/events/pull_requests.rb
@@ -12,6 +12,7 @@
 #  merged_at  :datetime
 #  number     :integer          not null
 #  opened_at  :datetime
+#  size       :integer
 #  state      :enum
 #  title      :text             not null
 #  created_at :datetime         not null
@@ -42,6 +43,7 @@ FactoryBot.define do
     number { Faker::Number.number(digits: 1) }
     title { "Pull Request-#{Faker::Number.number(digits: 1)}" }
     node_id { "#{Faker::Alphanumeric.alphanumeric}=" }
+    size { Faker::Number.within(range: 0..10_000) }
     state { 'open' }
     html_url { 'https://github.com/Codertocat/Hello-World/pull/2' }
     opened_at { Faker::Date.between(from: 1.month.ago, to: Time.zone.now) }

--- a/spec/factories/external_projects.rb
+++ b/spec/factories/external_projects.rb
@@ -4,7 +4,7 @@
 #
 #  id          :bigint           not null, primary key
 #  description :string
-#  enabled     :boolean          default(TRUE)
+#  enabled     :boolean          default(TRUE), not null
 #  full_name   :string           not null
 #  name        :string
 #  created_at  :datetime         not null

--- a/spec/models/events/pull_request_spec.rb
+++ b/spec/models/events/pull_request_spec.rb
@@ -12,6 +12,7 @@
 #  merged_at  :datetime
 #  number     :integer          not null
 #  opened_at  :datetime
+#  size       :integer
 #  state      :enum
 #  title      :text             not null
 #  created_at :datetime         not null

--- a/spec/models/external_project_spec.rb
+++ b/spec/models/external_project_spec.rb
@@ -4,7 +4,7 @@
 #
 #  id          :bigint           not null, primary key
 #  description :string
-#  enabled     :boolean          default(TRUE)
+#  enabled     :boolean          default(TRUE), not null
 #  full_name   :string           not null
 #  name        :string
 #  created_at  :datetime         not null

--- a/spec/services/builders/chartkick/department_distribution_data_spec.rb
+++ b/spec/services/builders/chartkick/department_distribution_data_spec.rb
@@ -49,8 +49,7 @@ RSpec.describe Builders::Chartkick::DepartmentDistributionData do
 
         before do
           sizes_values.each do |size_value|
-            pull_request = create(:pull_request, project: project, opened_at: Time.zone.now)
-            create(:pull_request_size, value: size_value, pull_request: pull_request)
+            create(:pull_request, project: project, opened_at: Time.zone.now, size: size_value)
           end
         end
 
@@ -61,8 +60,7 @@ RSpec.describe Builders::Chartkick::DepartmentDistributionData do
         context 'when some pull requests have been created outside of the requested period' do
           before do
             old_timestamp = range.first.yesterday
-            pull_request = create(:pull_request, project: project, opened_at: old_timestamp)
-            create(:pull_request_size, value: 3, pull_request: pull_request)
+            create(:pull_request, project: project, opened_at: old_timestamp, size: 3)
           end
 
           it 'does not count them' do


### PR DESCRIPTION
## What does this PR do?
- This is PART I of a refactor to move the PR size value from the associated `PullRequestSize` model to the `PullRequest` model. By doing this, we avoid unnecessary joins and bugs.
- After deploying it is needed to:
1. Run `rake pull_requests:fill_size` to move size values.
2. Run `rake pull_requests:update_missing_sizes` because there are PRs that do not have an associated size value, but these are available on Github.
3. Run `1` again in order to migrate these newly added values.

* Apart from this, it's worth mentioning that there are PRs from projects that are no longer available, so these will have null size values. So, we have to take into consideration that any query should exclude these null values.

## What's next?
- PART II will be about removing `PullRequestSize` logic and change it to save & update size values at the `PullRequest` table.
- Remove `PullRequestSize` table.

Resolves bugs [#EM-202](https://rootstrap.atlassian.net/browse/EM-202?atlOrigin=eyJpIjoiNDk4OGI1NzJmNGY0NGE4Nzg5NzY2NDhkYWU4ZmViN2EiLCJwIjoiaiJ9) [#EM-203](https://rootstrap.atlassian.net/browse/EM-203?atlOrigin=eyJpIjoiZThkNDU4ZTUwMDcyNGMxOTg4NjliOWY2N2E3ODY5MTAiLCJwIjoiaiJ9)
