### PR TITLE
PR Size distribution graph per project

### DIFF
--- a/app/services/builders/chartkick/development_metrics.rb
+++ b/app/services/builders/chartkick/development_metrics.rb
@@ -37,7 +37,8 @@ module Builders
         def entities_by_metric
           {
             review_turnaround: %w[project users_project project_distribution],
-            merge_time: %w[project users_project project_distribution]
+            merge_time: %w[project users_project project_distribution],
+            pull_request_size: %w[project_distribution]
           }
         end
       end

--- a/app/services/builders/chartkick/project_distribution_data_metrics/pull_request_size.rb
+++ b/app/services/builders/chartkick/project_distribution_data_metrics/pull_request_size.rb
@@ -1,0 +1,18 @@
+module Builders
+  module Chartkick
+    module ProjectDistributionDataMetrics
+      class PullRequestSize
+        def retrieve_records(entity_id:, time_range:)
+          ::Events::PullRequest
+            .where(project_id: entity_id)
+            .where(opened_at: time_range)
+            .where.not(size: nil)
+        end
+
+        def resolve_interval(entity)
+          Metrics::IntervalResolver::PrSize.call(entity.size)
+        end
+      end
+    end
+  end
+end

--- a/app/views/development_metrics/merge_time/_success_rate_detail.erb
+++ b/app/views/development_metrics/merge_time/_success_rate_detail.erb
@@ -1,5 +1,5 @@
 <% if merge_time_success_rate.present? %>
-  <p>
+  <p class='alert alert-secondary'>
     Out of <%= merge_time_success_rate[:total] %> pull requests,
     <%= merge_time_success_rate[:successful] %> were merged in the first
     <%= merge_time_success_rate[:metric_detail][:value] %> hours.

--- a/app/views/development_metrics/projects.erb
+++ b/app/views/development_metrics/projects.erb
@@ -40,6 +40,13 @@
         </div>
       <% end %>
     </div>
+
+    <div class="metrics shadow-box">
+      <h4 class="p-3">PR Size</h4>
+      <div class="graph">
+        <%= render 'development_metrics/pull_request_size/main_metric', pull_request_size: @pull_request_size %>
+      </div>
+    </div>
   <% else %>
     <div class="row">
       <div class="body-empty-container col-md-12 d-flex justify-content-center align-items-center">

--- a/app/views/development_metrics/pull_request_size/_main_metric.erb
+++ b/app/views/development_metrics/pull_request_size/_main_metric.erb
@@ -2,5 +2,5 @@
            locals: {
                metric_name: 'Distribution',
                suffix: " pull requests",
-               metric: pull_request_size[:per_department_distribution]
-           } if pull_request_size && pull_request_size[:per_department_distribution] %>
+               metric: pull_request_size[:per_project_distribution] || pull_request_size[:per_department_distribution]
+           } if pull_request_size && (pull_request_size[:per_project_distribution] || pull_request_size[:per_department_distribution]) %>

--- a/app/views/development_metrics/review_turnaround/_success_rate_detail.erb
+++ b/app/views/development_metrics/review_turnaround/_success_rate_detail.erb
@@ -1,5 +1,5 @@
 <% if review_turnaround_success_rate.present? %>
-  <p>
+  <p class='alert alert-secondary'>
     Out of <%= review_turnaround_success_rate[:total] %> reviews,
     <%= review_turnaround_success_rate[:successful] %> were completed in the first
     <%= review_turnaround_success_rate[:metric_detail][:value] %> hours.

--- a/spec/services/builders/chartkick/department_distribution_data_spec.rb
+++ b/spec/services/builders/chartkick/department_distribution_data_spec.rb
@@ -36,37 +36,8 @@ RSpec.describe Builders::Chartkick::DepartmentDistributionData do
 
       context 'when name is pull request size' do
         let(:metric_name) { :pull_request_size }
-        let(:sizes_values) { [419, 915, 134, 12, 3333] }
-        let(:expected_data) do
-          [
-            ['1-99', 1],
-            ['100-199', 1],
-            ['400-499', 1],
-            ['900-999', 1],
-            ['1000+', 1]
-          ]
-        end
 
-        before do
-          sizes_values.each do |size_value|
-            create(:pull_request, project: project, opened_at: Time.zone.now, size: size_value)
-          end
-        end
-
-        it 'counts and classifies each pr size in the correct intervals and returns the data' do
-          expect(subject.first[:data]).to eq(expected_data)
-        end
-
-        context 'when some pull requests have been created outside of the requested period' do
-          before do
-            old_timestamp = range.first.yesterday
-            create(:pull_request, project: project, opened_at: old_timestamp, size: 3)
-          end
-
-          it 'does not count them' do
-            expect(subject.first[:data]).to eq(expected_data)
-          end
-        end
+        it_behaves_like 'pull request size data distribution'
       end
     end
   end

--- a/spec/services/builders/chartkick/project_distribution_data_spec.rb
+++ b/spec/services/builders/chartkick/project_distribution_data_spec.rb
@@ -31,6 +31,12 @@ RSpec.describe Builders::Chartkick::ProjectDistributionData do
 
         it_behaves_like 'review turnaround data distribution'
       end
+
+      context 'when name is pull request size' do
+        let(:metric_name) { :pull_request_size }
+
+        it_behaves_like 'pull request size data distribution'
+      end
     end
   end
 end

--- a/spec/support/shared_examples/pull_request_size.rb
+++ b/spec/support/shared_examples/pull_request_size.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.shared_examples 'pull request size data distribution' do
+  let(:sizes_values) { [419, 915, 134, 12, 3333] }
+  let(:expected_data) do
+    [
+      ['1-99', 1],
+      ['100-199', 1],
+      ['400-499', 1],
+      ['900-999', 1],
+      ['1000+', 1]
+    ]
+  end
+
+  before do
+    sizes_values.each do |size_value|
+      create(:pull_request, project: project, opened_at: Time.zone.now, size: size_value)
+    end
+  end
+
+  it 'counts and classifies each pr size in the correct intervals and returns the data' do
+    expect(subject.first[:data]).to eq(expected_data)
+  end
+
+  context 'when some pull requests have been created outside of the requested period' do
+    before do
+      old_timestamp = range.first.yesterday
+      create(:pull_request, project: project, opened_at: old_timestamp, size: 3)
+    end
+
+    it 'does not count them' do
+      expect(subject.first[:data]).to eq(expected_data)
+    end
+  end
+end


### PR DESCRIPTION
## What does this PR do?
- Adds PR Size distribution graph for projects.
<img width="1440" alt="Captura de Pantalla 2021-01-18 a la(s) 15 43 12" src="https://user-images.githubusercontent.com/27789496/104952773-e61af600-59a3-11eb-8272-0fed182c84b6.png">

- Also, highlighted success rate subtitle:
<img width="761" alt="Captura de Pantalla 2021-01-18 a la(s) 15 44 29" src="https://user-images.githubusercontent.com/27789496/104952878-21b5c000-59a4-11eb-93d1-2c009d5ae18c.png">


Resolves [#EM-211](https://rootstrap.atlassian.net/browse/EM-211?atlOrigin=eyJpIjoiNjE0NjU1ZmI3NmZmNDZlOGE5NzViNWFlYmUxMTkxZjQiLCJwIjoiaiJ9)
