### PR TITLE
Upgrade puma gem to 5.2.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ ruby '~> 2.6.3'
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 6.0.2'
 # Use Puma as the app server
-gem 'puma', '~> 4.3'
+gem 'puma', '~> 5.2.1'
 # Use SCSS for stylesheets
 gem 'sass-rails', '>= 6'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -230,7 +230,7 @@ GEM
       pry (>= 0.10.4)
     psych (3.1.0)
     public_suffix (4.0.1)
-    puma (4.3.5)
+    puma (5.2.2)
       nio4r (~> 2.0)
     raabro (1.1.6)
     racc (1.5.2)
@@ -461,7 +461,7 @@ DEPENDENCIES
   listen (>= 3.0.5, < 3.2)
   pg (~> 1.1)
   pry-rails (~> 0.3.9)
-  puma (~> 4.3)
+  puma (~> 5.2.1)
   rack-mini-profiler (~> 2.0)
   rails (~> 6.0.2)
   rails-controller-testing

--- a/spec/services/github_client/pull_request_spec.rb
+++ b/spec/services/github_client/pull_request_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe GithubClient::PullRequest do
   end
 
   describe '#files' do
-    let(:project) { create(:project) }
+    let(:project) { create(:project, name: 'MyProject') }
     let(:pull_request) { create(:pull_request, project: project) }
     let(:pull_request_file_payload) { create(:pull_request_file_payload) }
 


### PR DESCRIPTION
## What does this PR do?

The existent puma gem version (4.3.5) raises an error when trying to install on Mac.

The error has been reported [here](https://github.com/puma/puma/issues/2304#) and it's tied specifically to the 4.3.5 version of the gem and MacOS 15.5.5/MacOS Big Sur.

It's solved by adding a flag to the installation of the gem, like this: 

`gem install puma:4.3.5 -- --with-cflags="-Wno-error=implicit-function-declaration"` 

Nevertheless, we considered useful to upgrade the gem to the latest version where the problem is solved.

**Note:** [#aa2ba51](https://github.com/rootstrap/rs-code-review-metrics/pull/413/commits/aa2ba516e614742227a3203d1319772608c2325e) Fixes flaky test caused by a misshaped name on Faker::App.name. You can check the failed build [here](https://travis-ci.com/github/rootstrap/rs-code-review-metrics/builds/219771430).