### PR TITLE
Add required steps to initial setup on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ brew services start redis
 
 2. You'll need SUPERUSER permissions on postgresql for the defined user.
 
-Either assign superuser permissions to `postrges` or update the env vars: `GITHUB_ANALYZER_USERNAME` and `GITHUB_ANALYZER_PASSWORD`
+Either assign superuser permissions to `postgres` or update the env vars: `GITHUB_ANALYZER_USERNAME` and `GITHUB_ANALYZER_PASSWORD`
 ## Tasks
 - `rake code_climate:link` is run only to update projects' Code Climate repository ids.
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,19 @@ This project comes with:
 1. `rspec` and make sure all tests pass
 1. `rails s`
 
+**IMPORTANT: At the moment of running the tests**
+
+1. You will need to have redis installed.
+
+On Mac:
+```
+brew install redis
+brew services start redis
+```
+
+2. You'll need SUPERUSER permissions on postgresql for the defined user.
+
+Either assign superuser permissions to `postrges` or update the env vars: `GITHUB_ANALYZER_USERNAME` and `GITHUB_ANALYZER_PASSWORD`
 ## Tasks
 - `rake code_climate:link` is run only to update projects' Code Climate repository ids.
 


### PR DESCRIPTION
## What does this PR do?

Adds two required steps to the README related to the initial installation.

These requirements were found when first installing and running the repository.

Even though the users might already have these requirements set up, they're still mandatory, that' s why we didn't add them in the flow but as a note after the description of the steps themselves. 

