### PR TITLE
Rename env variable JIRA_ADMIN_PASSWORD to JIRA_ADMIN_TOKEN as auth of jira has changed

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,6 @@ ENGINEERING_METRICS_URL=https://example.com
 
 # Jira
 JIRA_ADMIN_USER=admin
-JIRA_ADMIN_PASSWORD=admin
+JIRA_ADMIN_TOKEN=admin
 JIRA_ENVIRONMENT_FIELD=customfield_10000
 JIRA_ROOT_URL=http://localhost:2990

--- a/app/services/jira_client/base.rb
+++ b/app/services/jira_client/base.rb
@@ -4,7 +4,7 @@ module JiraClient
 
     def connection
       Faraday.new(ENV['JIRA_ROOT_URL']) do |conn|
-        conn.basic_auth(ENV.fetch('JIRA_ADMIN_USER'), ENV.fetch('JIRA_ADMIN_PASSWORD'))
+        conn.basic_auth(ENV.fetch('JIRA_ADMIN_USER'), ENV.fetch('JIRA_ADMIN_TOKEN'))
         conn.headers['Content-Type'] = 'application/json'
         conn.response :raise_error
       end

--- a/spec/support/helpers/jira_api_mocker.rb
+++ b/spec/support/helpers/jira_api_mocker.rb
@@ -18,7 +18,7 @@ module JiraApiMock
 
   def stub_envs
     stub_env('JIRA_ADMIN_USER', jira_admin_user)
-    stub_env('JIRA_ADMIN_PASSWORD', jira_admin_password)
+    stub_env('JIRA_ADMIN_TOKEN', jira_admin_token)
     stub_env('JIRA_ENVIRONMENT_FIELD', jira_environment_field)
     stub_env('JIRA_ROOT_URL', jira_root_url)
   end
@@ -29,8 +29,8 @@ module JiraApiMock
     'adminuser'
   end
 
-  def jira_admin_password
-    'asdminpassword'
+  def jira_admin_token
+    '123ir123r91238ry123rihb'
   end
 
   def jira_environment_field


### PR DESCRIPTION
Change the variable name because JIRA changed it's auth method