### PR TITLE
Fix EDR when several bugs for same environment

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -149,7 +149,7 @@ GEM
     faraday (1.1.0)
       multipart-post (>= 1.2, < 3)
       ruby2_keywords
-    ffi (1.11.3)
+    ffi (1.15.3)
     formtastic (3.1.5)
       actionpack (>= 3.2.13)
     formtastic_i18n (0.6.0)
@@ -349,7 +349,7 @@ GEM
     safe_yaml (1.0.5)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
-    sassc (2.2.1)
+    sassc (2.4.0)
       ffi (~> 1.9)
     sassc-rails (2.1.2)
       railties (>= 4.0.0)

--- a/app/services/metrics/defect_escape_rate/per_project.rb
+++ b/app/services/metrics/defect_escape_rate/per_project.rb
@@ -28,8 +28,8 @@ module Metrics
       end
 
       def bugs_by_environment(bug_issues)
-        bug_issues.each_with_object({}) do |bug, result|
-          result[bug.environment] = +1
+        bug_issues.each_with_object(Hash.new(0)) do |bug, result|
+          result[bug.environment] += 1
         end
       end
     end

--- a/app/views/development_metrics/defect_escape_rate/_values_details.erb
+++ b/app/views/development_metrics/defect_escape_rate/_values_details.erb
@@ -16,10 +16,9 @@
       <hr>
       <div>
         <h5>Bugs by environment:</h5>
-        <% metric[:values].each do |metric| %>
+        <% metric[:values].each do |environment, bugs| %>
           <div class="item-list">
-            <%= metric.first.to_s.capitalize %>:
-              <%= metric.second.to_s %>
+            <%= environment.to_s.capitalize.presence || 'None' %>: <%= bugs %>
           </div>
           <div></div>
         <% end %>

--- a/spec/controllers/development_metrics_controller_spec.rb
+++ b/spec/controllers/development_metrics_controller_spec.rb
@@ -1,11 +1,12 @@
 require 'rails_helper'
 
-RSpec.describe DevelopmentMetricsController, type: :controller do
+describe DevelopmentMetricsController, type: :controller do
   fixtures :departments, :languages
 
   let(:ruby_lang) { Language.find_by(name: 'ruby') }
   let(:project) { create(:project, name: 'rs-metrics', language: ruby_lang) }
   let!(:jira_project) { create(:jira_project, project: project) }
+  let(:beginning_of_day) { Time.zone.today.beginning_of_day }
 
   describe '#index' do
     context 'when metric params are empty' do
@@ -44,10 +45,79 @@ RSpec.describe DevelopmentMetricsController, type: :controller do
       end
 
       context '#projects' do
+        render_views
+
+        subject { get :projects, params: params }
+
+        let(:params) do
+          {
+            project_name: project.name,
+            metric: {
+              metric_name: 'defect_escape_rate',
+              period: 'weekly'
+            }
+          }
+        end
+
         it 'calls CodeClimate summary retriever class' do
           expect(CodeClimateSummaryRetriever).to receive(:call).and_return(code_climate_metric)
 
-          get :projects, params: params
+          subject
+        end
+
+        context 'when it has issues from different environments' do
+          let!(:production_jira_bugs) do
+            create_list(:jira_issue, 2,
+                        :bug,
+                        :production,
+                        jira_project: jira_project,
+                        informed_at: beginning_of_day)
+          end
+          let!(:staging_jira_bugs) do
+            create_list(:jira_issue, 1,
+                        :bug,
+                        :staging,
+                        jira_project: jira_project,
+                        informed_at: beginning_of_day)
+          end
+          let!(:qa_jira_bugs) do
+            create_list(:jira_issue, 3,
+                        :bug,
+                        :qa,
+                        jira_project: jira_project,
+                        informed_at: beginning_of_day)
+          end
+          let!(:no_env_jira_bugs) do
+            create_list(:jira_issue, 2,
+                        :bug,
+                        :no_environment,
+                        jira_project: jira_project,
+                        informed_at: beginning_of_day)
+          end
+
+          before do
+            subject
+          end
+
+          it 'has a successful response' do
+            expect(response).to be_successful
+          end
+
+          it 'render EDR metric with correct production issues' do
+            expect(response.body).to include("Production: #{production_jira_bugs.count}")
+          end
+
+          it 'render EDR metric with correct staging issues' do
+            expect(response.body).to include("Staging: #{staging_jira_bugs.count}")
+          end
+
+          it 'render EDR metric with correct QA issues' do
+            expect(response.body).to include("Qa: #{qa_jira_bugs.count}")
+          end
+
+          it 'render EDR metric with correct issues when no environment defined' do
+            expect(response.body).to include("None: #{no_env_jira_bugs.count}")
+          end
         end
       end
 

--- a/spec/factories/jira_issue.rb
+++ b/spec/factories/jira_issue.rb
@@ -44,6 +44,10 @@ FactoryBot.define do
       environment { 'staging' }
     end
 
+    trait :no_environment do
+      environment { nil }
+    end
+
     after(:build) do |jira_issue|
       jira_issue.key { "#{jira_issue.jira_project.jira_project_key}-#{Faker::Number.digits(3)}" }
     end

--- a/spec/services/metrics/defect_escape_rate/per_project_spec.rb
+++ b/spec/services/metrics/defect_escape_rate/per_project_spec.rb
@@ -1,6 +1,4 @@
-require 'rails_helper'
-
-RSpec.describe Metrics::DefectEscapeRate::PerProject do
+describe Metrics::DefectEscapeRate::PerProject do
   describe '.call' do
     let(:project) { create(:project) }
     let!(:jira_project) { create(:jira_project, project: project) }
@@ -8,12 +6,12 @@ RSpec.describe Metrics::DefectEscapeRate::PerProject do
     let(:subject) { described_class.call(project.id) }
 
     context 'when there are bugs for the project' do
-      let!(:jira_bug) do
-        create(:jira_issue,
-               :bug,
-               :production,
-               jira_project: jira_project,
-               informed_at: beginning_of_day)
+      let!(:jira_bugs) do
+        create_list(:jira_issue, rand(1..10),
+                    :bug,
+                    :production,
+                    jira_project: jira_project,
+                    informed_at: beginning_of_day)
       end
 
       it 'returns the expected payload' do
@@ -23,7 +21,8 @@ RSpec.describe Metrics::DefectEscapeRate::PerProject do
         expect(metrics.count).to eq(1)
         expect(metric.ownable_id).to eq(project.id)
         expect(metric.value_timestamp).to eq(beginning_of_day)
-        expect(metric.value).to eq(defect_rate: 100, bugs_by_environment: { 'production' => 1 })
+        expect(metric.value).to eq(defect_rate: 100,
+                                   bugs_by_environment: { 'production' => jira_bugs.count })
       end
     end
 


### PR DESCRIPTION
### **Jira cards:**
[EDR-221](https://rootstrap.atlassian.net/browse/EM-221) - EDR not taking updated bugs into account
[EDR-222](https://rootstrap.atlassian.net/browse/EM-222) - EDR showing empty string when environment is null

### **Description:**
This PR fixes a bug that is getting wrong quantity issues when are several bugs in the same period.
It also fixes the view when environment is `null`.