### PR TITLE
Handle repository events to soft-delete projects from system

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,6 +61,8 @@ gem 'groupdate', '~> 5.0'
 
 gem 'slack-notifier', '~> 2.3', '>= 2.3.2'
 
+gem 'acts_as_paranoid', '~> 0.7.0'
+
 group :development, :test do
   gem 'brakeman', '~> 5.0.0'
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,6 +67,9 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
       zeitwerk (~> 2.2, >= 2.2.2)
+    acts_as_paranoid (0.7.3)
+      activerecord (>= 5.2, < 7.0)
+      activesupport (>= 5.2, < 7.0)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
     annotate (3.0.3)
@@ -440,6 +443,7 @@ PLATFORMS
 
 DEPENDENCIES
   activeadmin (~> 2.7)
+  acts_as_paranoid (~> 0.7.0)
   annotate (~> 3.0)
   bootsnap (>= 1.4.2)
   bootstrap (~> 4.4.1)

--- a/app/models/code_climate_project_metric.rb
+++ b/app/models/code_climate_project_metric.rb
@@ -4,6 +4,7 @@
 #
 #  id                    :bigint           not null, primary key
 #  code_climate_rate     :string
+#  deleted_at            :datetime
 #  invalid_issues_count  :integer
 #  open_issues_count     :integer
 #  snapshot_time         :datetime
@@ -24,6 +25,8 @@
 #
 
 class CodeClimateProjectMetric < ApplicationRecord
+  acts_as_paranoid
+
   belongs_to :project
 
   scope :with_rates, lambda {

--- a/app/models/code_owner_project.rb
+++ b/app/models/code_owner_project.rb
@@ -3,6 +3,7 @@
 # Table name: code_owner_projects
 #
 #  id         :bigint           not null, primary key
+#  deleted_at :datetime
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
 #  project_id :bigint           not null
@@ -20,6 +21,8 @@
 #
 
 class CodeOwnerProject < ApplicationRecord
+  acts_as_paranoid
+
   belongs_to :project
   belongs_to :user
 end

--- a/app/models/completed_review_turnaround.rb
+++ b/app/models/completed_review_turnaround.rb
@@ -3,6 +3,7 @@
 # Table name: completed_review_turnarounds
 #
 #  id                :bigint           not null, primary key
+#  deleted_at        :datetime
 #  value             :integer
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
@@ -18,6 +19,8 @@
 #
 
 class CompletedReviewTurnaround < ApplicationRecord
+  acts_as_paranoid
+
   include EntityTimeRepresentation
 
   belongs_to :review_request

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -19,7 +19,7 @@
 #
 
 class Event < ApplicationRecord
-  TYPES = %w[pull_request review review_comment push].freeze
+  TYPES = %w[pull_request review review_comment push repository].freeze
 
   belongs_to :handleable, polymorphic: true, optional: true
   belongs_to :project

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -4,6 +4,7 @@
 #
 #  id              :bigint           not null, primary key
 #  data            :jsonb
+#  deleted_at      :datetime
 #  handleable_type :string
 #  name            :string
 #  type            :string
@@ -19,6 +20,8 @@
 #
 
 class Event < ApplicationRecord
+  acts_as_paranoid
+
   TYPES = %w[pull_request review review_comment push repository].freeze
 
   belongs_to :handleable, polymorphic: true, optional: true

--- a/app/models/events/pull_request.rb
+++ b/app/models/events/pull_request.rb
@@ -6,6 +6,7 @@
 #  body       :text
 #  branch     :string
 #  closed_at  :datetime
+#  deleted_at :datetime
 #  draft      :boolean          not null
 #  html_url   :string
 #  locked     :boolean          not null
@@ -36,6 +37,8 @@
 #
 module Events
   class PullRequest < ApplicationRecord
+    acts_as_paranoid
+
     enum state: { open: 'open', closed: 'closed' }
 
     belongs_to :project, inverse_of: :pull_requests

--- a/app/models/events/push.rb
+++ b/app/models/events/push.rb
@@ -3,6 +3,7 @@
 # Table name: pushes
 #
 #  id              :bigint           not null, primary key
+#  deleted_at      :datetime
 #  ref             :string
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
@@ -25,6 +26,8 @@
 
 module Events
   class Push < ApplicationRecord
+    acts_as_paranoid
+
     belongs_to :project
     belongs_to :pull_request, class_name: 'Events::PullRequest', optional: true
     belongs_to :sender, class_name: 'User', foreign_key: :sender_id, inverse_of: :pushes

--- a/app/models/events/repository.rb
+++ b/app/models/events/repository.rb
@@ -1,0 +1,42 @@
+# == Schema Information
+#
+# Table name: repositories
+#
+#  id         :bigint           not null, primary key
+#  action     :string
+#  html_url   :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  project_id :bigint           not null
+#  sender_id  :bigint           not null
+#
+# Indexes
+#
+#  index_repositories_on_project_id  (project_id)
+#  index_repositories_on_sender_id   (sender_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (project_id => projects.id)
+#  fk_rails_...  (sender_id => users.id)
+#
+
+module Events
+  class Repository < ApplicationRecord
+    enum action: {
+      created: 'created',
+      deleted: 'deleted',
+      archived: 'archived',
+      unarchived: 'unarchived',
+      edited: 'edited',
+      renamed: 'renamed',
+      transferred: 'transferred',
+      publicized: 'publicized',
+      privatized: 'privatized'
+    }
+
+    belongs_to :project
+    has_one :event, as: :handleable, dependent: :destroy
+    belongs_to :sender, class_name: 'User', foreign_key: :sender_id, inverse_of: :repositories
+  end
+end

--- a/app/models/events/repository.rb
+++ b/app/models/events/repository.rb
@@ -4,6 +4,7 @@
 #
 #  id         :bigint           not null, primary key
 #  action     :string
+#  deleted_at :datetime
 #  html_url   :string
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
@@ -23,6 +24,8 @@
 
 module Events
   class Repository < ApplicationRecord
+    acts_as_paranoid
+
     enum action: {
       created: 'created',
       deleted: 'deleted',

--- a/app/models/events/review.rb
+++ b/app/models/events/review.rb
@@ -4,6 +4,7 @@
 #
 #  id                :bigint           not null, primary key
 #  body              :string
+#  deleted_at        :datetime
 #  opened_at         :datetime         not null
 #  state             :enum             not null
 #  created_at        :datetime         not null
@@ -30,6 +31,8 @@
 
 module Events
   class Review < ApplicationRecord
+    acts_as_paranoid
+
     enum state: { approved: 'approved',
                   commented: 'commented',
                   changes_requested: 'changes_requested',

--- a/app/models/events/review_comment.rb
+++ b/app/models/events/review_comment.rb
@@ -4,6 +4,7 @@
 #
 #  id              :bigint           not null, primary key
 #  body            :string
+#  deleted_at      :datetime
 #  state           :enum             default("active")
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
@@ -25,6 +26,8 @@
 
 module Events
   class ReviewComment < ApplicationRecord
+    acts_as_paranoid
+
     enum state: { active: 'active', removed: 'removed' }
 
     has_many :events, as: :handleable, dependent: :destroy

--- a/app/models/jira_issue.rb
+++ b/app/models/jira_issue.rb
@@ -3,6 +3,7 @@
 # Table name: jira_issues
 #
 #  id              :bigint           not null, primary key
+#  deleted_at      :datetime
 #  environment     :enum
 #  informed_at     :datetime         not null
 #  issue_type      :enum             not null
@@ -21,6 +22,8 @@
 #
 
 class JiraIssue < ApplicationRecord
+  acts_as_paranoid
+
   enum issue_type: { bug: 'bug', task: 'task', epic: 'epic', story: 'story' }
   enum environment: {
     local: 'local',

--- a/app/models/jira_project.rb
+++ b/app/models/jira_project.rb
@@ -3,6 +3,7 @@
 # Table name: jira_projects
 #
 #  id               :bigint           not null, primary key
+#  deleted_at       :datetime
 #  jira_project_key :string           not null
 #  project_name     :string
 #  created_at       :datetime         not null
@@ -19,6 +20,8 @@
 #
 
 class JiraProject < ApplicationRecord
+  acts_as_paranoid
+
   belongs_to :project
 
   has_many :jira_issues, dependent: :destroy

--- a/app/models/merge_time.rb
+++ b/app/models/merge_time.rb
@@ -3,6 +3,7 @@
 # Table name: merge_times
 #
 #  id              :bigint           not null, primary key
+#  deleted_at      :datetime
 #  value           :integer
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
@@ -18,6 +19,8 @@
 #
 
 class MergeTime < ApplicationRecord
+  acts_as_paranoid
+
   include EntityTimeRepresentation
 
   belongs_to :pull_request, class_name: 'Events::PullRequest'

--- a/app/models/metric.rb
+++ b/app/models/metric.rb
@@ -3,6 +3,7 @@
 # Table name: metrics
 #
 #  id              :bigint           not null, primary key
+#  deleted_at      :datetime
 #  interval        :enum             default("daily")
 #  name            :enum
 #  ownable_type    :string           not null
@@ -18,6 +19,8 @@
 #
 
 class Metric < ApplicationRecord
+  acts_as_paranoid
+
   include EntityTimeRepresentation
 
   enum interval: { daily: 'daily', weekly: 'weekly', monthly: 'monthly', all_times: 'all_times' }

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -3,6 +3,7 @@
 # Table name: projects
 #
 #  id          :bigint           not null, primary key
+#  deleted_at  :datetime
 #  description :string
 #  is_private  :boolean
 #  name        :string
@@ -18,6 +19,8 @@
 #
 
 class Project < ApplicationRecord
+  acts_as_paranoid
+
   enum relevance: {
     commercial: 'commercial',
     internal: 'internal',
@@ -28,6 +31,10 @@ class Project < ApplicationRecord
   belongs_to :language
 
   has_many :events, dependent: :destroy
+  has_many :repositories,
+           class_name: 'Events::Repository',
+           dependent: :destroy,
+           inverse_of: :project
   has_many :pull_requests,
            class_name: 'Events::PullRequest',
            dependent: :destroy,

--- a/app/models/review_request.rb
+++ b/app/models/review_request.rb
@@ -3,6 +3,7 @@
 # Table name: review_requests
 #
 #  id              :bigint           not null, primary key
+#  deleted_at      :datetime
 #  state           :enum             default("active")
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
@@ -27,6 +28,8 @@
 #  fk_rails_...  (reviewer_id => users.id)
 #
 class ReviewRequest < ApplicationRecord
+  acts_as_paranoid
+
   enum state: { active: 'active', removed: 'removed' }
 
   belongs_to :owner, class_name: 'User',

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -57,6 +57,10 @@ class User < ApplicationRecord
            class_name: 'Events::Push',
            dependent: :destroy,
            inverse_of: :sender
+  has_many :repositories,
+           class_name: 'Events::Repository',
+           dependent: :destroy,
+           inverse_of: :sender
   validates :github_id,
             :login,
             :node_id,

--- a/app/models/users_project.rb
+++ b/app/models/users_project.rb
@@ -3,6 +3,7 @@
 # Table name: users_projects
 #
 #  id         :bigint           not null, primary key
+#  deleted_at :datetime
 #  project_id :bigint
 #  user_id    :bigint
 #
@@ -13,6 +14,8 @@
 #
 
 class UsersProject < ApplicationRecord
+  acts_as_paranoid
+
   belongs_to :user
   belongs_to :project
   has_many :metrics, as: :ownable, dependent: :destroy

--- a/app/services/action_handlers/repository.rb
+++ b/app/services/action_handlers/repository.rb
@@ -1,6 +1,6 @@
 module ActionHandlers
   class Repository < ActionHandler
-    ACTIONS = %w[deleted archived unarchived transferred].freeze
+    ACTIONS = %w[deleted archived transferred].freeze
     private_constant :ACTIONS
 
     private
@@ -17,16 +17,17 @@ module ActionHandlers
       mark_as_deleted
     end
 
-    def unarchived
-      # TODO
-    end
-
     def transferred
-      mark_as_deleted
+      mark_as_deleted if from_organization?
     end
 
     def mark_as_deleted
-      # TODO
+      @entity.project.destroy!
+    end
+
+    def from_organization?
+      owner = @payload['changes']['owner']
+      owner && owner['from']['organization']['login'] == ENV.fetch('GITHUB_ORGANIZATION')
     end
   end
 end

--- a/app/services/action_handlers/repository.rb
+++ b/app/services/action_handlers/repository.rb
@@ -1,0 +1,32 @@
+module ActionHandlers
+  class Repository < ActionHandler
+    ACTIONS = %w[deleted archived unarchived transferred].freeze
+    private_constant :ACTIONS
+
+    private
+
+    def handleable?
+      ACTIONS.include?(@payload['action'])
+    end
+
+    def deleted
+      mark_as_deleted
+    end
+
+    def archived
+      mark_as_deleted
+    end
+
+    def unarchived
+      # TODO
+    end
+
+    def transferred
+      mark_as_deleted
+    end
+
+    def mark_as_deleted
+      # TODO
+    end
+  end
+end

--- a/app/services/builders/events/repository.rb
+++ b/app/services/builders/events/repository.rb
@@ -1,0 +1,21 @@
+module Builders
+  module Events
+    class Repository < Builders::Events::Base
+      private
+
+      def build
+        ::Events::Repository.create! do |repo|
+          repo.action = @payload['action']
+          repo.html_url = @payload['html_url']
+          repo.sender = find_or_create_user(@payload['sender'])
+          repo.project = project
+          find_or_create_user_project(repo.project.id, repo.sender.id)
+        end
+      end
+
+      def project
+        @project ||= Builders::Project.call(@payload['repository'])
+      end
+    end
+  end
+end

--- a/app/services/builders/project.rb
+++ b/app/services/builders/project.rb
@@ -11,7 +11,10 @@ module Builders
     private
 
     def fetch_or_create
-      ::Project.find_or_initialize_by(github_id: @repository_data['id']).tap do |project|
+      ::Project.with_deleted
+               .find_or_initialize_by(github_id: @repository_data['id'])
+               .tap do |project|
+        project.recover if project.deleted?
         project.name = @repository_data['name']
         project.description = @repository_data['description']
         project.is_private = @repository_data['private']

--- a/db/migrate/20210706143943_create_repositories.rb
+++ b/db/migrate/20210706143943_create_repositories.rb
@@ -1,0 +1,11 @@
+class CreateRepositories < ActiveRecord::Migration[6.0]
+  def change
+    create_table :repositories do |t|
+      t.string :action
+      t.string :html_url
+      t.timestamps
+      t.references :sender, null: false, foreign_key: { to_table: :users }
+      t.references :project, null: false, foreign_key: true
+    end
+  end
+end

--- a/db/migrate/20210707194545_add_deleted_at_to_projects_and_associations.rb
+++ b/db/migrate/20210707194545_add_deleted_at_to_projects_and_associations.rb
@@ -1,0 +1,20 @@
+class AddDeletedAtToProjectsAndAssociations < ActiveRecord::Migration[6.0]
+  def change
+    add_column :projects, :deleted_at, :datetime, index: true
+    add_column :events, :deleted_at, :datetime, index: true
+    add_column :pull_requests, :deleted_at, :datetime, index: true
+    add_column :review_comments, :deleted_at, :datetime, index: true
+    add_column :pushes, :deleted_at, :datetime, index: true
+    add_column :merge_times, :deleted_at, :datetime, index: true
+    add_column :reviews, :deleted_at, :datetime, index: true
+    add_column :review_requests, :deleted_at, :datetime, index: true
+    add_column :completed_review_turnarounds, :deleted_at, :datetime, index: true
+    add_column :users_projects, :deleted_at, :datetime, index: true
+    add_column :metrics, :deleted_at, :datetime, index: true
+    add_column :code_owner_projects, :deleted_at, :datetime, index: true
+    add_column :code_climate_project_metrics, :deleted_at, :datetime, index: true
+    add_column :jira_projects, :deleted_at, :datetime, index: true
+    add_column :jira_issues, :deleted_at, :datetime, index: true
+    add_column :repositories, :deleted_at, :datetime, index: true
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -338,7 +338,8 @@ CREATE TABLE public.code_climate_project_metrics (
     open_issues_count integer,
     snapshot_time timestamp without time zone,
     cc_repository_id character varying,
-    test_coverage numeric
+    test_coverage numeric,
+    deleted_at timestamp without time zone
 );
 
 
@@ -370,7 +371,8 @@ CREATE TABLE public.code_owner_projects (
     project_id bigint NOT NULL,
     user_id bigint NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
+    updated_at timestamp(6) without time zone NOT NULL,
+    deleted_at timestamp without time zone
 );
 
 
@@ -402,7 +404,8 @@ CREATE TABLE public.completed_review_turnarounds (
     review_request_id bigint NOT NULL,
     value integer,
     created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
+    updated_at timestamp(6) without time zone NOT NULL,
+    deleted_at timestamp without time zone
 );
 
 
@@ -469,7 +472,8 @@ CREATE TABLE public.events (
     data jsonb,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
-    project_id bigint NOT NULL
+    project_id bigint NOT NULL,
+    deleted_at timestamp without time zone
 );
 
 
@@ -683,7 +687,8 @@ CREATE TABLE public.jira_issues (
     updated_at timestamp(6) without time zone NOT NULL,
     issue_type public.issue_type NOT NULL,
     environment public.environment,
-    key character varying
+    key character varying,
+    deleted_at timestamp without time zone
 );
 
 
@@ -716,7 +721,8 @@ CREATE TABLE public.jira_projects (
     jira_project_key character varying NOT NULL,
     project_name character varying,
     created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
+    updated_at timestamp(6) without time zone NOT NULL,
+    deleted_at timestamp without time zone
 );
 
 
@@ -778,7 +784,8 @@ CREATE TABLE public.merge_times (
     pull_request_id bigint NOT NULL,
     value integer,
     created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
+    updated_at timestamp(6) without time zone NOT NULL,
+    deleted_at timestamp without time zone
 );
 
 
@@ -814,7 +821,8 @@ CREATE TABLE public.metrics (
     ownable_type character varying NOT NULL,
     ownable_id bigint NOT NULL,
     name public.metric_name,
-    "interval" public.metric_interval DEFAULT 'daily'::public.metric_interval
+    "interval" public.metric_interval DEFAULT 'daily'::public.metric_interval,
+    deleted_at timestamp without time zone
 );
 
 
@@ -850,7 +858,8 @@ CREATE TABLE public.projects (
     updated_at timestamp(6) without time zone NOT NULL,
     language_id bigint,
     is_private boolean,
-    relevance public.project_relevance DEFAULT 'unassigned'::public.project_relevance NOT NULL
+    relevance public.project_relevance DEFAULT 'unassigned'::public.project_relevance NOT NULL,
+    deleted_at timestamp without time zone
 );
 
 
@@ -896,7 +905,8 @@ CREATE TABLE public.pull_requests (
     owner_id bigint,
     html_url character varying,
     branch character varying,
-    size integer
+    size integer,
+    deleted_at timestamp without time zone
 );
 
 
@@ -930,7 +940,8 @@ CREATE TABLE public.pushes (
     sender_id bigint NOT NULL,
     ref character varying,
     created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
+    updated_at timestamp(6) without time zone NOT NULL,
+    deleted_at timestamp without time zone
 );
 
 
@@ -964,7 +975,8 @@ CREATE TABLE public.repositories (
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
     sender_id bigint NOT NULL,
-    project_id bigint NOT NULL
+    project_id bigint NOT NULL,
+    deleted_at timestamp without time zone
 );
 
 
@@ -999,7 +1011,8 @@ CREATE TABLE public.review_comments (
     updated_at timestamp(6) without time zone NOT NULL,
     pull_request_id bigint NOT NULL,
     owner_id bigint,
-    state public.review_comment_state DEFAULT 'active'::public.review_comment_state
+    state public.review_comment_state DEFAULT 'active'::public.review_comment_state,
+    deleted_at timestamp without time zone
 );
 
 
@@ -1034,7 +1047,8 @@ CREATE TABLE public.review_requests (
     pull_request_id bigint NOT NULL,
     reviewer_id bigint NOT NULL,
     state public.review_request_state DEFAULT 'active'::public.review_request_state,
-    project_id bigint
+    project_id bigint,
+    deleted_at timestamp without time zone
 );
 
 
@@ -1104,7 +1118,8 @@ CREATE TABLE public.reviews (
     state public.review_state NOT NULL,
     opened_at timestamp without time zone NOT NULL,
     review_request_id bigint,
-    project_id bigint
+    project_id bigint,
+    deleted_at timestamp without time zone
 );
 
 
@@ -1241,7 +1256,8 @@ ALTER SEQUENCE public.users_id_seq OWNED BY public.users.id;
 CREATE TABLE public.users_projects (
     id bigint NOT NULL,
     user_id bigint,
-    project_id bigint
+    project_id bigint,
+    deleted_at timestamp without time zone
 );
 
 
@@ -2486,6 +2502,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20210316150725'),
 ('20210317024356'),
 ('20210318034939'),
-('20210706143943');
+('20210706143943'),
+('20210707194545');
 
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -954,6 +954,40 @@ ALTER SEQUENCE public.pushes_id_seq OWNED BY public.pushes.id;
 
 
 --
+-- Name: repositories; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.repositories (
+    id bigint NOT NULL,
+    action character varying,
+    html_url character varying,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL,
+    sender_id bigint NOT NULL,
+    project_id bigint NOT NULL
+);
+
+
+--
+-- Name: repositories_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.repositories_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: repositories_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.repositories_id_seq OWNED BY public.repositories.id;
+
+
+--
 -- Name: review_comments; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -1385,6 +1419,13 @@ ALTER TABLE ONLY public.pushes ALTER COLUMN id SET DEFAULT nextval('public.pushe
 
 
 --
+-- Name: repositories id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.repositories ALTER COLUMN id SET DEFAULT nextval('public.repositories_id_seq'::regclass);
+
+
+--
 -- Name: review_comments id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -1622,6 +1663,14 @@ ALTER TABLE ONLY public.pull_requests
 
 ALTER TABLE ONLY public.pushes
     ADD CONSTRAINT pushes_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: repositories repositories_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.repositories
+    ADD CONSTRAINT repositories_pkey PRIMARY KEY (id);
 
 
 --
@@ -1935,6 +1984,20 @@ CREATE INDEX index_pushes_on_sender_id ON public.pushes USING btree (sender_id);
 
 
 --
+-- Name: index_repositories_on_project_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_repositories_on_project_id ON public.repositories USING btree (project_id);
+
+
+--
+-- Name: index_repositories_on_sender_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_repositories_on_sender_id ON public.repositories USING btree (sender_id);
+
+
+--
 -- Name: index_review_comments_on_owner_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -2109,6 +2172,14 @@ ALTER TABLE ONLY public.review_turnarounds
 
 
 --
+-- Name: repositories fk_rails_36d1823ddd; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.repositories
+    ADD CONSTRAINT fk_rails_36d1823ddd FOREIGN KEY (project_id) REFERENCES public.projects(id);
+
+
+--
 -- Name: pushes fk_rails_3f633d82fd; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -2194,6 +2265,14 @@ ALTER TABLE ONLY public.code_owner_projects
 
 ALTER TABLE ONLY public.code_owner_projects
     ADD CONSTRAINT fk_rails_98029d380a FOREIGN KEY (project_id) REFERENCES public.projects(id);
+
+
+--
+-- Name: repositories fk_rails_9dbb09e26a; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.repositories
+    ADD CONSTRAINT fk_rails_9dbb09e26a FOREIGN KEY (sender_id) REFERENCES public.users(id);
 
 
 --
@@ -2406,6 +2485,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20210315154031'),
 ('20210316150725'),
 ('20210317024356'),
-('20210318034939');
+('20210318034939'),
+('20210706143943');
 
 

--- a/spec/factories/code_climate_project_metrics.rb
+++ b/spec/factories/code_climate_project_metrics.rb
@@ -4,6 +4,7 @@
 #
 #  id                    :bigint           not null, primary key
 #  code_climate_rate     :string
+#  deleted_at            :datetime
 #  invalid_issues_count  :integer
 #  open_issues_count     :integer
 #  snapshot_time         :datetime

--- a/spec/factories/code_owner_projects.rb
+++ b/spec/factories/code_owner_projects.rb
@@ -3,6 +3,7 @@
 # Table name: code_owner_projects
 #
 #  id         :bigint           not null, primary key
+#  deleted_at :datetime
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
 #  project_id :bigint           not null

--- a/spec/factories/completed_review_turnarounds.rb
+++ b/spec/factories/completed_review_turnarounds.rb
@@ -3,6 +3,7 @@
 # Table name: completed_review_turnarounds
 #
 #  id                :bigint           not null, primary key
+#  deleted_at        :datetime
 #  value             :integer
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -4,6 +4,7 @@
 #
 #  id              :bigint           not null, primary key
 #  data            :jsonb
+#  deleted_at      :datetime
 #  handleable_type :string
 #  name            :string
 #  type            :string

--- a/spec/factories/events/pull_requests.rb
+++ b/spec/factories/events/pull_requests.rb
@@ -6,6 +6,7 @@
 #  body       :text
 #  branch     :string
 #  closed_at  :datetime
+#  deleted_at :datetime
 #  draft      :boolean          not null
 #  html_url   :string
 #  locked     :boolean          not null

--- a/spec/factories/events/pushes.rb
+++ b/spec/factories/events/pushes.rb
@@ -3,6 +3,7 @@
 # Table name: pushes
 #
 #  id              :bigint           not null, primary key
+#  deleted_at      :datetime
 #  ref             :string
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null

--- a/spec/factories/events/repositories.rb
+++ b/spec/factories/events/repositories.rb
@@ -4,6 +4,7 @@
 #
 #  id         :bigint           not null, primary key
 #  action     :string
+#  deleted_at :datetime
 #  html_url   :string
 #  created_at :datetime         not null
 #  updated_at :datetime         not null

--- a/spec/factories/events/repositories.rb
+++ b/spec/factories/events/repositories.rb
@@ -1,0 +1,31 @@
+# == Schema Information
+#
+# Table name: repositories
+#
+#  id         :bigint           not null, primary key
+#  action     :string
+#  html_url   :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  project_id :bigint           not null
+#  sender_id  :bigint           not null
+#
+# Indexes
+#
+#  index_repositories_on_project_id  (project_id)
+#  index_repositories_on_sender_id   (sender_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (project_id => projects.id)
+#  fk_rails_...  (sender_id => users.id)
+#
+
+FactoryBot.define do
+  factory :repository, class: Events::Repository do
+    action { Events::Repository.actions.values.sample }
+    html_url { Faker::Internet.url(host: 'github.com') }
+    association :project
+    association :sender, factory: :user
+  end
+end

--- a/spec/factories/events/review_comments.rb
+++ b/spec/factories/events/review_comments.rb
@@ -4,6 +4,7 @@
 #
 #  id              :bigint           not null, primary key
 #  body            :string
+#  deleted_at      :datetime
 #  state           :enum             default("active")
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null

--- a/spec/factories/events/reviews.rb
+++ b/spec/factories/events/reviews.rb
@@ -4,6 +4,7 @@
 #
 #  id                :bigint           not null, primary key
 #  body              :string
+#  deleted_at        :datetime
 #  opened_at         :datetime         not null
 #  state             :enum             not null
 #  created_at        :datetime         not null

--- a/spec/factories/metrics.rb
+++ b/spec/factories/metrics.rb
@@ -3,6 +3,7 @@
 # Table name: metrics
 #
 #  id              :bigint           not null, primary key
+#  deleted_at      :datetime
 #  interval        :enum             default("daily")
 #  name            :enum
 #  ownable_type    :string           not null

--- a/spec/factories/payloads/repository.rb
+++ b/spec/factories/payloads/repository.rb
@@ -23,4 +23,15 @@ FactoryBot.define do
       repository_payload['full_name'] = "#{owner}/#{repository_name}"
     end
   end
+
+  factory :repository_event_payload, class: Hash do
+    skip_create
+
+    action { Events::Repository.actions.values.sample }
+    html_url { Faker::Internet.url(host: 'github.com') }
+    repository { create(:repository_payload) }
+    sender { (attributes_for :user, id: generate(:user_id)).as_json }
+
+    initialize_with { attributes.deep_stringify_keys }
+  end
 end

--- a/spec/factories/payloads/repository.rb
+++ b/spec/factories/payloads/repository.rb
@@ -31,6 +31,7 @@ FactoryBot.define do
     html_url { Faker::Internet.url(host: 'github.com') }
     repository { create(:repository_payload) }
     sender { (attributes_for :user, id: generate(:user_id)).as_json }
+    changes { { 'owner': { 'from': { 'organization': { 'login': 'rootstrap' } } } } }
 
     initialize_with { attributes.deep_stringify_keys }
   end

--- a/spec/factories/projects.rb
+++ b/spec/factories/projects.rb
@@ -3,6 +3,7 @@
 # Table name: projects
 #
 #  id          :bigint           not null, primary key
+#  deleted_at  :datetime
 #  description :string
 #  is_private  :boolean
 #  name        :string

--- a/spec/factories/projects.rb
+++ b/spec/factories/projects.rb
@@ -20,7 +20,7 @@
 FactoryBot.define do
   factory :project do
     sequence(:github_id, 1000)
-    name { Faker::App.name.gsub(' ', '') }
+    name { Faker::App.name.split.first }
     description { Faker::FunnyName.name }
     language { Language.unassigned }
     is_private { false }

--- a/spec/models/code_climate_project_metric_spec.rb
+++ b/spec/models/code_climate_project_metric_spec.rb
@@ -4,6 +4,7 @@
 #
 #  id                    :bigint           not null, primary key
 #  code_climate_rate     :string
+#  deleted_at            :datetime
 #  invalid_issues_count  :integer
 #  open_issues_count     :integer
 #  snapshot_time         :datetime

--- a/spec/models/code_owner_project_spec.rb
+++ b/spec/models/code_owner_project_spec.rb
@@ -3,6 +3,7 @@
 # Table name: code_owner_projects
 #
 #  id         :bigint           not null, primary key
+#  deleted_at :datetime
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
 #  project_id :bigint           not null

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -4,6 +4,7 @@
 #
 #  id              :bigint           not null, primary key
 #  data            :jsonb
+#  deleted_at      :datetime
 #  handleable_type :string
 #  name            :string
 #  type            :string

--- a/spec/models/events/pull_request_spec.rb
+++ b/spec/models/events/pull_request_spec.rb
@@ -6,6 +6,7 @@
 #  body       :text
 #  branch     :string
 #  closed_at  :datetime
+#  deleted_at :datetime
 #  draft      :boolean          not null
 #  html_url   :string
 #  locked     :boolean          not null

--- a/spec/models/events/push_spec.rb
+++ b/spec/models/events/push_spec.rb
@@ -3,6 +3,7 @@
 # Table name: pushes
 #
 #  id              :bigint           not null, primary key
+#  deleted_at      :datetime
 #  ref             :string
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null

--- a/spec/models/events/repository_spec.rb
+++ b/spec/models/events/repository_spec.rb
@@ -4,6 +4,7 @@
 #
 #  id         :bigint           not null, primary key
 #  action     :string
+#  deleted_at :datetime
 #  html_url   :string
 #  created_at :datetime         not null
 #  updated_at :datetime         not null

--- a/spec/models/events/repository_spec.rb
+++ b/spec/models/events/repository_spec.rb
@@ -1,0 +1,38 @@
+# == Schema Information
+#
+# Table name: repositories
+#
+#  id         :bigint           not null, primary key
+#  action     :string
+#  html_url   :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  project_id :bigint           not null
+#  sender_id  :bigint           not null
+#
+# Indexes
+#
+#  index_repositories_on_project_id  (project_id)
+#  index_repositories_on_sender_id   (sender_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (project_id => projects.id)
+#  fk_rails_...  (sender_id => users.id)
+#
+
+require 'rails_helper'
+
+RSpec.describe Events::Repository, type: :model do
+  context 'validations' do
+    subject { build(:repository) }
+
+    it 'is valid with valid attributes' do
+      expect(subject).to be_valid
+    end
+
+    it { is_expected.to have_one(:event) }
+    it { is_expected.to belong_to(:sender) }
+    it { is_expected.to belong_to(:project) }
+  end
+end

--- a/spec/models/events/review_comment_spec.rb
+++ b/spec/models/events/review_comment_spec.rb
@@ -4,6 +4,7 @@
 #
 #  id              :bigint           not null, primary key
 #  body            :string
+#  deleted_at      :datetime
 #  state           :enum             default("active")
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null

--- a/spec/models/events/review_spec.rb
+++ b/spec/models/events/review_spec.rb
@@ -4,6 +4,7 @@
 #
 #  id                :bigint           not null, primary key
 #  body              :string
+#  deleted_at        :datetime
 #  opened_at         :datetime         not null
 #  state             :enum             not null
 #  created_at        :datetime         not null

--- a/spec/models/jira_issue_spec.rb
+++ b/spec/models/jira_issue_spec.rb
@@ -3,6 +3,7 @@
 # Table name: jira_issues
 #
 #  id              :bigint           not null, primary key
+#  deleted_at      :datetime
 #  environment     :enum
 #  informed_at     :datetime         not null
 #  issue_type      :enum             not null

--- a/spec/models/jira_project_spec.rb
+++ b/spec/models/jira_project_spec.rb
@@ -3,6 +3,7 @@
 # Table name: jira_projects
 #
 #  id               :bigint           not null, primary key
+#  deleted_at       :datetime
 #  jira_project_key :string           not null
 #  project_name     :string
 #  created_at       :datetime         not null

--- a/spec/models/merge_time_spec.rb
+++ b/spec/models/merge_time_spec.rb
@@ -3,6 +3,7 @@
 # Table name: merge_times
 #
 #  id              :bigint           not null, primary key
+#  deleted_at      :datetime
 #  value           :integer
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null

--- a/spec/models/metric_spec.rb
+++ b/spec/models/metric_spec.rb
@@ -3,6 +3,7 @@
 # Table name: metrics
 #
 #  id              :bigint           not null, primary key
+#  deleted_at      :datetime
 #  interval        :enum             default("daily")
 #  name            :enum
 #  ownable_type    :string           not null

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -3,6 +3,7 @@
 # Table name: projects
 #
 #  id          :bigint           not null, primary key
+#  deleted_at  :datetime
 #  description :string
 #  is_private  :boolean
 #  name        :string

--- a/spec/models/users_project_spec.rb
+++ b/spec/models/users_project_spec.rb
@@ -3,6 +3,7 @@
 # Table name: users_projects
 #
 #  id         :bigint           not null, primary key
+#  deleted_at :datetime
 #  project_id :bigint
 #  user_id    :bigint
 #

--- a/spec/services/builders/action_handlers/repository_spec.rb
+++ b/spec/services/builders/action_handlers/repository_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+describe ActionHandlers::Repository do
+  describe '.call' do
+    let(:payload) { create(:repository_event_payload, action: action) }
+    let!(:repository) { create(:repository) }
+
+    subject(:handle_action) { described_class.call(payload: payload, entity: repository) }
+
+    handleable_actions = %w[deleted archived transferred].freeze
+    unhandleable_actions = Events::Repository.actions.values - handleable_actions
+
+    context 'when the action is handleable' do
+      handleable_actions.each do |action|
+        let(:action) { action }
+
+        it 'marks the project as deleted' do
+          expect { handle_action }.to change(Project, :count)
+          expect(repository.project.deleted?).to be(true)
+        end
+      end
+    end
+
+    context 'when the action is unhandleable' do
+      unhandleable_actions.each do |action|
+        let(:action) { action }
+
+        it 'does not mark the project as deleted' do
+          expect { handle_action }.not_to change(Project, :count)
+          expect(repository.project.deleted?).to be(false)
+        end
+      end
+    end
+  end
+end

--- a/spec/services/builders/events/repository_spec.rb
+++ b/spec/services/builders/events/repository_spec.rb
@@ -1,0 +1,21 @@
+describe Builders::Events::Repository do
+  describe '.call' do
+    let(:payload) { create(:repository_event_payload) }
+    let(:repository_payload) { payload['repository'] }
+    let(:user_payload) { payload['sender'] }
+
+    subject { described_class.call(payload: payload) }
+
+    it 'creates a new Repository Event' do
+      expect { subject }.to change { Events::Repository.count }.by(1)
+    end
+
+    it 'creates or assigns correctly its attributes' do
+      expect(subject.html_url).to eq(payload['html_url'])
+      expect(subject.action).to eq(payload['action'])
+      expect(subject.project.github_id).to eq(repository_payload['id'])
+      expect(subject.sender.github_id).to eq(user_payload['id'])
+      expect(subject.sender.projects).to include(subject.project)
+    end
+  end
+end


### PR DESCRIPTION
## What does this PR do?

Handles repository events from github, so we can process them and soft-delete projects from our system when those repos are `archived`, `transferred` or `deleted`.

This PR is one part of the full feature.

Resolves https://rootstrap.atlassian.net/jira/software/projects/EM/boards/42?selectedIssue=EM-201 (in part)
