### PR TITLE
Add Product model

### DIFF
--- a/app/admin/products.rb
+++ b/app/admin/products.rb
@@ -1,0 +1,14 @@
+ActiveAdmin.register Product do
+  permit_params :description, :name
+
+  index do
+    selectable_column
+    id_column
+    column :name
+    column :description
+    actions
+  end
+
+  filter :name
+  filter :description
+end

--- a/app/models/jira_project.rb
+++ b/app/models/jira_project.rb
@@ -7,19 +7,19 @@
 #  project_name     :string
 #  created_at       :datetime         not null
 #  updated_at       :datetime         not null
-#  project_id       :bigint
+#  product_id       :bigint
 #
 # Indexes
 #
-#  index_jira_projects_on_project_id  (project_id)
+#  index_jira_projects_on_product_id  (product_id)
 #
 # Foreign Keys
 #
-#  fk_rails_...  (project_id => projects.id)
+#  fk_rails_...  (product_id => products.id)
 #
 
 class JiraProject < ApplicationRecord
-  belongs_to :project
+  belongs_to :product
 
   has_many :jira_issues, dependent: :destroy
 

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -1,0 +1,23 @@
+# == Schema Information
+#
+# Table name: products
+#
+#  id          :bigint           not null, primary key
+#  description :string
+#  name        :string           not null
+#
+# Indexes
+#
+#  index_products_on_name  (name)
+#
+
+class Product < ApplicationRecord
+  has_one :jira_project, dependent: :destroy
+
+  has_many :projects, dependent: :destroy
+  has_many :metrics, as: :ownable, dependent: :destroy
+
+  validates :name, presence: true, uniqueness: true
+
+  accepts_nested_attributes_for :jira_project
+end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -11,10 +11,16 @@
 #  updated_at  :datetime         not null
 #  github_id   :integer          not null
 #  language_id :bigint
+#  product_id  :bigint
 #
 # Indexes
 #
 #  index_projects_on_language_id  (language_id)
+#  index_projects_on_product_id   (product_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (product_id => products.id)
 #
 
 class Project < ApplicationRecord
@@ -26,6 +32,7 @@ class Project < ApplicationRecord
   }
 
   belongs_to :language
+  belongs_to :product, optional: true
 
   has_many :events, dependent: :destroy
   has_many :pull_requests,
@@ -49,13 +56,13 @@ class Project < ApplicationRecord
            source: :user
 
   has_one :code_climate_project_metric, dependent: :destroy
-  has_one :jira_project, dependent: :destroy
-  accepts_nested_attributes_for :jira_project
 
   validates :github_id, presence: true, uniqueness: true
   validates :relevance, inclusion: { in: relevances.keys }
 
   before_validation :set_default_language, on: :create
+
+  delegate :jira_project, to: :product
 
   scope :open_source, lambda {
     internal.with_language.where(is_private: false)

--- a/app/services/builders/chartkick/development_metrics.rb
+++ b/app/services/builders/chartkick/development_metrics.rb
@@ -51,7 +51,7 @@ module Builders
         end
 
         def project_has_jira_board_associated?(project_id)
-          ::Project.find(project_id).jira_project.present?
+          ::Project.find(project_id).jira_project&.present?
         end
       end
 

--- a/app/services/metrics/defect_escape_rate/per_project.rb
+++ b/app/services/metrics/defect_escape_rate/per_project.rb
@@ -13,8 +13,8 @@ module Metrics
       end
 
       def query(interval)
-        project = JiraProject.find_by!(project_id: @entity_id)
-        bug_issues = project.jira_issues.bug.where(informed_at: interval)
+        product = Project.find(@entity_id).product
+        bug_issues = product.jira_project.jira_issues.bug.where(informed_at: interval)
         return [] if bug_issues.empty?
 
         defect_rate = bug_issues

--- a/db/migrate/20210707210306_create_products.rb
+++ b/db/migrate/20210707210306_create_products.rb
@@ -1,0 +1,10 @@
+class CreateProducts < ActiveRecord::Migration[6.0]
+  def change
+    create_table :products do |t|
+      t.string :name, null: false
+      t.string :description
+    end
+
+    add_index :products, :name
+  end
+end

--- a/db/migrate/20210707221342_create_products_metrics_join_table.rb
+++ b/db/migrate/20210707221342_create_products_metrics_join_table.rb
@@ -1,0 +1,7 @@
+class CreateProductsMetricsJoinTable < ActiveRecord::Migration[6.0]
+  def change
+    create_join_table :products, :metrics do |t|
+      t.index %i[product_id metric_id]
+    end
+  end
+end

--- a/db/migrate/20210707225815_projects_add_product_reference.rb
+++ b/db/migrate/20210707225815_projects_add_product_reference.rb
@@ -1,0 +1,7 @@
+class ProjectsAddProductReference < ActiveRecord::Migration[6.0]
+  def change
+    change_table :projects do |t|
+      t.references :product, foreign_key: true
+    end
+  end
+end

--- a/db/migrate/20210708153602_remove_jira_project_from_project.rb
+++ b/db/migrate/20210708153602_remove_jira_project_from_project.rb
@@ -1,0 +1,13 @@
+class RemoveJiraProjectFromProject < ActiveRecord::Migration[6.0]
+  def up
+    change_table :jira_projects do |t|
+      t.remove :project_id
+    end
+  end
+
+  def down
+    change_table :jira_projects do |t|
+      t.references :project, foreign_key: true
+    end
+  end
+end

--- a/db/migrate/20210712190532_jira_projects_add_product_reference.rb
+++ b/db/migrate/20210712190532_jira_projects_add_product_reference.rb
@@ -1,0 +1,7 @@
+class JiraProjectsAddProductReference < ActiveRecord::Migration[6.0]
+  def change
+    change_table :jira_projects do |t|
+      t.references :product, foreign_key: true
+    end
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -26,9 +26,17 @@ if Rails.env.development?
       Language.create(name: lang)
     end
 
+    product = Product.create!(name: 'rs-code-review-metrics',
+                              description: 'Project for tracking PKIs')
+
+    jira_project = JiraProject.create!(jira_project_key: 'RSCODE',
+                                       project_name: 'rs-code-review-metrics',
+                                       product: product)
+
     project = Project.create!(github_id: rand(1000),
                               name: 'rs-code-review-metrics',
-                              language: Language.find_by(name: 'ruby'))
+                              language: Language.find_by(name: 'ruby'),
+                              product: product)
 
     %w[santiagovidal santib hdamico horacio hvilloria sandro].each do |name|
       FactoryBot.create(:user, login: name)
@@ -66,9 +74,17 @@ if Rails.env.development?
       end
     end
 
+    second_product = Product.create!(name: 'forecast',
+                                     description: 'Forecast')
+
+    second_jira_project = JiraProject.create!(jira_project_key: 'forc',
+                                              project_name: 'forecast',
+                                              product: second_product)
+
     second_project = Project.create!(github_id: rand(1000),
                                      name: 'forecast',
-                                     language: Language.find_by(name: 'ruby'))
+                                     language: Language.find_by(name: 'ruby'),
+                                     product: second_product)
 
     %w[juan pedro].each do |name|
       FactoryBot.create(:user, login: name)

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -712,11 +712,11 @@ ALTER SEQUENCE public.jira_issues_id_seq OWNED BY public.jira_issues.id;
 
 CREATE TABLE public.jira_projects (
     id bigint NOT NULL,
-    project_id bigint,
     jira_project_key character varying NOT NULL,
     project_name character varying,
     created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
+    updated_at timestamp(6) without time zone NOT NULL,
+    product_id bigint
 );
 
 
@@ -838,6 +838,46 @@ ALTER SEQUENCE public.metrics_id_seq OWNED BY public.metrics.id;
 
 
 --
+-- Name: metrics_products; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.metrics_products (
+    product_id bigint NOT NULL,
+    metric_id bigint NOT NULL
+);
+
+
+--
+-- Name: products; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.products (
+    id bigint NOT NULL,
+    name character varying NOT NULL,
+    description character varying
+);
+
+
+--
+-- Name: products_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.products_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: products_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.products_id_seq OWNED BY public.products.id;
+
+
+--
 -- Name: projects; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -850,7 +890,8 @@ CREATE TABLE public.projects (
     updated_at timestamp(6) without time zone NOT NULL,
     language_id bigint,
     is_private boolean,
-    relevance public.project_relevance DEFAULT 'unassigned'::public.project_relevance NOT NULL
+    relevance public.project_relevance DEFAULT 'unassigned'::public.project_relevance NOT NULL,
+    product_id bigint
 );
 
 
@@ -1364,6 +1405,13 @@ ALTER TABLE ONLY public.metrics ALTER COLUMN id SET DEFAULT nextval('public.metr
 
 
 --
+-- Name: products id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.products ALTER COLUMN id SET DEFAULT nextval('public.products_id_seq'::regclass);
+
+
+--
 -- Name: projects id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -1598,6 +1646,14 @@ ALTER TABLE ONLY public.merge_times
 
 ALTER TABLE ONLY public.metrics
     ADD CONSTRAINT metrics_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: products products_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.products
+    ADD CONSTRAINT products_pkey PRIMARY KEY (id);
 
 
 --
@@ -1851,10 +1907,10 @@ CREATE INDEX index_jira_issues_on_jira_project_id ON public.jira_issues USING bt
 
 
 --
--- Name: index_jira_projects_on_project_id; Type: INDEX; Schema: public; Owner: -
+-- Name: index_jira_projects_on_product_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_jira_projects_on_project_id ON public.jira_projects USING btree (project_id);
+CREATE INDEX index_jira_projects_on_product_id ON public.jira_projects USING btree (product_id);
 
 
 --
@@ -1879,10 +1935,31 @@ CREATE INDEX index_metrics_on_ownable_type_and_ownable_id ON public.metrics USIN
 
 
 --
+-- Name: index_metrics_products_on_product_id_and_metric_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_metrics_products_on_product_id_and_metric_id ON public.metrics_products USING btree (product_id, metric_id);
+
+
+--
+-- Name: index_products_on_name; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_products_on_name ON public.products USING btree (name);
+
+
+--
 -- Name: index_projects_on_language_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_projects_on_language_id ON public.projects USING btree (language_id);
+
+
+--
+-- Name: index_projects_on_product_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_projects_on_product_id ON public.projects USING btree (product_id);
 
 
 --
@@ -2077,6 +2154,14 @@ ALTER TABLE ONLY public.completed_review_turnarounds
 
 
 --
+-- Name: projects fk_rails_21e11c2480; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.projects
+    ADD CONSTRAINT fk_rails_21e11c2480 FOREIGN KEY (product_id) REFERENCES public.products(id);
+
+
+--
 -- Name: pushes fk_rails_2981d8bb5a; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -2114,14 +2199,6 @@ ALTER TABLE ONLY public.review_turnarounds
 
 ALTER TABLE ONLY public.pushes
     ADD CONSTRAINT fk_rails_3f633d82fd FOREIGN KEY (project_id) REFERENCES public.projects(id);
-
-
---
--- Name: jira_projects fk_rails_42da1c3599; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.jira_projects
-    ADD CONSTRAINT fk_rails_42da1c3599 FOREIGN KEY (project_id) REFERENCES public.projects(id);
 
 
 --
@@ -2250,6 +2327,14 @@ ALTER TABLE ONLY public.review_requests
 
 ALTER TABLE ONLY public.review_requests
     ADD CONSTRAINT fk_rails_dd17aeab6c FOREIGN KEY (project_id) REFERENCES public.projects(id);
+
+
+--
+-- Name: jira_projects fk_rails_eaa3060e1c; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.jira_projects
+    ADD CONSTRAINT fk_rails_eaa3060e1c FOREIGN KEY (product_id) REFERENCES public.products(id);
 
 
 --
@@ -2406,6 +2491,11 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20210315154031'),
 ('20210316150725'),
 ('20210317024356'),
-('20210318034939');
+('20210318034939'),
+('20210707210306'),
+('20210707221342'),
+('20210707225815'),
+('20210708153602'),
+('20210712190532');
 
 

--- a/spec/controllers/development_metrics_controller_spec.rb
+++ b/spec/controllers/development_metrics_controller_spec.rb
@@ -4,8 +4,9 @@ describe DevelopmentMetricsController, type: :controller do
   fixtures :departments, :languages
 
   let(:ruby_lang) { Language.find_by(name: 'ruby') }
-  let(:project) { create(:project, name: 'rs-metrics', language: ruby_lang) }
-  let!(:jira_project) { create(:jira_project, project: project) }
+  let(:product) { create(:product) }
+  let(:project) { create(:project, name: 'rs-metrics', language: ruby_lang, product: product) }
+  let!(:jira_project) { create(:jira_project, product: product) }
   let(:beginning_of_day) { Time.zone.today.beginning_of_day }
 
   describe '#index' do

--- a/spec/factories/jira_project.rb
+++ b/spec/factories/jira_project.rb
@@ -20,8 +20,9 @@
 
 FactoryBot.define do
   factory :jira_project do
-    association :project
+    project_name { Faker::Lorem.sentence }
+    jira_project_key { Faker::Name.name }
 
-    jira_project_key { Faker::App.name }
+    product
   end
 end

--- a/spec/factories/products.rb
+++ b/spec/factories/products.rb
@@ -1,0 +1,19 @@
+# == Schema Information
+#
+# Table name: products
+#
+#  id          :bigint           not null, primary key
+#  description :string
+#  name        :string           not null
+#
+# Indexes
+#
+#  index_products_on_name  (name)
+#
+
+FactoryBot.define do
+  factory :product do
+    name { Faker::Name.name.gsub(' ', '') }
+    description { Faker::Lorem.sentence }
+  end
+end

--- a/spec/factories/projects.rb
+++ b/spec/factories/projects.rb
@@ -11,10 +11,16 @@
 #  updated_at  :datetime         not null
 #  github_id   :integer          not null
 #  language_id :bigint
+#  product_id  :bigint
 #
 # Indexes
 #
 #  index_projects_on_language_id  (language_id)
+#  index_projects_on_product_id   (product_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (product_id => products.id)
 #
 
 FactoryBot.define do
@@ -24,6 +30,7 @@ FactoryBot.define do
     description { Faker::FunnyName.name }
     language { Language.unassigned }
     is_private { false }
+    product
 
     transient do
       last_activity_in_weeks { 2 }

--- a/spec/models/jira_project_spec.rb
+++ b/spec/models/jira_project_spec.rb
@@ -7,15 +7,15 @@
 #  project_name     :string
 #  created_at       :datetime         not null
 #  updated_at       :datetime         not null
-#  project_id       :bigint
+#  product_id       :bigint
 #
 # Indexes
 #
-#  index_jira_projects_on_project_id  (project_id)
+#  index_jira_projects_on_product_id  (product_id)
 #
 # Foreign Keys
 #
-#  fk_rails_...  (project_id => projects.id)
+#  fk_rails_...  (product_id => products.id)
 #
 require 'rails_helper'
 
@@ -31,6 +31,6 @@ RSpec.describe JiraProject, type: :model do
     it { is_expected.to validate_uniqueness_of(:jira_project_key) }
 
     it { is_expected.to have_many(:jira_issues) }
-    it { is_expected.to belong_to(:project) }
+    it { is_expected.to belong_to(:product) }
   end
 end

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -1,0 +1,39 @@
+# == Schema Information
+#
+# Table name: products
+#
+#  id          :bigint           not null, primary key
+#  description :string
+#  name        :string           not null
+#
+# Indexes
+#
+#  index_products_on_name  (name)
+#
+
+require 'rails_helper'
+
+describe Product, type: :model do
+  subject { build :product }
+
+  context 'validations' do
+    context 'with valid attributes' do
+      it 'is valid' do
+        expect(subject).to be_valid
+      end
+
+      it { is_expected.to validate_presence_of(:name) }
+      it { is_expected.to validate_uniqueness_of(:name) }
+      it { is_expected.to have_many(:projects) }
+      it { is_expected.to have_many(:metrics) }
+      it { is_expected.to have_one(:jira_project) }
+    end
+
+    context 'with invalid attributes' do
+      it 'is not valid without name' do
+        subject.name = nil
+        expect(subject).to_not be_valid
+      end
+    end
+  end
+end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -11,15 +11,21 @@
 #  updated_at  :datetime         not null
 #  github_id   :integer          not null
 #  language_id :bigint
+#  product_id  :bigint
 #
 # Indexes
 #
 #  index_projects_on_language_id  (language_id)
+#  index_projects_on_product_id   (product_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (product_id => products.id)
 #
 
 require 'rails_helper'
 
-RSpec.describe Project, type: :model do
+describe Project, type: :model do
   subject { build :project }
 
   context 'validations' do
@@ -34,7 +40,6 @@ RSpec.describe Project, type: :model do
 
     it { is_expected.to validate_uniqueness_of(:github_id) }
     it { is_expected.to have_many(:events) }
-    it { is_expected.to have_one(:jira_project) }
   end
 
   describe '#open_source' do

--- a/spec/services/builders/chartkick/development_metrics_spec.rb
+++ b/spec/services/builders/chartkick/development_metrics_spec.rb
@@ -2,8 +2,9 @@ require 'rails_helper'
 
 RSpec.describe Builders::Chartkick::DevelopmentMetrics do
   describe Builders::Chartkick::DevelopmentMetrics::Project do
-    let(:project) { create(:project) }
-    let!(:jira_project) { create(:jira_project, project: project) }
+    let(:product) { create(:product) }
+    let(:project) { create(:project, product: product) }
+    let!(:jira_project) { create(:jira_project, product: product) }
     let(:period) { 4 }
     let(:review_turnaround_entities) { %i[per_project per_users_project per_project_distribution] }
     let(:merge_time_entities) { %i[per_project per_users_project per_project_distribution] }

--- a/spec/services/metrics/defect_escape_rate/per_project_spec.rb
+++ b/spec/services/metrics/defect_escape_rate/per_project_spec.rb
@@ -1,7 +1,10 @@
+require 'rails_helper'
+
 describe Metrics::DefectEscapeRate::PerProject do
   describe '.call' do
-    let(:project) { create(:project) }
-    let!(:jira_project) { create(:jira_project, project: project) }
+    let(:product) { create(:product) }
+    let(:project) { create(:project, product: product) }
+    let!(:jira_project) { create(:jira_project, product: product) }
     let(:beginning_of_day) { Time.zone.today.beginning_of_day }
     let(:subject) { described_class.call(project.id) }
 

--- a/spec/services/processors/jira_project_defect_escape_rate_updater_spec.rb
+++ b/spec/services/processors/jira_project_defect_escape_rate_updater_spec.rb
@@ -2,9 +2,10 @@ require 'rails_helper'
 
 RSpec.describe Processors::JiraProjectDefectEscapeRateUpdater do
   describe '#call' do
-    let(:project) { create(:project) }
+    let(:product) { create(:product) }
+    let(:project) { create(:project, product: product) }
     let(:project_key) { 'TES' }
-    let!(:jira_project) { create(:jira_project, project: project, jira_project_key: project_key) }
+    let!(:jira_project) { create(:jira_project, product: product, jira_project_key: project_key) }
     let(:subject) { described_class.call(jira_project) }
     let(:bugs) do
       [


### PR DESCRIPTION
## What does this PR do?

Creates a new entity `Product`, which represents a product from a client. This product is managed in a Jira project and has some KPIs. At the moment, only Defect Escape Rate is supported. In addition, a product have several Github repositories (`project` entity).

This PR is one part of the full feature. Next steps includes adding this information in the frontend.


Resolves [EM-223](https://rootstrap.atlassian.net/browse/EM-223) (in part).
