### PR TITLE
Redisign UX/UI to add new Product entity

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -63,7 +63,7 @@ detectors:
     exclude: []
   RepeatedConditional:
     enabled: true
-    exclude: []
+    exclude: ['DevelopmentMetricsController']
     max_ifs: 3
   SubclassedFromCoreClass:
     enabled: true

--- a/app/admin/jira_projects.rb
+++ b/app/admin/jira_projects.rb
@@ -1,0 +1,32 @@
+ActiveAdmin.register JiraProject do
+  index do
+    selectable_column
+    id_column
+    column :jira_project_key
+    column :project_name
+    actions
+  end
+
+  filter :product
+  filter :jira_project_key
+
+  show do
+    attributes_table do
+      row :id
+      row :jira_project_key
+      row :project_name
+      row :product
+      row :created_at
+      row :updated_at
+    end
+  end
+
+  form do |f|
+    f.inputs do
+      f.input :jira_project_key
+      f.input :project_name, required: false
+      f.input :product
+      actions
+    end
+  end
+end

--- a/app/admin/products.rb
+++ b/app/admin/products.rb
@@ -1,14 +1,61 @@
 ActiveAdmin.register Product do
-  permit_params :description, :name
+  permit_params :id, :description, :name, :jira_key, :new_jira_key,
+                jira_project_attributes: %i[id jira_project_key],
+                project_ids: []
 
   index do
     selectable_column
     id_column
     column :name
     column :description
+    column :jira_project do |product|
+      product.jira_project&.jira_project_key
+    end
     actions
+  end
+
+  show do
+    attributes_table(*default_attribute_table_rows) do
+      attributes_table_for product.jira_project do
+        row :jira_project_key
+      end
+
+      table_for product.projects.order('name ASC') do
+        column 'Projects' do |project|
+          link_to project.name, [:admin, project]
+        end
+      end
+    end
   end
 
   filter :name
   filter :description
+
+  form do |f|
+    f.inputs do
+      f.input :name
+      f.input :description, required: false
+      if object.jira_project
+        f.inputs for: [:jira_project, f.object.jira_project] do |s|
+          s.input :jira_project_key
+        end
+      end
+
+      f.input :projects, as: :check_boxes
+    end
+    f.actions
+  end
+
+  controller do
+    def update
+      @product = resource
+      product_service = ProductService.new(@product)
+
+      respond_to do |format|
+        product_service.update!(resource_params[0])
+        format.html { redirect_to admin_product_path(@product) }
+        format.json { render json: @product }
+      end
+    end
+  end
 end

--- a/app/admin/projects.rb
+++ b/app/admin/projects.rb
@@ -6,7 +6,6 @@ ActiveAdmin.register Project do
     selectable_column
     id_column
     column :github_id
-    column :jira_key
     column :name
     column :description
     column :language_id do |r|
@@ -16,15 +15,8 @@ ActiveAdmin.register Project do
     actions
   end
 
-  show do
-    attributes_table(*default_attribute_table_rows) do
-      row :jira_key
-    end
-  end
-
   filter :name
   filter :is_private
-  filter :jira_key, label: 'Jira Project Key'
   filter :github_id, label: 'GITHUB ID'
   filter :relevance, as: :select, collection: Project.relevances.values
   filter :language, as: :select, collection: -> { Language.order('LOWER(name)') }
@@ -40,16 +32,6 @@ ActiveAdmin.register Project do
       f.input :description, required: false
       f.input :language
       f.input :relevance, as: :radio, collection: Project.relevances.values
-      if object.jira_project
-        f.inputs for: [:jira_project, f.object.jira_project] do |s|
-          s.input :jira_project_key
-        end
-      else
-        jira_project = JiraProject.new(project: project)
-        f.inputs for: [:jira_project, jira_project] do |s|
-          s.input :jira_project_key, placeholder: 'Add your jira project key to link'
-        end
-      end
     end
     f.actions
   end

--- a/app/assets/stylesheets/shared/_sidebar.scss
+++ b/app/assets/stylesheets/shared/_sidebar.scss
@@ -1,6 +1,9 @@
 .project-selection {
   @include centered-flex-columns;
 }
+.product-selection {
+  @include centered-flex-columns;
+}
 .entity-btn {
   border-radius: 0px;
   margin-bottom: 5px;

--- a/app/controllers/development_metrics_controller.rb
+++ b/app/controllers/development_metrics_controller.rb
@@ -4,6 +4,12 @@ class DevelopmentMetricsController < ApplicationController
 
   def index; end
 
+  def products
+    return if metric_params.blank?
+
+    build_product_metrics(product.id, Product.name)
+  end
+
   def projects
     return if metric_params.blank?
 
@@ -23,6 +29,12 @@ class DevelopmentMetricsController < ApplicationController
 
   def users; end
 
+  def products_metrics
+    return if metric_params.blank?
+
+    build_product_metrics(product.id, Product.name)
+  end
+
   private
 
   def build_success_rates
@@ -38,6 +50,16 @@ class DevelopmentMetricsController < ApplicationController
     @merge_time = metrics[:merge_time]
     @pull_request_size = metrics[:pull_request_size]
     @defect_escape_rate = metrics[:defect_escape_rate]
+  end
+
+  def build_product_metrics(entity_id, entity_name)
+    metrics = Builders::Chartkick::DevelopmentMetrics.const_get(entity_name)
+                                                     .call(entity_id, metric_params[:period])
+    @defect_escape_rate = metrics[:defect_escape_rate]
+  end
+
+  def product
+    @product ||= Product.find_by(name: params[:product_name])
   end
 
   def project

--- a/app/helpers/models_names_helper.rb
+++ b/app/helpers/models_names_helper.rb
@@ -14,4 +14,8 @@ module ModelsNamesHelper
   def all_languages_names(department)
     department.languages.pluck(:name)
   end
+
+  def all_products_names
+    Product.pluck(:name).sort
+  end
 end

--- a/app/javascript/modules/sidebar/index.js
+++ b/app/javascript/modules/sidebar/index.js
@@ -9,14 +9,16 @@ let elementSelector = (className) => {
 
 export const disablePeriod = () => {
   const button = document.getElementById('submitButton');
-  let sidebarSelectionInput = elementSelector('project-selection') || elementSelector('department-selection');
+  const sidebarSelectionInput = elementSelector('project-selection') || elementSelector('department-selection')
+    || elementSelector('product-selection');
   if (sidebarSelectionInput && sidebarSelectionInput.selectedIndex === 0){
     button.disabled = true;
   }
 }
 
 export const handleChangeSidebar = () => {
-  const sidebarSelectionInput = elementSelector('project-selection') || elementSelector('department-selection');
+  const sidebarSelectionInput = elementSelector('project-selection') || elementSelector('department-selection')
+    || elementSelector('product-selection');
   if (sidebarSelectionInput != null) {
     sidebarSelectionInput.onchange = () => {
       submitNavForm()
@@ -49,7 +51,7 @@ export const handleChangeUser = () => {
 
 export const initializeSelect2 = () => {
   if (!elementSelector('select2')) {
-    $('.project-selection, .department-selection, .user-selection').select2({
+    $('.project-selection, .product-selection, .department-selection, .user-selection').select2({
       theme: 'bootstrap4',
     })
   }

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -20,4 +20,5 @@ class Product < ApplicationRecord
   validates :name, presence: true, uniqueness: true
 
   accepts_nested_attributes_for :jira_project
+  accepts_nested_attributes_for :projects
 end

--- a/app/services/builders/chartkick/defect_escape_rate_data.rb
+++ b/app/services/builders/chartkick/defect_escape_rate_data.rb
@@ -1,6 +1,6 @@
 module Builders
   module Chartkick
-    class DefectEscapeRateData < Builders::Chartkick::ProjectData
+    class DefectEscapeRateData < Builders::Chartkick::ProductData
       def build_data(metrics)
         metrics.inject({}) do |hash, metric|
           hash.merge!(

--- a/app/services/builders/chartkick/defect_escape_value_data.rb
+++ b/app/services/builders/chartkick/defect_escape_value_data.rb
@@ -1,6 +1,6 @@
 module Builders
   module Chartkick
-    class DefectEscapeValueData < Builders::Chartkick::ProjectData
+    class DefectEscapeValueData < Builders::Chartkick::ProductData
       def build_data(metrics)
         values = metrics.inject({}) do |hash, metric|
           hash.merge!(metric.value[:bugs_by_environment]) { |_key, old, new| new + old }

--- a/app/services/builders/chartkick/development_metrics.rb
+++ b/app/services/builders/chartkick/development_metrics.rb
@@ -31,16 +31,13 @@ module Builders
         )
       end
 
-      class Project < DevelopmentMetrics
+      class Product < DevelopmentMetrics
         private
 
         def entities_by_metric
-          metrics = {
-            review_turnaround: %w[project users_project project_distribution],
-            merge_time: %w[project users_project project_distribution],
-            pull_request_size: %w[project_distribution]
-          }
-          if project_has_jira_board_associated?(@entity_id)
+          metrics = {}
+
+          if product_has_jira_board_associated?(@entity_id)
             metrics.merge!(defect_escape_rate_entities)
           end
           metrics
@@ -50,8 +47,25 @@ module Builders
           { defect_escape_rate: %w[defect_escape_rate defect_escape_values] }
         end
 
-        def project_has_jira_board_associated?(project_id)
-          ::Project.find(project_id).jira_project&.present?
+        def product_has_jira_board_associated?(product_id)
+          ::Product.find(product_id).jira_project&.present?
+        end
+      end
+
+      class Project < DevelopmentMetrics
+        private
+
+        def entities_by_metric
+          metrics = {
+            review_turnaround: %w[project users_project project_distribution],
+            merge_time: %w[project users_project project_distribution],
+            pull_request_size: %w[project_distribution]
+          }
+          metrics
+        end
+
+        def defect_escape_rate_entities
+          { defect_escape_rate: %w[defect_escape_rate defect_escape_values] }
         end
       end
 

--- a/app/services/builders/chartkick/product_data.rb
+++ b/app/services/builders/chartkick/product_data.rb
@@ -1,0 +1,14 @@
+module Builders
+  module Chartkick
+    class ProductData < Builders::Chartkick::Base
+      def call
+        product = ::Product.find(@entity_id)
+
+        metrics = Metrics
+                  .const_get(@query[:name].to_s.camelize)::PerProduct
+                  .call(product.id, @query[:value_timestamp])
+        [{ name: product.name, data: build_data(metrics) }]
+      end
+    end
+  end
+end

--- a/app/services/metrics/defect_escape_rate/per_product.rb
+++ b/app/services/metrics/defect_escape_rate/per_product.rb
@@ -1,0 +1,37 @@
+module Metrics
+  module DefectEscapeRate
+    class PerProduct < Metrics::Base
+      private
+
+      def process
+        week_intervals.flat_map do |week|
+          interval = build_interval(week)
+          query(interval).map do |product, metric_value|
+            Metric.new(product, interval.first, metric_value)
+          end
+        end
+      end
+
+      def query(interval)
+        product = Product.find(@entity_id)
+        bug_issues = product.jira_project.jira_issues.bug.where(informed_at: interval)
+        return [] if bug_issues.empty?
+
+        defect_rate = bug_issues
+                      .where(environment: %w[staging production]).count * 100 / bug_issues.count
+        [[
+          @entity_id, {
+            defect_rate: defect_rate,
+            bugs_by_environment: bugs_by_environment(bug_issues)
+          }
+        ]]
+      end
+
+      def bugs_by_environment(bug_issues)
+        bug_issues.each_with_object(Hash.new(0)) do |bug, result|
+          result[bug.environment] += 1
+        end
+      end
+    end
+  end
+end

--- a/app/services/product_service.rb
+++ b/app/services/product_service.rb
@@ -1,0 +1,26 @@
+class ProductService
+  attr_accessor :product
+
+  def initialize(product)
+    @product = product
+  end
+
+  def update!(params)
+    project_ids = params['project_ids']
+
+    update_projects(project_ids, params['name']) if project_ids
+
+    product.update!(params)
+  end
+
+  private
+
+  def update_projects(project_ids, name)
+    product_id = Product.find_by(name: name)
+    projects = Project.where(product_id: product_id)
+
+    projects.each do |project|
+      project.update!(product_id: nil) unless project_ids.include?(project.id)
+    end
+  end
+end

--- a/app/views/development_metrics/_navigation.html.erb
+++ b/app/views/development_metrics/_navigation.html.erb
@@ -1,0 +1,16 @@
+<nav class="nav nav-style nav-txt-color p-2 nav-items-container col-md-12 d-flex justify-content-between">
+  <div class="d-flex flex-row">
+    <%if current_page?(products_development_metrics_path) || current_page?(products_metrics_development_metrics_path)%>
+      <a href='<%= products_development_metrics_path({product_name: product[:name], metric: { period: params&.dig(:metric, :period) }}) %>' class='nav-link active nav-txt-color selected mx-1' role='button'>General</a>
+    <% else %>
+      <a href='<%= products_development_metrics_path({product_name: product[:name], metric: { period: params&.dig(:metric, :period) }}) %>' class='nav-link active nav-txt-color mx-1' role='button'>General</a>
+    <% end %>
+    <% product.projects.each do |project|%>
+      <%if current_page?(projects_development_metrics_path({project_name: project[:name], metric: { period: params&.dig(:metric, :period) }}))%>
+        <a href='<%= projects_development_metrics_path({project_name: project[:name], metric: { period: params&.dig(:metric, :period) }}) %>' class='nav-link active nav-txt-color selected mx-1' role='button'><%= project[:name] %></a>
+      <% else %>
+        <a href='<%= projects_development_metrics_path({project_name: project[:name], metric: { period: params&.dig(:metric, :period) }}) %>' class='nav-link active nav-txt-color mx-1' role='button'><%= project[:name] %></a>
+      <% end %>
+    <% end %>
+  </div>
+</nav>

--- a/app/views/development_metrics/_products_dropdown.erb
+++ b/app/views/development_metrics/_products_dropdown.erb
@@ -1,0 +1,18 @@
+<%= content_for :products_dropdown do %>
+  <div class="list-product">
+    <select name="product_name" class="product-selection" form='nav-filter-form'>
+      <% if params[:product_name].blank? %>
+        <option selected value disabled>Choose a project</option>
+      <% else %>
+        <option value disabled>Choose a project</option>
+      <% end %>
+      <% all_products_names.each do |name|%>
+        <%if params[:product_name] == name %>
+          <option selected value=<%= name %>> <%= name%> </option>
+        <% else %>
+          <option value=<%= name%>> <%= name%></option> %>
+        <% end %>
+      <% end %>
+    </select>
+  </div>
+<% end %>

--- a/app/views/development_metrics/_projects_dropdown.erb
+++ b/app/views/development_metrics/_projects_dropdown.erb
@@ -2,9 +2,9 @@
   <div class="list-project">
     <select name="project_name" class="project-selection" form='nav-filter-form'>
       <% if params[:project_name].blank? %>
-        <option selected value disabled>Choose a project</option>
+        <option selected value disabled>Choose a repository</option>
       <% else %>
-        <option value disabled>Choose a project</option>
+        <option value disabled>Choose a repository</option>
       <% end %>
       <% all_projects_names.each do |name|%>
         <%if params[:project_name] == name %>

--- a/app/views/development_metrics/_sidebar.erb
+++ b/app/views/development_metrics/_sidebar.erb
@@ -10,11 +10,11 @@
 <div class="btn-group btn-entity-group">
   <div class='custom-list d-flex flex-row align-items-center'>
     <div class='circle'></div>
-    <%= link_to projects_development_metrics_path do %>
+    <%= link_to products_development_metrics_path do %>
       <span class='font-size-1'>Project metrics</span>
     <% end %>
   </div>
-  <%= yield(:projects_dropdown) %>
+  <%= yield(:products_dropdown) %>
 </div>
 <% if enabled_users_section %>
   <div class="btn-group btn-entity-group">

--- a/app/views/development_metrics/defect_escape_rate/_main_metric.erb
+++ b/app/views/development_metrics/defect_escape_rate/_main_metric.erb
@@ -7,4 +7,5 @@
 <%= render partial: 'development_metrics/defect_escape_rate/values_details',
            locals: {
              metric: defect_escape_rate[:per_defect_escape_values].first[:data],
+             details: details
            } if defect_escape_rate && defect_escape_rate[:per_defect_escape_values] %>

--- a/app/views/development_metrics/defect_escape_rate/_values_details.erb
+++ b/app/views/development_metrics/defect_escape_rate/_values_details.erb
@@ -1,4 +1,4 @@
-<div class="summary col-md-4">
+<div class="summary col-md-#{details ? '4' : '12'}">
   <div class="container p-4">
     <h3>Summary</h3>
     <hr>

--- a/app/views/development_metrics/products.erb
+++ b/app/views/development_metrics/products.erb
@@ -1,0 +1,26 @@
+<%= render 'development_metrics/products_dropdown' %>
+<%= render 'development_metrics/development_metrics_sidebar', enabled_users_section: @enabled_users_section %>
+
+<% if @product %>
+  <div class="col-md-12 text-center mt-2">
+    <b><%= @product[:name] %></b>
+  </div>
+  <%= render 'development_metrics/navigation', product: @product %>
+<% end %>
+<div class="metrics-container container col-md-12">
+  <%= render 'shared/product/nav-filter' do |f| %>
+      <%= hidden_field_tag 'metric[period]', '4'  %>
+  <% end %>
+
+  <% if @product %>
+      <%if current_page?(products_development_metrics_path)%>
+        <%= render 'development_metrics/products/general', product: @product, defect_escape_rate: @defect_escape_rate %>
+      <% end %>
+  <% else %>
+    <div class="row">
+      <div class="body-empty-container col-md-12 d-flex justify-content-center align-items-center">
+        <span>Please select a project to see its metrics</span>
+      </div>
+    </div>
+  <% end %>
+</div>

--- a/app/views/development_metrics/products/_general.erb
+++ b/app/views/development_metrics/products/_general.erb
@@ -1,0 +1,35 @@
+<div class="container">
+  <div class="summary">
+    <div class='p-3 chart-container <%if current_page?(products_development_metrics_path)%>col-md-4'<% else %>'<% end %> >
+      <div class="metrics shadow-box">
+        <h4 class="p-3">Defect Escape Rate</h4>
+        <% if defect_escape_rate %>
+
+          <%if current_page?(products_metrics_development_metrics_path)%>
+            <div class="metrics shadow-box">
+              <div class="graph">
+                <%= render 'development_metrics/defect_escape_rate/main_metric', defect_escape_rate: defect_escape_rate, details: true %>
+              </div>
+            </div>
+          <% else %>
+            <%= render partial: 'development_metrics/defect_escape_rate/values_details',
+            locals: {
+              metric: defect_escape_rate[:per_defect_escape_values].first[:data],
+              details: false
+            } if defect_escape_rate && defect_escape_rate[:per_defect_escape_values] %>
+            <div class="distribution-report-button mr-3 mb-2"><%= link_to 'See details',
+                      products_metrics_development_metrics_path({product_name: product[:name], metric: { period: params&.dig(:metric, :period) }}),
+                      class: 'btn btn-secondary'
+            %></div>
+          <% end %>
+        <% else %>
+          <div class="summary col-md-12">
+            <div class="container p-12 text-center">
+              <span class="text-danger extra-padding"><h5>No Jira project associated. Contact an administrator</h5></span>
+            </div>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/development_metrics/products_metrics.erb
+++ b/app/views/development_metrics/products_metrics.erb
@@ -1,0 +1,30 @@
+<%= render 'development_metrics/products_dropdown' %>
+<%= render 'development_metrics/development_metrics_sidebar', enabled_users_section: @enabled_users_section %>
+
+<% if @product %>
+  <div class="col-md-12 text-center mt-2">
+    <b><%= @product[:name] %></b>
+  </div>
+  <%= render 'development_metrics/navigation', product: @product %>
+<% end %>
+<div class="metrics-container container col-md-12">
+  <%= render 'shared/products_metrics/nav-filter' do |f| %>
+    <div class="row">
+      <div class="col-md-5 period-input">
+        <%= render 'shared/interval-filter', form: f %>
+      </div>
+    </div>
+  <% end %>
+
+  <% if @product %>
+      <%if current_page?(products_metrics_development_metrics_path)%>
+        <%= render 'development_metrics/products/general', product: @product, defect_escape_rate: @defect_escape_rate  %>
+      <% end %>
+  <% else %>
+    <div class="row">
+      <div class="body-empty-container col-md-12 d-flex justify-content-center align-items-center">
+        <span>Please select a project to see its metrics</span>
+      </div>
+    </div>
+  <% end %>
+</div>

--- a/app/views/development_metrics/projects.erb
+++ b/app/views/development_metrics/projects.erb
@@ -1,8 +1,10 @@
-<%= render 'development_metrics/projects_dropdown' %>
 <%= render 'development_metrics/development_metrics_sidebar', enabled_users_section: @enabled_users_section %>
+
+<%= render 'development_metrics/navigation', product: @project.product %>
 
 <div class="metrics-container container col-md-12">
   <%= render 'shared/project/nav-filter' do |f| %>
+    <%= hidden_field_tag 'project_name', @project.name  %>
     <div class="row">
       <div class="col-md-5 period-input">
         <%= render 'shared/interval-filter', form: f %>
@@ -46,21 +48,6 @@
       <div class="graph">
         <%= render 'development_metrics/pull_request_size/main_metric', pull_request_size: @pull_request_size %>
       </div>
-    </div>
-
-    <div class="metrics shadow-box">
-      <h4 class="p-3">Defect Escape Rate</h4>
-      <% if @defect_escape_rate %>
-        <div class="graph">
-          <%= render 'development_metrics/defect_escape_rate/main_metric', defect_escape_rate: @defect_escape_rate %>
-        </div>
-      <% else %>
-        <div class="summary col-md-12">
-          <div class="container p-12 text-center">
-            <span class="text-danger extra-padding"><h5>No Jira project associated. Contact an administrator</h5></span>
-          </div>
-        </div>
-      <% end %>
     </div>
   <% else %>
     <div class="row">

--- a/app/views/shared/product/_nav-filter.erb
+++ b/app/views/shared/product/_nav-filter.erb
@@ -1,0 +1,6 @@
+<%= simple_form_for :metric, url: products_development_metrics_path,
+  method: 'GET', html: {
+    class: 'nav-filter p-3 shadow-box',
+    id: 'nav-filter-form' } do |f|%>
+  <%= yield f if block_given? %>
+<% end %>

--- a/app/views/shared/products_metrics/_nav-filter.erb
+++ b/app/views/shared/products_metrics/_nav-filter.erb
@@ -1,0 +1,6 @@
+<%= simple_form_for :metric, url: products_metrics_development_metrics_path,
+  method: 'GET', html: {
+    class: 'nav-filter p-3 shadow-box',
+    id: 'nav-filter-form' } do |f|%>
+  <%= yield f if block_given? %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,7 @@ Rails.application.routes.draw do
       resources :users, only: [] do
         resources :projects, only: :index, controller: 'users/projects'
       end
+
       get 'projects'
       get 'departments'
       get 'users'
@@ -26,6 +27,10 @@ Rails.application.routes.draw do
         resources :departments, only: :show, param: :department_name
       end
     end
+  end
+  resources :development_metrics, only: [] do
+    get 'products', on: :collection
+    get 'products_metrics', on: :collection
   end
   resources :departments, only: [], param: :name do
     namespace :projects do

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -618,9 +618,9 @@ CREATE TABLE public.external_pull_requests (
     external_project_id bigint NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
-    number integer,
     opened_at timestamp without time zone,
-    state public.external_pull_request_state
+    state public.external_pull_request_state,
+    number integer
 );
 
 
@@ -721,8 +721,8 @@ CREATE TABLE public.jira_projects (
     project_name character varying,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
-    product_id bigint,
-    deleted_at timestamp without time zone
+    deleted_at timestamp without time zone,
+    product_id bigint
 );
 
 
@@ -899,8 +899,8 @@ CREATE TABLE public.projects (
     language_id bigint,
     is_private boolean,
     relevance public.project_relevance DEFAULT 'unassigned'::public.project_relevance NOT NULL,
-    product_id bigint,
-    deleted_at timestamp without time zone
+    deleted_at timestamp without time zone,
+    product_id bigint
 );
 
 

--- a/spec/controllers/development_metrics_controller_spec.rb
+++ b/spec/controllers/development_metrics_controller_spec.rb
@@ -45,25 +45,19 @@ describe DevelopmentMetricsController, type: :controller do
         assert_response :success
       end
 
-      context '#projects' do
+      context '#products' do
         render_views
 
-        subject { get :projects, params: params }
+        subject { get :products, params: params }
 
         let(:params) do
           {
-            project_name: project.name,
+            product_name: product.name,
             metric: {
               metric_name: 'defect_escape_rate',
               period: 'weekly'
             }
           }
-        end
-
-        it 'calls CodeClimate summary retriever class' do
-          expect(CodeClimateSummaryRetriever).to receive(:call).and_return(code_climate_metric)
-
-          subject
         end
 
         context 'when it has issues from different environments' do
@@ -119,6 +113,27 @@ describe DevelopmentMetricsController, type: :controller do
           it 'render EDR metric with correct issues when no environment defined' do
             expect(response.body).to include("None: #{no_env_jira_bugs.count}")
           end
+        end
+      end
+
+      context '#projects' do
+        render_views
+
+        subject { get :projects, params: params }
+
+        let(:params) do
+          {
+            project_name: project.name,
+            metric: {
+              period: 'weekly'
+            }
+          }
+        end
+
+        it 'calls CodeClimate summary retriever class' do
+          expect(CodeClimateSummaryRetriever).to receive(:call).and_return(code_climate_metric)
+
+          subject
         end
       end
 

--- a/spec/services/builders/chartkick/development_metrics_spec.rb
+++ b/spec/services/builders/chartkick/development_metrics_spec.rb
@@ -1,21 +1,32 @@
 require 'rails_helper'
 
-RSpec.describe Builders::Chartkick::DevelopmentMetrics do
+describe Builders::Chartkick::DevelopmentMetrics do
+  describe Builders::Chartkick::DevelopmentMetrics::Product do
+    let(:product) { create(:product) }
+    let!(:jira_project) { create(:jira_project, product: product) }
+    let(:period) { 4 }
+    let(:defect_escape_rate_entities) { %i[per_defect_escape_rate per_defect_escape_values] }
+
+    describe '.call' do
+      it 'returns a hash with the right data per entity for each metric' do
+        metric_data = described_class.call(product.id, period)
+        expect(metric_data[:defect_escape_rate].keys).to match_array(defect_escape_rate_entities)
+      end
+    end
+  end
+
   describe Builders::Chartkick::DevelopmentMetrics::Project do
     let(:product) { create(:product) }
     let(:project) { create(:project, product: product) }
-    let!(:jira_project) { create(:jira_project, product: product) }
     let(:period) { 4 }
     let(:review_turnaround_entities) { %i[per_project per_users_project per_project_distribution] }
     let(:merge_time_entities) { %i[per_project per_users_project per_project_distribution] }
-    let(:defect_escape_rate_entities) { %i[per_defect_escape_rate per_defect_escape_values] }
 
     describe '.call' do
       it 'returns a hash with the right data per entity for each metric' do
         metric_data = described_class.call(project.id, period)
         expect(metric_data[:review_turnaround].keys).to match_array(review_turnaround_entities)
         expect(metric_data[:merge_time].keys).to match_array(merge_time_entities)
-        expect(metric_data[:defect_escape_rate].keys).to match_array(defect_escape_rate_entities)
       end
     end
   end

--- a/spec/services/metrics/defect_escape_rate/per_product_spec.rb
+++ b/spec/services/metrics/defect_escape_rate/per_product_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+describe Metrics::DefectEscapeRate::PerProduct do
+  describe '.call' do
+    let(:product) { create(:product) }
+    let!(:jira_project) { create(:jira_project, product: product) }
+    let(:beginning_of_day) { Time.zone.today.beginning_of_day }
+    let(:subject) { described_class.call(product.id) }
+    let(:defect_rate) { 100 }
+    let(:metric) { subject.first }
+
+    context 'when there are bugs for the project' do
+      let!(:jira_bugs) do
+        create_list(:jira_issue, rand(1..10),
+                    :bug,
+                    :production,
+                    jira_project: jira_project,
+                    informed_at: beginning_of_day)
+      end
+
+      it 'returns the metrics' do
+        expect(subject.count).to eq(1)
+      end
+
+      it 'returns the metric ownable id' do
+        expect(metric.ownable_id).to eq(product.id)
+      end
+
+      it 'returns the metric value timestamp' do
+        expect(metric.value_timestamp).to eq(beginning_of_day)
+      end
+
+      it 'returns the metric values' do
+        expect(metric.value).to eq(defect_rate: defect_rate,
+                                   bugs_by_environment: { 'production' => jira_bugs.count })
+      end
+    end
+
+    context 'when the project has no bugs in the period' do
+      it 'returns an empty array' do
+        expect(subject).to be_empty
+      end
+    end
+  end
+end

--- a/spec/services/product_service_spec.rb
+++ b/spec/services/product_service_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+
+describe ProductService do
+  let(:product) { create(:product) }
+  let(:projects) { create_list(:project, 2) }
+  let(:jira_project) { create(:jira_project, product: product) }
+
+  let!(:params) do
+    {
+      name: product.name,
+      description: product.description,
+      jira_project_attributes: {
+        id: jira_project.id,
+        jira_project_key: jira_project.jira_project_key
+      },
+      project_ids: projects.first.id
+    }
+  end
+
+  describe '#update' do
+    subject { ProductService.new(product).update!(params) }
+
+    context 'when adding projects to a product' do
+      it 'add the project to the product' do
+        subject
+        expect(product.projects.count).to eq(1)
+      end
+
+      it 'creates the association between the product and the project' do
+        subject
+        expect(product.projects.first).to eq(projects.first)
+      end
+
+      it 'does not add other projects of the system' do
+        subject
+        expect(product.projects).not_to include(projects.last)
+      end
+    end
+
+    context 'when removing projects to a product' do
+      it 'removes the association between the product and the project' do
+        params[:project_ids] = []
+        product.projects = projects
+
+        subject
+        expect(product.projects).to be_empty
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What does this PR do?
With this PR now in the frontend we should see a dropdown with the projects (`Product` entity) of the company. The KPI's that relies on every repository like Jira boards are shown here in a summary of last four weeks and can be seen further details if wanted.
In addition to this, every project has their own repositories with related KPI's.

By last, the admin has a new Product tab with all the CRUD features.

This PR is second part of the full feature. 

Resolves [EM-223](https://rootstrap.atlassian.net/browse/EM-223).

**Summary of a project:**

<img width="1440" alt="Screen Shot 2021-07-19 at 11 56 11" src="https://user-images.githubusercontent.com/13893921/126202602-616d49b3-81b5-45f2-8939-c0adb1a6f2de.png">

**Detail view of KPI's of a project:**

<img width="1440" alt="Screen Shot 2021-07-19 at 11 58 28" src="https://user-images.githubusercontent.com/13893921/126202706-7580a012-dc9f-4f6c-be76-d0e5b63edf84.png">

**Product admin view:**

<img width="1410" alt="Screen Shot 2021-07-19 at 14 35 10" src="https://user-images.githubusercontent.com/13893921/126202775-d39f5f90-336d-47ca-84ee-7b82c2235de3.png">



