### PR TITLE
Add tooltip to metrics

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -74,7 +74,7 @@ detectors:
     max_constants: 5
   TooManyInstanceVariables:
     enabled: true
-    exclude: []
+    exclude: ['DevelopmentMetricsController']
     max_instance_variables: 9
   TooManyMethods:
     enabled: true

--- a/app/admin/jira_projects.rb
+++ b/app/admin/jira_projects.rb
@@ -1,4 +1,6 @@
 ActiveAdmin.register JiraProject do
+  permit_params :jira_key, :jira_project_key, :project_name, :product_id
+
   index do
     selectable_column
     id_column

--- a/app/admin/metric_definitions.rb
+++ b/app/admin/metric_definitions.rb
@@ -1,0 +1,20 @@
+ActiveAdmin.register MetricDefinition do
+  permit_params :name, :explanation, :code
+
+  form do |f|
+    f.inputs do
+      f.input :name
+      f.input :code,
+              as: :select,
+              collection: MetricDefinition.codes.values
+      f.input :explanation
+    end
+    f.actions
+  end
+
+  filter :code,
+         as: :select,
+         collection: MetricDefinition.codes.values
+  filter :created_at
+  filter :updated_at
+end

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -70,3 +70,16 @@ canvas[style] {
     }
   }
 }
+
+.metric_tooltip {
+  font-size: x-large;
+  color: white;
+  background:black;
+  border-radius:50%;
+  height: 26px;
+  width: 26px;
+  line-height: 26px;
+  display: inline-block;
+  text-align: center;
+  margin-right: 6px;
+}

--- a/app/controllers/development_metrics_controller.rb
+++ b/app/controllers/development_metrics_controller.rb
@@ -14,6 +14,8 @@ class DevelopmentMetricsController < ApplicationController
     return if metric_params.blank?
 
     build_metrics(project.id, Project.name)
+    build_metrics_definitions
+
     @code_owners = project.code_owners.pluck(:login)
     @code_climate = code_climate_project_summary
   end
@@ -49,13 +51,19 @@ class DevelopmentMetricsController < ApplicationController
     @review_turnaround = metrics[:review_turnaround]
     @merge_time = metrics[:merge_time]
     @pull_request_size = metrics[:pull_request_size]
-    @defect_escape_rate = metrics[:defect_escape_rate]
   end
 
   def build_product_metrics(entity_id, entity_name)
     metrics = Builders::Chartkick::DevelopmentMetrics.const_get(entity_name)
                                                      .call(entity_id, metric_params[:period])
     @defect_escape_rate = metrics[:defect_escape_rate]
+    @metric_definition = MetricDefinition.find_by(code: :defect_escape_rate)
+  end
+
+  def build_metrics_definitions
+    @review_turnaround_definition = MetricDefinition.find_by(code: :review_turnaround)
+    @merge_time_definition = MetricDefinition.find_by(code: :merge_time)
+    @pull_request_size_definition = MetricDefinition.find_by(code: :pull_request_size)
   end
 
   def product

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -14,6 +14,7 @@
 //
 // const images = require.context('../images', true)
 // const imagePath = (name) => images(name, true)
+require('bootstrap');
 require('@rails/ujs').start();
 require('turbolinks').start();
 require('chartkick');

--- a/app/javascript/packs/toggleDetailsMetric.js
+++ b/app/javascript/packs/toggleDetailsMetric.js
@@ -20,3 +20,7 @@ $(document).on('turbolinks:load', function() {
     $('.details-button').show();
   }
 });
+
+$(function () {
+  $('[data-toggle="tooltip"]').tooltip();
+});

--- a/app/models/metric_definition.rb
+++ b/app/models/metric_definition.rb
@@ -1,0 +1,25 @@
+# == Schema Information
+#
+# Table name: metric_definitions
+#
+#  id          :bigint           not null, primary key
+#  code        :enum             not null
+#  explanation :string           not null
+#  name        :string           not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
+
+class MetricDefinition < ApplicationRecord
+  enum code: { review_turnaround: 'review_turnaround',
+               blog_visits: 'blog_visits',
+               merge_time: 'merge_time',
+               blog_post_count: 'blog_post_count',
+               open_source_visits: 'open_source_visits',
+               defect_escape_rate: 'defect_escape_rate',
+               pull_request_size: 'pull_request_size' }
+
+  validates :code, uniqueness: true
+  validates :name, presence: true, uniqueness: true
+  validates :explanation, presence: true
+end

--- a/app/views/development_metrics/products.erb
+++ b/app/views/development_metrics/products.erb
@@ -14,7 +14,7 @@
 
   <% if @product %>
       <%if current_page?(products_development_metrics_path)%>
-        <%= render 'development_metrics/products/general', product: @product, defect_escape_rate: @defect_escape_rate %>
+        <%= render 'development_metrics/products/general', product: @product, defect_escape_rate: @defect_escape_rate, metric_definition: @metric_definition %>
       <% end %>
   <% else %>
     <div class="row">

--- a/app/views/development_metrics/products/_general.erb
+++ b/app/views/development_metrics/products/_general.erb
@@ -2,7 +2,10 @@
   <div class="summary">
     <div class='p-3 chart-container <%if current_page?(products_development_metrics_path)%>col-md-4'<% else %>'<% end %> >
       <div class="metrics shadow-box">
-        <h4 class="p-3">Defect Escape Rate</h4>
+        <div class='row'>
+          <h4 class="p-3" style='margin-left:10px;'><%= metric_definition && metric_definition[:name] %></h4>
+          <span data-placement='right' class='metric_tooltip' style='margin-top: 4%;' aria-hidden='true' data-toggle='tooltip' title='<%= metric_definition && metric_definition[:explanation] %>'>?</span>
+        </div>
         <% if defect_escape_rate %>
 
           <%if current_page?(products_metrics_development_metrics_path)%>

--- a/app/views/development_metrics/projects.erb
+++ b/app/views/development_metrics/projects.erb
@@ -20,7 +20,10 @@
   </div>
   <% if @project %>
     <div class="metrics shadow-box">
-      <h4 class="p-3">Time to second review</h4>
+      <div class='row'>
+        <h4 class="p-3" style='margin-left:10px;'><%= @review_turnaround_definition && @review_turnaround_definition[:name] %></h4>
+        <span data-placement='right' class='metric_tooltip' style='margin-top: 1.5%;' aria-hidden='true' data-toggle='tooltip' title='<%= @review_turnaround_definition && @review_turnaround_definition[:explanation] %>'>?</span>
+      </div>
       <div class="graph">
         <%= render 'development_metrics/review_turnaround/main_metric', review_turnaround: @review_turnaround %>
       </div>
@@ -32,7 +35,10 @@
     </div>
 
     <div class="metrics shadow-box">
-      <h4 class="p-3">Time to merge</h4>
+      <div class='row'>
+        <h4 class="p-3" style='margin-left:10px;'><%= @merge_time_definition && @merge_time_definition[:name] %></h4>
+        <span data-placement='right' class='metric_tooltip' style='margin-top: 1.5%;' aria-hidden='true' data-toggle='tooltip' title='<%= @merge_time_definition && @merge_time_definition[:explanation] %>'>?</span>
+      </div>
       <div class="graph">
         <%= render 'development_metrics/merge_time/main_metric', merge_time: @merge_time %>
       </div>
@@ -44,7 +50,10 @@
     </div>
 
     <div class="metrics shadow-box">
-      <h4 class="p-3">PR Size</h4>
+      <div class='row'>
+        <h4 class="p-3" style='margin-left:10px;'><%= @pull_request_size_definition && @pull_request_size_definition[:name] %></h4>
+        <span data-placement='right' class='metric_tooltip' style='margin-top: 1.5%;' aria-hidden='true' data-toggle='tooltip' title='<%= @pull_request_size_definition && @pull_request_size_definition[:explanation] %>'>?</span>
+      </div>
       <div class="graph">
         <%= render 'development_metrics/pull_request_size/main_metric', pull_request_size: @pull_request_size %>
       </div>

--- a/db/migrate/20210720212026_create_metric_definitions.rb
+++ b/db/migrate/20210720212026_create_metric_definitions.rb
@@ -1,0 +1,12 @@
+class CreateMetricDefinitions < ActiveRecord::Migration[6.0]
+  def change
+    create_table :metric_definitions do |t|
+      t.string :name, null: false
+      t.string :explanation, null: false
+
+      t.timestamps
+    end
+
+    add_column :metric_definitions, :code, :metric_name, null: false
+  end
+end

--- a/db/migrate/20210722152015_add_pull_request_size_to_metric_name_type.rb
+++ b/db/migrate/20210722152015_add_pull_request_size_to_metric_name_type.rb
@@ -1,0 +1,18 @@
+class AddPullRequestSizeToMetricNameType < ActiveRecord::Migration[6.0]
+  disable_ddl_transaction!
+
+  def up
+    execute <<-SQL
+      ALTER TYPE metric_name ADD VALUE 'pull_request_size';
+    SQL
+  end
+
+  def down
+    execute <<-SQL
+      ALTER TYPE metric_name RENAME TO metric_name_old;
+      CREATE TYPE metric_name AS ENUM ('review_turnaround', 'blog_visits', 'merge_time', 'blog_post_count', 'open_source_visits', 'defect_escape_rate');
+      ALTER TABLE metrics ALTER COLUMN name TYPE metric_name USING name::text::metric_name;
+      DROP TYPE metric_name_old;
+    SQL
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -111,7 +111,8 @@ CREATE TYPE public.metric_name AS ENUM (
     'merge_time',
     'blog_post_count',
     'open_source_visits',
-    'defect_escape_rate'
+    'defect_escape_rate',
+    'pull_request_size'
 );
 
 
@@ -809,6 +810,39 @@ ALTER SEQUENCE public.merge_times_id_seq OWNED BY public.merge_times.id;
 
 
 --
+-- Name: metric_definitions; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.metric_definitions (
+    id bigint NOT NULL,
+    name character varying NOT NULL,
+    explanation character varying NOT NULL,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL,
+    code public.metric_name NOT NULL
+);
+
+
+--
+-- Name: metric_definitions_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.metric_definitions_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: metric_definitions_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.metric_definitions_id_seq OWNED BY public.metric_definitions.id;
+
+
+--
 -- Name: metrics; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -1448,6 +1482,13 @@ ALTER TABLE ONLY public.merge_times ALTER COLUMN id SET DEFAULT nextval('public.
 
 
 --
+-- Name: metric_definitions id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.metric_definitions ALTER COLUMN id SET DEFAULT nextval('public.metric_definitions_id_seq'::regclass);
+
+
+--
 -- Name: metrics id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -1695,6 +1736,14 @@ ALTER TABLE ONLY public.languages
 
 ALTER TABLE ONLY public.merge_times
     ADD CONSTRAINT merge_times_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: metric_definitions metric_definitions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.metric_definitions
+    ADD CONSTRAINT metric_definitions_pkey PRIMARY KEY (id);
 
 
 --
@@ -2593,6 +2642,8 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20210707221342'),
 ('20210707225815'),
 ('20210708153602'),
-('20210712190532');
+('20210712190532'),
+('20210720212026'),
+('20210722152015');
 
 

--- a/spec/controllers/development_metrics_controller_spec.rb
+++ b/spec/controllers/development_metrics_controller_spec.rb
@@ -8,6 +8,14 @@ describe DevelopmentMetricsController, type: :controller do
   let(:project) { create(:project, name: 'rs-metrics', language: ruby_lang, product: product) }
   let!(:jira_project) { create(:jira_project, product: product) }
   let(:beginning_of_day) { Time.zone.today.beginning_of_day }
+  let!(:der_metric_definition) { create(:metric_definition, code: :defect_escape_rate) }
+  let!(:review_turnaround_metric_definition) do
+    create(:metric_definition, code: :review_turnaround)
+  end
+  let!(:merge_time_metric_metric_definition) { create(:metric_definition, code: :merge_time) }
+  let!(:pull_request_size_metric_definition) do
+    create(:metric_definition, code: :pull_request_size)
+  end
 
   describe '#index' do
     context 'when metric params are empty' do
@@ -113,6 +121,14 @@ describe DevelopmentMetricsController, type: :controller do
           it 'render EDR metric with correct issues when no environment defined' do
             expect(response.body).to include("None: #{no_env_jira_bugs.count}")
           end
+
+          it 'render metric name' do
+            expect(response.body).to include(der_metric_definition.name)
+          end
+
+          it 'render metric tooltip' do
+            expect(response.body).to include(der_metric_definition.explanation)
+          end
         end
       end
 
@@ -134,6 +150,21 @@ describe DevelopmentMetricsController, type: :controller do
           expect(CodeClimateSummaryRetriever).to receive(:call).and_return(code_climate_metric)
 
           subject
+        end
+
+        it 'render review turnaround metric tooltip' do
+          subject
+          expect(response.body).to include(review_turnaround_metric_definition.explanation)
+        end
+
+        it 'render merge time metric tooltip' do
+          subject
+          expect(response.body).to include(merge_time_metric_metric_definition.explanation)
+        end
+
+        it 'render pull request size metric tooltip' do
+          subject
+          expect(response.body).to include(pull_request_size_metric_definition.explanation)
         end
       end
 

--- a/spec/factories/metric_definitions.rb
+++ b/spec/factories/metric_definitions.rb
@@ -1,0 +1,22 @@
+# == Schema Information
+#
+# Table name: metric_definitions
+#
+#  id          :bigint           not null, primary key
+#  code        :enum             not null
+#  explanation :string           not null
+#  name        :string           not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
+
+FactoryBot.define do
+  factory :metric_definition do
+    name { Faker::Name.name.gsub(' ', '') }
+    code do
+      %w[review_turnaround blog_visits merge_time blog_post_count
+         open_source_visits defect_escape_rate pull_request_size].sample
+    end
+    explanation { Faker::Lorem.sentence }
+  end
+end

--- a/spec/models/metric_definition_spec.rb
+++ b/spec/models/metric_definition_spec.rb
@@ -1,0 +1,35 @@
+# == Schema Information
+#
+# Table name: metric_definitions
+#
+#  id          :bigint           not null, primary key
+#  code        :enum             not null
+#  explanation :string           not null
+#  name        :string           not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
+
+require 'rails_helper'
+
+describe MetricDefinition, type: :model do
+  subject { build(:metric_definition) }
+
+  context 'validations' do
+    context 'with valid attributes' do
+      it 'is valid' do
+        expect(subject).to be_valid
+      end
+
+      it { is_expected.to validate_presence_of(:name) }
+      it { is_expected.to validate_presence_of(:explanation) }
+    end
+  end
+
+  context 'with invalid attributes' do
+    it 'is not valid without name' do
+      subject.name = nil
+      expect(subject).to_not be_valid
+    end
+  end
+end


### PR DESCRIPTION
## What does this PR do?
It creates a new entity `metric_definition` with the `name` of a metric and an `explanation` of what it is. This information is handled in the admin panel and can be seen in the frontend.

Each metric has a question mark that when it is hovered it shows the explanation, as can be seen in next image:

<img width="592" alt="Screen Shot 2021-07-22 at 14 19 20" src="https://user-images.githubusercontent.com/13893921/126681439-e83f77b3-7002-4847-a241-dad31791510f.png">

This image shows the admin panel for metric definition:

<img width="722" alt="Screen Shot 2021-07-22 at 14 20 36" src="https://user-images.githubusercontent.com/13893921/126681621-fcd3f3c6-ebaa-4156-be71-166bd50927ac.png">



Resolves [EM-89](https://rootstrap.atlassian.net/browse/EM-89): Add tooltips to explain each metric

