### PR TITLE
Development cycle metric - Part 2 of 2

### DIFF
--- a/app/javascript/packs/toggleDetailsMetric.js
+++ b/app/javascript/packs/toggleDetailsMetric.js
@@ -19,8 +19,6 @@ $(document).on('turbolinks:load', function() {
   } else {
     $('.details-button').show();
   }
-});
 
-$(function () {
   $('[data-toggle="tooltip"]').tooltip();
 });

--- a/app/models/metric_definition.rb
+++ b/app/models/metric_definition.rb
@@ -17,7 +17,8 @@ class MetricDefinition < ApplicationRecord
                blog_post_count: 'blog_post_count',
                open_source_visits: 'open_source_visits',
                defect_escape_rate: 'defect_escape_rate',
-               pull_request_size: 'pull_request_size' }
+               pull_request_size: 'pull_request_size',
+               development_cycle: 'development_cycle' }
 
   validates :code, uniqueness: true
   validates :name, presence: true, uniqueness: true

--- a/app/services/builders/chartkick/development_cycle_average_data.rb
+++ b/app/services/builders/chartkick/development_cycle_average_data.rb
@@ -1,0 +1,20 @@
+module Builders
+  module Chartkick
+    class DevelopmentCycleAverageData < Builders::Chartkick::ProductData
+      def build_data(metrics)
+        values = metrics.inject({}) do |hash, metric|
+          hash.merge!(
+            metric.value_timestamp.strftime('%Y-%m-%d').to_s => metric.value[:development_cycle]
+          )
+        end
+
+        metrics_length = metrics.count
+        total = values.values.inject(:+)
+
+        average = total / metrics_length if metrics_length.positive?
+
+        { average: average }
+      end
+    end
+  end
+end

--- a/app/services/builders/chartkick/development_cycle_value_data.rb
+++ b/app/services/builders/chartkick/development_cycle_value_data.rb
@@ -1,0 +1,13 @@
+module Builders
+  module Chartkick
+    class DevelopmentCycleValueData < Builders::Chartkick::ProductData
+      def build_data(metrics)
+        metrics.inject({}) do |hash, metric|
+          hash.merge!(
+            metric.value_timestamp.strftime('%Y-%m-%d').to_s => metric.value[:development_cycle]
+          )
+        end
+      end
+    end
+  end
+end

--- a/app/services/builders/chartkick/development_metrics.rb
+++ b/app/services/builders/chartkick/development_metrics.rb
@@ -38,13 +38,17 @@ module Builders
           metrics = {}
 
           if product_has_jira_board_associated?(@entity_id)
-            metrics.merge!(defect_escape_rate_entities)
+            metrics.merge!(defect_escape_rate_entities, development_cycle_entities)
           end
           metrics
         end
 
         def defect_escape_rate_entities
           { defect_escape_rate: %w[defect_escape_rate defect_escape_values] }
+        end
+
+        def development_cycle_entities
+          { development_cycle: %w[development_cycle_average development_cycle_values] }
         end
 
         def product_has_jira_board_associated?(product_id)

--- a/app/services/metrics/development_cycle/per_product.rb
+++ b/app/services/metrics/development_cycle/per_product.rb
@@ -1,0 +1,42 @@
+module Metrics
+  module DevelopmentCycle
+    class PerProduct < Metrics::Base
+      private
+
+      def process
+        week_intervals.flat_map do |week|
+          interval = build_interval(week)
+          query(interval).map do |product, metric_value|
+            Metric.new(product, interval.first, metric_value)
+          end
+        end
+      end
+
+      def query(interval)
+        product = Product.find(@entity_id)
+
+        resolved_issues = product.jira_project.jira_issues.where(resolved_at: interval)
+        return [] if resolved_issues.empty?
+
+        total_development_cycle = development_cycle(resolved_issues)['average']
+
+        avg_development_cycle = 0
+        if total_development_cycle.positive?
+          avg_development_cycle = total_development_cycle / resolved_issues.count
+        end
+
+        [[
+          @entity_id, {
+            development_cycle: avg_development_cycle
+          }
+        ]]
+      end
+
+      def development_cycle(resolved_issues)
+        resolved_issues.each_with_object(Hash.new(0)) do |issue, result|
+          result['average'] += (issue.resolved_at - issue.in_progress_at) / 1.day
+        end
+      end
+    end
+  end
+end

--- a/app/views/development_metrics/_navigation.html.erb
+++ b/app/views/development_metrics/_navigation.html.erb
@@ -1,9 +1,9 @@
 <nav class="nav nav-style nav-txt-color p-2 nav-items-container col-md-12 d-flex justify-content-between">
   <div class="d-flex flex-row">
     <%if current_page?(products_development_metrics_path) || current_page?(products_metrics_development_metrics_path)%>
-      <a href='<%= products_development_metrics_path({product_name: product[:name], metric: { period: params&.dig(:metric, :period) }}) %>' class='nav-link active nav-txt-color selected mx-1' role='button'>General</a>
+      <a href='<%= products_development_metrics_path({product_name: product[:name], metric: { period: 4 }}) %>' class='nav-link active nav-txt-color selected mx-1' role='button'>General</a>
     <% else %>
-      <a href='<%= products_development_metrics_path({product_name: product[:name], metric: { period: params&.dig(:metric, :period) }}) %>' class='nav-link active nav-txt-color mx-1' role='button'>General</a>
+      <a href='<%= products_development_metrics_path({product_name: product[:name], metric: { period: 4 }}) %>' class='nav-link active nav-txt-color mx-1' role='button'>General</a>
     <% end %>
     <% product.projects.each do |project|%>
       <%if current_page?(projects_development_metrics_path({project_name: project[:name], metric: { period: params&.dig(:metric, :period) }}))%>

--- a/app/views/development_metrics/defect_escape_rate/_main_metric.erb
+++ b/app/views/development_metrics/defect_escape_rate/_main_metric.erb
@@ -7,5 +7,6 @@
 <%= render partial: 'development_metrics/defect_escape_rate/values_details',
            locals: {
              metric: defect_escape_rate[:per_defect_escape_values].first[:data],
-             details: details
+             details: details,
+             defect_escape_rate_definition: defect_escape_rate_definition
            } if defect_escape_rate && defect_escape_rate[:per_defect_escape_values] %>

--- a/app/views/development_metrics/defect_escape_rate/_values_details.erb
+++ b/app/views/development_metrics/defect_escape_rate/_values_details.erb
@@ -5,7 +5,7 @@
     <% if metric && metric[:rate] -%>
       <div class="item-list">
         <div>
-          <h5>Overall Defect Escape Rate:</h5>
+          <h5>Overall <%= defect_escape_rate_definition && defect_escape_rate_definition[:name] %>:</h5>
           <span class="text-primary">
                 <h2>
                   <%= metric[:rate] %> %

--- a/app/views/development_metrics/development_cycle/_main_metric.erb
+++ b/app/views/development_metrics/development_cycle/_main_metric.erb
@@ -1,0 +1,10 @@
+<%= line_chart development_cycle[:per_development_cycle_values],
+        ytitle: "Days",
+        suffix: " days",
+        library: { spanGaps: true } if development_cycle %>
+<%= render partial: 'development_metrics/development_cycle/values_details',
+           locals: {
+             metric: development_cycle[:per_development_cycle_average].first[:data],
+             development_cycle_definition: development_cycle_definition,
+             details: details
+           } if development_cycle %>

--- a/app/views/development_metrics/development_cycle/_values_details.erb
+++ b/app/views/development_metrics/development_cycle/_values_details.erb
@@ -1,0 +1,22 @@
+<div class="summary col-md-#{details ? '4' : '12'}">
+  <div class="container p-4">
+    <h3>Summary</h3>
+    <hr>
+    <% if metric -%>
+      <div class="item-list">
+        <div>
+          <h5>Overall <%= development_cycle_definition && development_cycle_definition[:name] %>:</h5>
+          <span class="text-primary">
+                <h2>
+                  <%= metric[:average] %> days
+                </h2>
+              </span>
+        </div>
+      </div>
+    <% else -%>
+      <div class="col-md-12 text-center mt-2">
+        <span class="text-danger">No issues reported on this period</span>
+      </div>
+    <% end -%>
+  </div>
+</div>

--- a/app/views/development_metrics/products.erb
+++ b/app/views/development_metrics/products.erb
@@ -14,7 +14,15 @@
 
   <% if @product %>
       <%if current_page?(products_development_metrics_path)%>
-        <%= render 'development_metrics/products/general', product: @product, defect_escape_rate: @defect_escape_rate, metric_definition: @metric_definition %>
+        <%= render 'development_metrics/products/general',
+          product: @product,
+          defect_escape_rate: @defect_escape_rate,
+          development_cycle: @development_cycle,
+          development_cycle_definition: @development_cycle_definition,
+          defect_escape_rate_definition: @defect_escape_rate_definition,
+          has_jira_project: @has_jira_project,
+          show_defect_escape_rate: @show_defect_escape_rate,
+          show_development_cycle: @show_development_cycle %>
       <% end %>
   <% else %>
     <div class="row">

--- a/app/views/development_metrics/products/_general.erb
+++ b/app/views/development_metrics/products/_general.erb
@@ -1,29 +1,61 @@
 <div class="container">
   <div class="summary">
-    <div class='p-3 chart-container <%if current_page?(products_development_metrics_path)%>col-md-4'<% else %>'<% end %> >
-      <div class="metrics shadow-box">
-        <div class='row'>
-          <h4 class="p-3" style='margin-left:10px;'><%= metric_definition && metric_definition[:name] %></h4>
-          <span data-placement='right' class='metric_tooltip' style='margin-top: 4%;' aria-hidden='true' data-toggle='tooltip' title='<%= metric_definition && metric_definition[:explanation] %>'>?</span>
-        </div>
-        <% if defect_escape_rate %>
-
-          <%if current_page?(products_metrics_development_metrics_path)%>
-            <div class="metrics shadow-box">
-              <div class="graph">
-                <%= render 'development_metrics/defect_escape_rate/main_metric', defect_escape_rate: defect_escape_rate, details: true %>
+    <div class='p-3 chart-container <%if current_page?(products_development_metrics_path)%>col-md-8 info'<% else %>'<% end %> >
+        <% if has_jira_project %>
+          <% if show_defect_escape_rate %>
+              <div class="metrics shadow-box">
+                <div class='row'>
+                  <h4 class="p-3" style='margin-left:10px;'><%= defect_escape_rate_definition && defect_escape_rate_definition[:name] %></h4>
+                  <span data-placement='right' class='metric_tooltip' style=<% if current_page?(products_development_metrics_path) %> 'margin-top: 4%;' <% else %> 'margin-top: 1.5%;' <% end %> aria-hidden='true' data-toggle='tooltip' title='<%= defect_escape_rate_definition && defect_escape_rate_definition[:explanation] %>'>?</span>
+                </div>
+                <%if current_page?(products_metrics_development_metrics_path)%>
+                  <div class="metrics shadow-box">
+                    <div class="graph">
+                      <%= render 'development_metrics/defect_escape_rate/main_metric', defect_escape_rate: defect_escape_rate, details: true, defect_escape_rate_definition: defect_escape_rate_definition %>
+                    </div>
+                  </div>
+                <% else %>
+                  <%= render partial: 'development_metrics/defect_escape_rate/values_details',
+                  locals: {
+                    metric: defect_escape_rate[:per_defect_escape_values].first[:data],
+                    details: false,
+                    defect_escape_rate_definition: defect_escape_rate_definition
+                  } if defect_escape_rate && defect_escape_rate[:per_defect_escape_values] %>
+                  <div class="distribution-report-button mr-3 mb-2"><%= link_to 'See details',
+                            products_metrics_development_metrics_path({product_name: product[:name], metric: { period: params&.dig(:metric, :period), name: 'defect_escape_rate'}}),
+                            class: 'btn btn-secondary'
+                  %></div>
+                <% end %>
               </div>
-            </div>
-          <% else %>
-            <%= render partial: 'development_metrics/defect_escape_rate/values_details',
-            locals: {
-              metric: defect_escape_rate[:per_defect_escape_values].first[:data],
-              details: false
-            } if defect_escape_rate && defect_escape_rate[:per_defect_escape_values] %>
-            <div class="distribution-report-button mr-3 mb-2"><%= link_to 'See details',
-                      products_metrics_development_metrics_path({product_name: product[:name], metric: { period: params&.dig(:metric, :period) }}),
+          <% end %>
+
+          <% if show_development_cycle %>
+              <div class="metrics shadow-box" style="margin-left:10%">
+                <div class='row'>
+                  <h4 class="p-3" style='margin-left:10px;'><%= development_cycle_definition && development_cycle_definition[:name] %></h4>
+                  <span data-placement='right' class='metric_tooltip' style=<% if current_page?(products_development_metrics_path) %> 'margin-top: 4%;' <% else %> 'margin-top: 1.5%;' <% end %> aria-hidden='true' data-toggle='tooltip' title='<%= development_cycle_definition && development_cycle_definition[:explanation] %>'>?</span>
+                </div>
+                <%if current_page?(products_metrics_development_metrics_path)%>
+                  <div class="metrics shadow-box">
+                    <div class="graph">
+                      <%= render 'development_metrics/development_cycle/main_metric', development_cycle: development_cycle, development_cycle_definition: development_cycle_definition, details: true %>
+                    </div>
+                  </div>
+                <% else %>
+                  <%= render partial: 'development_metrics/development_cycle/values_details',
+                  locals: {
+                    metric: development_cycle[:per_development_cycle_average].first[:data],
+                    details: false,
+                    development_cycle_definition: development_cycle_definition
+                  } if development_cycle %>
+                  <div class="distribution-report-button mr-3 mb-2">
+                    <%= link_to 'See details',
+                      products_metrics_development_metrics_path({product_name: product[:name], metric: { period: params&.dig(:metric, :period), name: 'development_cycle'}}),
                       class: 'btn btn-secondary'
-            %></div>
+                    %>
+                  </div>
+                <% end %>
+              </div>
           <% end %>
         <% else %>
           <div class="summary col-md-12">

--- a/app/views/development_metrics/products_metrics.erb
+++ b/app/views/development_metrics/products_metrics.erb
@@ -9,6 +9,7 @@
 <% end %>
 <div class="metrics-container container col-md-12">
   <%= render 'shared/products_metrics/nav-filter' do |f| %>
+    <%= hidden_field_tag 'metric[name]', @query_metric_name  %>
     <div class="row">
       <div class="col-md-5 period-input">
         <%= render 'shared/interval-filter', form: f %>
@@ -18,7 +19,15 @@
 
   <% if @product %>
       <%if current_page?(products_metrics_development_metrics_path)%>
-        <%= render 'development_metrics/products/general', product: @product, defect_escape_rate: @defect_escape_rate  %>
+        <%= render 'development_metrics/products/general',
+          product: @product,
+          defect_escape_rate: @defect_escape_rate,
+          development_cycle: @development_cycle,
+          development_cycle_definition: @development_cycle_definition,
+          defect_escape_rate_definition: @defect_escape_rate_definition,
+          has_jira_project: @has_jira_project,
+          show_defect_escape_rate: @show_defect_escape_rate,
+          show_development_cycle: @show_development_cycle %>
       <% end %>
   <% else %>
     <div class="row">

--- a/spec/services/builders/chartkick/development_cycle_average_data_spec.rb
+++ b/spec/services/builders/chartkick/development_cycle_average_data_spec.rb
@@ -1,0 +1,67 @@
+require 'rails_helper'
+
+describe Builders::Chartkick::DevelopmentCycleAverageData do
+  subject { described_class.send(:new, 1, '') }
+
+  describe '.build_data' do
+    context 'for a given set of metrics' do
+      let(:first_week) { '2021-07-19'.to_date }
+      let(:this_week) { '2021-07-26'.to_date }
+      let(:formatted_first_week) { first_week.strftime('%Y-%m-%d') }
+      let(:formatted_this_week) { this_week.strftime('%Y-%m-%d') }
+
+      let(:jira_project) { create(:jira_project) }
+
+      let(:jira_issue1) do
+        create(:jira_issue,
+               informed_at: '2021-07-12T15:48:00.000-0300',
+               in_progress_at: '2021-07-19T15:48:04.000-0300',
+               resolved_at: '2021-07-21T15:48:04.000-0300',
+               issue_type: 'task',
+               environment: 'development',
+               jira_project: jira_project)
+      end
+
+      let(:jira_issue2) do
+        create(:jira_issue,
+               informed_at: '2021-07-12T15:48:00.000-0300',
+               in_progress_at: '2021-07-26T15:48:04.000-0300',
+               resolved_at: '2021-07-30T15:48:04.000-0300',
+               issue_type: 'task',
+               environment: 'development',
+               jira_project: jira_project)
+      end
+
+      let(:average_last_week) { (jira_issue1.resolved_at - jira_issue1.in_progress_at) / 1.day }
+      let(:average_this_week) { (jira_issue2.resolved_at - jira_issue2.in_progress_at) / 1.day }
+
+      let(:average) do
+        (((jira_issue1.resolved_at - jira_issue1.in_progress_at) +
+        (jira_issue2.resolved_at - jira_issue2.in_progress_at)) / 1.day) / 2
+      end
+
+      let(:value_for_last_week) do
+        {
+          development_cycle: average_last_week
+        }
+      end
+      let(:value_for_this_week) do
+        {
+          development_cycle: average_this_week
+        }
+      end
+      let(:metric_for_last_week) { Metrics::Base::Metric.new(1, first_week, value_for_last_week) }
+      let(:metric_for_this_week) { Metrics::Base::Metric.new(1, this_week, value_for_this_week) }
+      let(:metrics) { [metric_for_this_week, metric_for_last_week] }
+      let(:expected_hash_value) do
+        {
+          average: average
+        }
+      end
+
+      it 'returns the expected hash value' do
+        expect(subject.build_data(metrics)).to eq(expected_hash_value)
+      end
+    end
+  end
+end

--- a/spec/services/builders/chartkick/development_cycle_value_data_spec.rb
+++ b/spec/services/builders/chartkick/development_cycle_value_data_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+describe Builders::Chartkick::DevelopmentCycleValueData do
+  subject { described_class.send(:new, 1, '') }
+
+  describe '.build_data' do
+    context 'for a given set of metrics' do
+      let(:yesterday) { Date.yesterday }
+      let(:formatted_yesterday) { yesterday.strftime('%Y-%m-%d') }
+      let(:yesterday_development_cycle) { 4 }
+      let(:today) { Time.zone.today }
+      let(:today_development_cycle) { 50 }
+      let(:formatted_today) { today.strftime('%Y-%m-%d') }
+      let(:value_for_yesterday) do
+        {
+          development_cycle: yesterday_development_cycle
+        }
+      end
+      let(:value_for_today) do
+        {
+          development_cycle: today_development_cycle
+        }
+      end
+      let(:metric_for_yesterday) { Metrics::Base::Metric.new(1, yesterday, value_for_yesterday) }
+      let(:metric_for_today) { Metrics::Base::Metric.new(1, today, value_for_today) }
+      let(:metrics) { [metric_for_today, metric_for_yesterday] }
+      let(:expected_hash_value) do
+        {
+          formatted_yesterday => yesterday_development_cycle,
+          formatted_today => today_development_cycle
+        }
+      end
+
+      it 'returns the expected hash value' do
+        expect(subject.build_data(metrics)).to eq(expected_hash_value)
+      end
+    end
+  end
+end

--- a/spec/services/builders/chartkick/development_metrics_spec.rb
+++ b/spec/services/builders/chartkick/development_metrics_spec.rb
@@ -15,6 +15,29 @@ describe Builders::Chartkick::DevelopmentMetrics do
     end
   end
 
+  describe Builders::Chartkick::DevelopmentMetrics::Product do
+    let(:product) { create(:product) }
+    let(:project_key) { 'TES' }
+    let!(:jira_project) { create(:jira_project, product: product) }
+    let(:period) { 4 }
+    let(:defect_escape_rate_entities) { %i[per_defect_escape_rate per_defect_escape_values] }
+    let(:development_cycle_entities) do
+      %i[per_development_cycle_average per_development_cycle_values]
+    end
+
+    describe '.call' do
+      it 'returns a hash with the right data per entity for defect escape rate metric' do
+        metric_data = described_class.call(product.id, period)
+        expect(metric_data[:defect_escape_rate].keys).to match_array(defect_escape_rate_entities)
+      end
+
+      it 'returns a hash with the right data per entity for development cycle metric' do
+        metric_data = described_class.call(product.id, period)
+        expect(metric_data[:development_cycle].keys).to match_array(development_cycle_entities)
+      end
+    end
+  end
+
   describe Builders::Chartkick::DevelopmentMetrics::Project do
     let(:product) { create(:product) }
     let(:project) { create(:project, product: product) }


### PR DESCRIPTION
## What does this PR do?

This PR is the second part of the full feature. In this PR the metric is added to the frontend.
Also, a small fix to tooltip metrics were found.

Now in the product view a summary of both metrics are shown (last four weeks), as can be seen in next image:

<img width="1190" alt="Screen Shot 2021-08-03 at 19 59 08" src="https://user-images.githubusercontent.com/13893921/128096904-3470ed6c-70f8-4b58-9687-46bd06b8de26.png">

When user click in 'See details' button, a chart with more details is shown and the period is variable, as can be seen in next image:

<img width="1159" alt="Screen Shot 2021-08-03 at 19 40 48" src="https://user-images.githubusercontent.com/13893921/128097001-ffdd006e-50bd-4669-b4e2-42cd18969593.png">


Resolves [EM-226](https://rootstrap.atlassian.net/browse/EM-226): See project metric: Development Cycle.
