### PR TITLE
Customize error when jira key not found

### DIFF
--- a/app/exceptions/jira_boards/no_project_key_error.rb
+++ b/app/exceptions/jira_boards/no_project_key_error.rb
@@ -1,0 +1,11 @@
+module JiraBoards
+  class NoProjectKeyError < StandardError
+    def initialize(jira_project_key)
+      @jira_project_key = jira_project_key
+    end
+
+    def message
+      "Jira key #{@jira_project_key} not found"
+    end
+  end
+end

--- a/app/services/jira_client/repository.rb
+++ b/app/services/jira_client/repository.rb
@@ -11,7 +11,7 @@ module JiraClient
 
       JSON.parse(fetch_response.body)['issues'].map(&:deep_symbolize_keys)
     rescue Faraday::ForbiddenError => exception
-      ExceptionHunter.track(exception)
+      raised_exception(exception)
     end
 
     def issues
@@ -19,7 +19,7 @@ module JiraClient
 
       JSON.parse(fetch_response.body)['issues'].map(&:deep_symbolize_keys)
     rescue Faraday::ForbiddenError => exception
-      ExceptionHunter.track(exception)
+      raised_exception(exception)
     end
 
     private
@@ -35,6 +35,11 @@ module JiraClient
       connection.get('search') do |request|
         request.params = @request_params
       end
+    end
+
+    def raised_exception(exception)
+      ExceptionHunter.track(JiraBoards::NoProjectKeyError.new(@jira_board.jira_project_key),
+                            custom_data: exception)
     end
   end
 end

--- a/spec/services/jira_client/repository_spec.rb
+++ b/spec/services/jira_client/repository_spec.rb
@@ -42,7 +42,9 @@ describe JiraClient::Repository do
       before { stub_failed_authentication(project_key) }
 
       it 'notifies the error to exception hunter' do
-        expect(ExceptionHunter).to receive(:track).with(Faraday::ForbiddenError)
+        expect(ExceptionHunter).to receive(:track)
+          .with(JiraBoards::NoProjectKeyError.new(project_key),
+                custom_data: Faraday::ForbiddenError)
 
         subject
       end
@@ -85,6 +87,20 @@ describe JiraClient::Repository do
 
       it 'returns an array with the data' do
         expect(subject).to match_array(bugs)
+      end
+    end
+
+    context 'when the request fails for unauthorized user' do
+      let(:bugs) { [] }
+
+      before { stub_issues_failed_authentication(project_key) }
+
+      it 'notifies the error to exception hunter' do
+        expect(ExceptionHunter).to receive(:track)
+          .with(JiraBoards::NoProjectKeyError.new(project_key),
+                custom_data: Faraday::ForbiddenError)
+
+        subject
       end
     end
   end

--- a/spec/support/helpers/jira_api_mocker.rb
+++ b/spec/support/helpers/jira_api_mocker.rb
@@ -26,6 +26,13 @@ module JiraApiMock
       .to_raise(Faraday::ForbiddenError, 'Unauthorized user')
   end
 
+  def stub_issues_failed_authentication(jira_project_key)
+    stub_envs
+
+    stub_request(:get, "#{ENV['JIRA_ROOT_URL']}search?jql=project=#{jira_project_key}%20AND%20issuetype!=Bug&fields=#{ENV['JIRA_ENVIRONMENT_FIELD']},created")
+      .to_raise(Faraday::ForbiddenError, 'Unauthorized user')
+  end
+
   def stub_envs
     stub_env('JIRA_ADMIN_USER', jira_admin_user)
     stub_env('JIRA_ADMIN_TOKEN', jira_admin_token)


### PR DESCRIPTION
## What does this PR do?
This PR customize the Exception Hunter error when trying to fetch data from Jira projects and the project key is not found.

Resolves [EM-234](https://rootstrap.atlassian.net/browse/EM-234): Faraday::BadRequestError: the server responded with status 400
