### PR TITLE
Development cycle empty state

### DIFF
--- a/app/controllers/development_metrics_controller.rb
+++ b/app/controllers/development_metrics_controller.rb
@@ -105,10 +105,6 @@ class DevelopmentMetricsController < ApplicationController
 
     @development_cycle = metrics[:development_cycle]
     @development_cycle_definition = MetricDefinition.find_by(code: :development_cycle)
-
-    return unless @development_cycle[:per_development_cycle_values].first[:data].empty?
-
-    @show_development_cycle = false
   end
 
   def show_defect_escape_rate

--- a/app/views/development_metrics/development_cycle/_values_details.erb
+++ b/app/views/development_metrics/development_cycle/_values_details.erb
@@ -2,7 +2,7 @@
   <div class="container p-4">
     <h3>Summary</h3>
     <hr>
-    <% if metric -%>
+    <% if metric && metric[:average]&.positive? -%>
       <div class="item-list">
         <div>
           <h5>Overall <%= development_cycle_definition && development_cycle_definition[:name] %>:</h5>


### PR DESCRIPTION
## What does this PR do?
This PR adds an empty state when no issues are reported in the selected period for development cycle metric with the same behaviour as defect escape rate, as can be seen in next image:

<img width="795" alt="Screen Shot 2021-08-13 at 11 53 08" src="https://user-images.githubusercontent.com/13893921/129376444-53316fc4-8d17-452b-9d25-a960dc3fe721.png">



Resolves [EM-237](https://rootstrap.atlassian.net/browse/EM-237): Development cycle empty state
