### PR TITLE
Pull request validation when simultaneous webhooks are received

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -98,6 +98,8 @@ Rails/FilePath:
 
 Rails/SaveBang:
   Enabled: true
+  Exclude:
+    - app/services/builders/events/pull_request.rb
 
 Style/BlockDelimiters:
   EnforcedStyle: braces_for_chaining

--- a/app/services/builders/events/pull_request.rb
+++ b/app/services/builders/events/pull_request.rb
@@ -7,14 +7,17 @@ module Builders
 
       def build
         pull_request_data = @payload['pull_request']
+
         ::Events::PullRequest
-          .find_or_create_by!(github_id: pull_request_data['id']) do |pull_request|
+          .create_or_find_by(github_id: pull_request_data['id']) do |pull_request|
           ATTR_PAYLOAD_MAP.each do |key, value|
             pull_request.public_send("#{key}=", pull_request_data.fetch(value))
           end
           pull_request.branch = pull_request_data.dig('head', 'ref')
 
           assign_attrs(pull_request, pull_request_data)
+
+          pull_request.save!(validate: false)
         end
       end
 

--- a/spec/services/builders/events/pull_request_spec.rb
+++ b/spec/services/builders/events/pull_request_spec.rb
@@ -50,6 +50,22 @@ RSpec.describe Builders::Events::PullRequest do
           .not_to change { Events::PullRequest.count }
       end
     end
+
+    context 'when multiple hooks for the same pull request are sent at the same time' do
+      let(:threads) { [] }
+
+      it 'does not raise a validation error' do
+        expect {
+          2.times do
+            threads << Thread.new do
+              described_class.call(payload: payload)
+            end
+          end
+
+          threads.map(&:join)
+        }.to_not raise_error
+      end
+    end
   end
 
   def boolean_of(value)


### PR DESCRIPTION
## What does this PR do?
This PR changes the method a Pull Request is created when receiving a webhook from Github. Sometimes, several webhooks are received within miliseconds (`review_requested` action for instance) and one job failed I believe because of a race condition.

The fix is to replace `find_or_create_by!` for `create_or_find_by` method. So that first attempts to create and if failed means other job simultaneously created so that it returns the record.

Resolves [EM-239](https://rootstrap.atlassian.net/browse/EM-239): ActiveRecord::RecordInvalid: Validation failed: Github has already been taken
