### PR TITLE
Adds retry when github id is already been taken

### DIFF
--- a/app/exceptions/pull_requests/github_uniqueness_error.rb
+++ b/app/exceptions/pull_requests/github_uniqueness_error.rb
@@ -1,0 +1,4 @@
+module PullRequests
+  class GithubUniquenessError < StandardError
+  end
+end

--- a/app/jobs/request_handler_job.rb
+++ b/app/jobs/request_handler_job.rb
@@ -4,6 +4,8 @@ class RequestHandlerJob < ApplicationJob
              Reviews::NoReviewRequestError,
              PullRequests::RequestTeamAsReviewerError
 
+  retry_on PullRequests::GithubUniquenessError
+
   def perform(payload, event)
     GithubService.call(payload: payload, event: event)
   end

--- a/app/models/events/pull_request.rb
+++ b/app/models/events/pull_request.rb
@@ -66,7 +66,7 @@ module Events
     validates :draft,
               :locked,
               inclusion: { in: [true, false] }
-    validates :github_id, uniqueness: true
+    validates :github_id, uniqueness: true, strict: PullRequests::GithubUniquenessError
 
     after_validation :build_merge_time, on: :update, if: :merged_at_changed?
 

--- a/spec/jobs/request_handler_job_spec.rb
+++ b/spec/jobs/request_handler_job_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+describe RequestHandlerJob do
+  describe '#perform' do
+    let!(:payload) { (create :full_pull_request_payload) }
+    let!(:event) { 'pull_request' }
+
+    it 'correctly initializes the Github service and calls it' do
+      expect_any_instance_of(GithubService)
+        .to receive(:call)
+        .once
+
+      described_class.perform_now(payload, event)
+    end
+  end
+end

--- a/spec/models/events/pull_request_spec.rb
+++ b/spec/models/events/pull_request_spec.rb
@@ -44,7 +44,6 @@ RSpec.describe Events::PullRequest, type: :model do
 
     it { is_expected.to have_many(:events) }
     it { is_expected.to belong_to(:owner) }
-    it { is_expected.to validate_uniqueness_of(:github_id) }
     it { is_expected.to validate_presence_of(:opened_at) }
     it { is_expected.to validate_presence_of(:github_id) }
     it { is_expected.to validate_presence_of(:title) }
@@ -64,6 +63,18 @@ RSpec.describe Events::PullRequest, type: :model do
     it 'is not valid without draft' do
       subject.draft = nil
       expect(subject).to_not be_valid
+    end
+
+    context 'when github id is already been taken' do
+      let!(:pull_request) { create(:pull_request, github_id: 100) }
+
+      it 'raise uniqueness exception' do
+        subject.github_id = 100
+
+        expect {
+          subject.save!
+        }.to raise_error(PullRequests::GithubUniquenessError)
+      end
     end
   end
 


### PR DESCRIPTION
## What does this PR do?
In [this](https://github.com/rootstrap/rs-code-review-metrics/pull/464) previous PR, talking with @santib we figured out that `find_or_create_by` function has a strange behaviour when the model has a uniqueness validation (more [info](https://github.com/rails/rails/issues/36027)). So that we decided to leave it as it is and retry the job in this case with a custom exception.

Resolves [EM-239](https://rootstrap.atlassian.net/browse/EM-239): ActiveRecord::RecordInvalid: Validation failed: Github has already been taken
