### PR TITLE
Add slack notification when code climate project not found

### DIFF
--- a/app/services/code_climate/update_project_service.rb
+++ b/app/services/code_climate/update_project_service.rb
@@ -9,7 +9,9 @@ module CodeClimate
 
       update_metric
     rescue Faraday::Error => exception
-      track_request_error(exception)
+      response = exception.response
+      error = response[:status].to_s + ' - ' + response[:body]
+      SlackService.code_climate_error(project, error)
     end
 
     private

--- a/app/services/slack_service.rb
+++ b/app/services/slack_service.rb
@@ -1,6 +1,7 @@
 module SlackService
   extend self
 
+  ENGINEERING_METRICS_NOTIFICATIONS = '#engineering-metrics-notifications'.freeze
   OPEN_SOURCE = '#open-source'.freeze
   ENGINEERING_METRICS_URL = ENV['ENGINEERING_METRICS_URL']
   EMOJI = ':wave:'.freeze
@@ -9,6 +10,14 @@ module SlackService
     message = I18n.t('services.slack.open_source_reminder.message',
                      url: "#{ENGINEERING_METRICS_URL}/open_source")
     ping(OPEN_SOURCE, message)
+  end
+
+  def code_climate_error(repository, error)
+    message = I18n.t('services.slack.code_climate_error.message',
+                     repository: repository.name,
+                     error: error)
+
+    ping(ENGINEERING_METRICS_NOTIFICATIONS, message)
   end
 
   private

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -34,3 +34,5 @@ en:
     slack:
       open_source_reminder:
         message: 'Hey! check this out: [Open Source metrics](%{url}) 🚀'
+      code_climate_error:
+        message: 'Hey! Check this out: [Code Climate error] Repository: %{repository} - Error: %{error}'

--- a/spec/services/code_climate/update_project_service/api_call_failures_spec.rb
+++ b/spec/services/code_climate/update_project_service/api_call_failures_spec.rb
@@ -30,6 +30,8 @@ describe CodeClimate::UpdateProjectService do
   context 'when the call to /repos' do
     context 'returns anything but 200' do
       before do
+        stub_notification_webhook
+
         on_request_repository_by_slug(project_name: project.name,
                                       respond: { status: 500 })
       end
@@ -39,8 +41,8 @@ describe CodeClimate::UpdateProjectService do
           .not_to change { CodeClimateProjectMetric.count }
       end
 
-      it 'notifies the error to exception hunter' do
-        expect(ExceptionHunter).to receive(:track).with(kind_of(Faraday::Error), anything)
+      it 'notifies the error to slack channel' do
+        expect(SlackService).to receive(:code_climate_error).with(project, anything)
 
         update_project_code_climate_info
       end
@@ -48,6 +50,8 @@ describe CodeClimate::UpdateProjectService do
 
     context 'returns empty data' do
       before do
+        stub_notification_webhook
+
         on_request_repository_by_slug(
           project_name: project.name,
           respond: { status: 200, body: code_climate_repository_json }
@@ -68,6 +72,8 @@ describe CodeClimate::UpdateProjectService do
   context 'when the call to /repos/:id/snapshots/' do
     context 'returns anything but 200' do
       before do
+        stub_notification_webhook
+
         on_request_repository_by_slug(
           project_name: project.name,
           respond: { status: 200, body: code_climate_repository_json }
@@ -83,8 +89,8 @@ describe CodeClimate::UpdateProjectService do
           .not_to change { CodeClimateProjectMetric.count }
       end
 
-      it 'notifies the error to exception hunter' do
-        expect(ExceptionHunter).to receive(:track).with(kind_of(Faraday::Error), anything)
+      it 'notifies the error to slack channel' do
+        expect(SlackService).to receive(:code_climate_error).with(project, anything)
 
         update_project_code_climate_info
       end
@@ -94,6 +100,8 @@ describe CodeClimate::UpdateProjectService do
   context 'when the call to /repos/:id/snapshots/issues' do
     context 'returns anything but 200' do
       before do
+        stub_notification_webhook
+
         on_request_repository_by_slug(
           project_name: project.name,
           respond: { status: 200, body: code_climate_repository_json }
@@ -113,8 +121,8 @@ describe CodeClimate::UpdateProjectService do
           .not_to change { CodeClimateProjectMetric.count }
       end
 
-      it 'notifies the error to exception hunter' do
-        expect(ExceptionHunter).to receive(:track).with(kind_of(Faraday::Error), anything)
+      it 'notifies the error to slack channel' do
+        expect(SlackService).to receive(:code_climate_error).with(project, anything)
 
         update_project_code_climate_info
       end
@@ -124,6 +132,8 @@ describe CodeClimate::UpdateProjectService do
   context 'when the call to /repos/:id/test_report/' do
     context 'returns anything but 200' do
       before do
+        stub_notification_webhook
+
         on_request_repository_by_slug(
           project_name: project.name,
           respond: { status: 200, body: code_climate_repository_json }
@@ -147,8 +157,8 @@ describe CodeClimate::UpdateProjectService do
           .not_to change { CodeClimateProjectMetric.count }
       end
 
-      it 'notifies the error to exception hunter' do
-        expect(ExceptionHunter).to receive(:track).with(kind_of(Faraday::Error), anything)
+      it 'notifies the error to slack channel' do
+        expect(SlackService).to receive(:code_climate_error).with(project, anything)
 
         update_project_code_climate_info
       end

--- a/spec/services/slack_service_spec.rb
+++ b/spec/services/slack_service_spec.rb
@@ -1,6 +1,25 @@
 require 'rails_helper'
 
 RSpec.describe SlackService do
+  shared_context 'a successful request' do
+    it 'calls Slack Notifier' do
+      expect_any_instance_of(Slack::Notifier)
+        .to receive(:post)
+        .with(text: message, icon_emoji: SlackService::EMOJI)
+      subject
+    end
+
+    it 'calls Slack API' do
+      subject
+      expect(WebMock).to have_requested(:post, ENV['SLACK_WEBHOOK_URL']).once
+    end
+
+    it 'returns a Slack API successful response' do
+      response = subject
+      expect(response.first.code.to_i).to eq 200
+    end
+  end
+
   describe '#open_source_reminder' do
     let(:subject) { described_class.open_source_reminder }
     let(:message) do
@@ -11,22 +30,26 @@ RSpec.describe SlackService do
     context 'when sent to valid channel' do
       before { stub_notification_webhook }
 
-      it 'calls Slack Notifier' do
-        expect_any_instance_of(Slack::Notifier)
-          .to receive(:post)
-          .with(text: message, icon_emoji: SlackService::EMOJI)
-        subject
-      end
+      it_behaves_like 'a successful request'
+    end
+  end
 
-      it 'calls Slack API' do
-        subject
-        expect(WebMock).to have_requested(:post, ENV['SLACK_WEBHOOK_URL']).once
-      end
+  describe '#code_climate_error' do
+    let(:project) { create(:project) }
+    let(:error) { kind_of(Faraday::Error) }
 
-      it 'returns a Slack API successful response' do
-        response = subject
-        expect(response.first.code.to_i).to eq 200
-      end
+    let(:message) do
+      I18n.t('services.slack.code_climate_error.message',
+             repository: project.name,
+             error: error)
+    end
+
+    let(:subject) { described_class.code_climate_error(project, error) }
+
+    context 'when sent to valid channel' do
+      before { stub_notification_webhook }
+
+      it_behaves_like 'a successful request'
     end
   end
 end


### PR DESCRIPTION
## What does this PR do?
When trying to fetch data from Code Climate, there are some repositories that aren't available.
This PR add a Slack notification to `#engineering-metrics-notifications` channel with the repository and the error. It also removes the tracking error in ExceptionHunter.

Resolves [EM-235](https://rootstrap.atlassian.net/browse/EM-235): Faraday::ResourceNotFound: the server responded with status 404
