### PR TITLE
Jira updater job filter issue types

### DIFF
--- a/app/services/processors/jira_project_development_cycle_updater.rb
+++ b/app/services/processors/jira_project_development_cycle_updater.rb
@@ -35,12 +35,16 @@ module Processors
     def issue_update!(issue, issue_fields, histories)
       environment_field = issue_fields[JIRA_ENVIRONMENT_FIELD]
 
+      issue_type = issue_type_field(issue_fields)&.downcase
+
+      return unless handleable_issue?(issue_type)
+
       issue.update!(
         informed_at: issue_fields[:created],
         resolved_at: issue_fields[:resolutiondate] || nil,
         in_progress_at: in_progress_at(histories) || issue.in_progress_at,
         environment: environment_field ? environment_field.first[:value]&.downcase : nil,
-        issue_type: issue_type_field(issue_fields)&.downcase
+        issue_type: issue_type
       )
     end
 
@@ -59,6 +63,10 @@ module Processors
       end
 
       in_progress_at[:created] if in_progress_at.presence
+    end
+
+    def handleable_issue?(issue_type)
+      JiraIssue.issue_types.include?(issue_type)
     end
   end
 end

--- a/spec/services/processors/jira_project_development_cycle_updater_spec.rb
+++ b/spec/services/processors/jira_project_development_cycle_updater_spec.rb
@@ -75,6 +75,28 @@ describe Processors::JiraProjectDevelopmentCycleUpdater do
         subject
         expect(last_issue.resolved_at).to be_nil
       end
+
+      context 'when the issue type is not in the enum' do
+        let(:bugs) do
+          [
+            {
+              'key': 'TES-4',
+              'fields': {
+                'customfield_10000': [{ 'value': 'production' }],
+                'created': informed_at_date,
+                'resolutiondate': resolved_at_date,
+                'issuetype': {
+                  'name': 'test_execution'
+                }
+              }
+            }
+          ]
+        end
+
+        it 'does not creates a record in the db' do
+          expect { subject }.not_to change(JiraIssue, :count)
+        end
+      end
     end
 
     context 'when the issue is done' do


### PR DESCRIPTION
## What does this PR do?
This PR add a validation to only store the data from issues types defined in the model.


Resolves [EM-243](https://rootstrap.atlassian.net/browse/EM-243): ArgumentError: 'test execution' is not a valid issue_type
