### PR TITLE
Refactor Project to Repository - Part 1

### DIFF
--- a/app/models/events.rb
+++ b/app/models/events.rb
@@ -1,0 +1,5 @@
+module Events
+  def self.table_name_prefix
+    'events_'
+  end
+end

--- a/app/models/events/pull_request.rb
+++ b/app/models/events/pull_request.rb
@@ -1,6 +1,6 @@
 # == Schema Information
 #
-# Table name: pull_requests
+# Table name: events_pull_requests
 #
 #  id         :bigint           not null, primary key
 #  body       :text
@@ -25,10 +25,10 @@
 #
 # Indexes
 #
-#  index_pull_requests_on_github_id   (github_id) UNIQUE
-#  index_pull_requests_on_owner_id    (owner_id)
-#  index_pull_requests_on_project_id  (project_id)
-#  index_pull_requests_on_state       (state)
+#  index_events_pull_requests_on_github_id   (github_id) UNIQUE
+#  index_events_pull_requests_on_owner_id    (owner_id)
+#  index_events_pull_requests_on_project_id  (project_id)
+#  index_events_pull_requests_on_state       (state)
 #
 # Foreign Keys
 #

--- a/app/models/events/pull_request_comment.rb
+++ b/app/models/events/pull_request_comment.rb
@@ -1,6 +1,6 @@
 # == Schema Information
 #
-# Table name: pull_request_comments
+# Table name: events_pull_request_comments
 #
 #  id                :bigint           not null, primary key
 #  body              :string
@@ -16,11 +16,11 @@
 #
 # Indexes
 #
-#  index_pull_request_comments_on_deleted_at         (deleted_at)
-#  index_pull_request_comments_on_owner_id           (owner_id)
-#  index_pull_request_comments_on_pull_request_id    (pull_request_id)
-#  index_pull_request_comments_on_review_request_id  (review_request_id)
-#  index_pull_request_comments_on_state              (state)
+#  index_events_pull_request_comments_on_deleted_at         (deleted_at)
+#  index_events_pull_request_comments_on_owner_id           (owner_id)
+#  index_events_pull_request_comments_on_pull_request_id    (pull_request_id)
+#  index_events_pull_request_comments_on_review_request_id  (review_request_id)
+#  index_events_pull_request_comments_on_state              (state)
 #
 # Foreign Keys
 #

--- a/app/models/events/push.rb
+++ b/app/models/events/push.rb
@@ -1,6 +1,6 @@
 # == Schema Information
 #
-# Table name: pushes
+# Table name: events_pushes
 #
 #  id              :bigint           not null, primary key
 #  deleted_at      :datetime
@@ -13,9 +13,9 @@
 #
 # Indexes
 #
-#  index_pushes_on_project_id       (project_id)
-#  index_pushes_on_pull_request_id  (pull_request_id)
-#  index_pushes_on_sender_id        (sender_id)
+#  index_events_pushes_on_project_id       (project_id)
+#  index_events_pushes_on_pull_request_id  (pull_request_id)
+#  index_events_pushes_on_sender_id        (sender_id)
 #
 # Foreign Keys
 #

--- a/app/models/events/repository.rb
+++ b/app/models/events/repository.rb
@@ -1,6 +1,6 @@
 # == Schema Information
 #
-# Table name: repositories
+# Table name: events_repositories
 #
 #  id         :bigint           not null, primary key
 #  action     :string
@@ -13,8 +13,8 @@
 #
 # Indexes
 #
-#  index_repositories_on_project_id  (project_id)
-#  index_repositories_on_sender_id   (sender_id)
+#  index_events_repositories_on_project_id  (project_id)
+#  index_events_repositories_on_sender_id   (sender_id)
 #
 # Foreign Keys
 #

--- a/app/models/events/review.rb
+++ b/app/models/events/review.rb
@@ -1,6 +1,6 @@
 # == Schema Information
 #
-# Table name: reviews
+# Table name: events_reviews
 #
 #  id                :bigint           not null, primary key
 #  body              :string
@@ -17,11 +17,11 @@
 #
 # Indexes
 #
-#  index_reviews_on_owner_id           (owner_id)
-#  index_reviews_on_project_id         (project_id)
-#  index_reviews_on_pull_request_id    (pull_request_id)
-#  index_reviews_on_review_request_id  (review_request_id)
-#  index_reviews_on_state              (state)
+#  index_events_reviews_on_owner_id           (owner_id)
+#  index_events_reviews_on_project_id         (project_id)
+#  index_events_reviews_on_pull_request_id    (pull_request_id)
+#  index_events_reviews_on_review_request_id  (review_request_id)
+#  index_events_reviews_on_state              (state)
 #
 # Foreign Keys
 #

--- a/app/models/events/review_comment.rb
+++ b/app/models/events/review_comment.rb
@@ -1,6 +1,6 @@
 # == Schema Information
 #
-# Table name: review_comments
+# Table name: events_review_comments
 #
 #  id              :bigint           not null, primary key
 #  body            :string
@@ -14,9 +14,9 @@
 #
 # Indexes
 #
-#  index_review_comments_on_owner_id         (owner_id)
-#  index_review_comments_on_pull_request_id  (pull_request_id)
-#  index_review_comments_on_state            (state)
+#  index_events_review_comments_on_owner_id         (owner_id)
+#  index_events_review_comments_on_pull_request_id  (pull_request_id)
+#  index_events_review_comments_on_state            (state)
 #
 # Foreign Keys
 #

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -92,11 +92,11 @@ class Project < ApplicationRecord
   }
 
   scope :with_a_pr_opened_after, lambda { |date|
-    joins(:pull_requests).where('pull_requests.opened_at > ?', date)
+    joins(:pull_requests).where('events_pull_requests.opened_at > ?', date)
   }
 
   scope :with_a_pr_merged_after, lambda { |date|
-    joins(:pull_requests).where('pull_requests.merged_at > ?', date)
+    joins(:pull_requests).where('events_pull_requests.merged_at > ?', date)
   }
 
   scope :by_department, lambda { |department|

--- a/app/services/builders/chartkick/department_distribution_data_metrics/merge_time.rb
+++ b/app/services/builders/chartkick/department_distribution_data_metrics/merge_time.rb
@@ -6,7 +6,7 @@ module Builders
           ::MergeTime
             .joins(pull_request: { project: { language: :department } })
             .where(departments: { id: entity_id })
-            .where(pull_requests: { merged_at: time_range })
+            .where(events_pull_requests: { merged_at: time_range })
         end
 
         def resolve_interval(entity)

--- a/app/services/builders/chartkick/project_distribution_data_metrics/merge_time.rb
+++ b/app/services/builders/chartkick/project_distribution_data_metrics/merge_time.rb
@@ -6,7 +6,7 @@ module Builders
           ::MergeTime
             .joins(pull_request: :project)
             .where(projects: { id: entity_id })
-            .where(pull_requests: { merged_at: time_range })
+            .where(events_pull_requests: { merged_at: time_range })
         end
 
         def resolve_interval(entity)

--- a/app/services/builders/distribution/pull_requests/time_to_merge.rb
+++ b/app/services/builders/distribution/pull_requests/time_to_merge.rb
@@ -21,7 +21,7 @@ module Builders
           @merge_times ||= ::MergeTime.where(created_at: @from.weeks.ago..Time.zone.now)
                                       .joins(pull_request: { project: { language: :department } })
                                       .where(departments: { name: @department_name })
-                                      .where.not(pull_requests: { html_url: nil })
+                                      .where.not(events_pull_requests: { html_url: nil })
                                       .includes(:pull_request)
         end
 

--- a/app/services/builders/distribution/pull_requests/time_to_second_review.rb
+++ b/app/services/builders/distribution/pull_requests/time_to_second_review.rb
@@ -28,7 +28,7 @@ module Builders
                                        .joins(review_request:
                                         { pull_request: { project: { language: :department } } })
                                        .where(departments: { name: @department_name })
-                                       .where.not(pull_requests: { html_url: nil })
+                                       .where.not(events_pull_requests: { html_url: nil })
                                        .includes(review_request: :pull_request)
           end
         end

--- a/app/services/metrics/merge_time/per_department.rb
+++ b/app/services/metrics/merge_time/per_department.rb
@@ -14,7 +14,7 @@ module Metrics
 
       def query(interval)
         Department.joins(languages: { projects: { pull_requests: :merge_time } })
-                  .where(pull_requests: { merged_at: interval })
+                  .where(events_pull_requests: { merged_at: interval })
                   .where(id: @entity_id)
                   .group(:id)
                   .pluck(:id, Arel.sql('AVG(merge_times.value)'))

--- a/app/services/metrics/merge_time/per_language.rb
+++ b/app/services/metrics/merge_time/per_language.rb
@@ -14,7 +14,7 @@ module Metrics
 
       def query(interval)
         Language.joins(projects: { pull_requests: :merge_time })
-                .where(pull_requests: { merged_at: interval })
+                .where(events_pull_requests: { merged_at: interval })
                 .where(id: @entity_id)
                 .group(:id)
                 .pluck(:id, Arel.sql('AVG(merge_times.value)'))

--- a/app/services/metrics/merge_time/per_project.rb
+++ b/app/services/metrics/merge_time/per_project.rb
@@ -14,7 +14,7 @@ module Metrics
 
       def query(interval)
         Project.joins(pull_requests: :merge_time)
-               .where(pull_requests: { merged_at: interval })
+               .where(events_pull_requests: { merged_at: interval })
                .where(id: @entity_id)
                .group(:id)
                .pluck(:id, Arel.sql('AVG(merge_times.value)'))

--- a/app/services/metrics/merge_time/per_user_project.rb
+++ b/app/services/metrics/merge_time/per_user_project.rb
@@ -15,7 +15,7 @@ module Metrics
 
       def query(interval)
         ::MergeTime.joins(:pull_request)
-                   .where(pull_requests: { merged_at: interval, owner_id: @entity_id })
+                   .where(events_pull_requests: { merged_at: interval, owner_id: @entity_id })
                    .group(:project_id, :owner_id)
                    .pluck(:project_id, :owner_id, Arel.sql('AVG(merge_times.value)'))
       end

--- a/db/migrate/20210827172747_add_namespace_to_events_tables.rb
+++ b/db/migrate/20210827172747_add_namespace_to_events_tables.rb
@@ -1,0 +1,10 @@
+class AddNamespaceToEventsTables < ActiveRecord::Migration[6.0]
+  def change
+    rename_table :pull_requests, :events_pull_requests
+    rename_table :pull_request_comments, :events_pull_request_comments
+    rename_table :pushes, :events_pushes
+    rename_table :repositories, :events_repositories
+    rename_table :review_comments, :events_review_comments
+    rename_table :reviews, :events_reviews
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -510,6 +510,236 @@ ALTER SEQUENCE public.events_id_seq OWNED BY public.events.id;
 
 
 --
+-- Name: events_pull_request_comments; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.events_pull_request_comments (
+    id bigint NOT NULL,
+    github_id integer,
+    body character varying,
+    opened_at timestamp without time zone NOT NULL,
+    deleted_at timestamp without time zone,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL,
+    pull_request_id bigint NOT NULL,
+    owner_id bigint,
+    review_request_id bigint,
+    state public.pull_request_comment_state DEFAULT 'created'::public.pull_request_comment_state
+);
+
+
+--
+-- Name: events_pull_request_comments_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.events_pull_request_comments_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: events_pull_request_comments_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.events_pull_request_comments_id_seq OWNED BY public.events_pull_request_comments.id;
+
+
+--
+-- Name: events_pull_requests; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.events_pull_requests (
+    id bigint NOT NULL,
+    github_id bigint NOT NULL,
+    number integer NOT NULL,
+    locked boolean NOT NULL,
+    title text NOT NULL,
+    body text,
+    closed_at timestamp without time zone,
+    merged_at timestamp without time zone,
+    draft boolean NOT NULL,
+    node_id character varying NOT NULL,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL,
+    state public.pull_request_state,
+    opened_at timestamp without time zone,
+    project_id bigint,
+    owner_id bigint,
+    html_url character varying,
+    branch character varying,
+    size integer,
+    deleted_at timestamp without time zone
+);
+
+
+--
+-- Name: events_pull_requests_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.events_pull_requests_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: events_pull_requests_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.events_pull_requests_id_seq OWNED BY public.events_pull_requests.id;
+
+
+--
+-- Name: events_pushes; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.events_pushes (
+    id bigint NOT NULL,
+    project_id bigint NOT NULL,
+    pull_request_id bigint,
+    sender_id bigint NOT NULL,
+    ref character varying,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL,
+    deleted_at timestamp without time zone
+);
+
+
+--
+-- Name: events_pushes_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.events_pushes_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: events_pushes_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.events_pushes_id_seq OWNED BY public.events_pushes.id;
+
+
+--
+-- Name: events_repositories; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.events_repositories (
+    id bigint NOT NULL,
+    action character varying,
+    html_url character varying,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL,
+    sender_id bigint NOT NULL,
+    project_id bigint NOT NULL,
+    deleted_at timestamp without time zone
+);
+
+
+--
+-- Name: events_repositories_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.events_repositories_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: events_repositories_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.events_repositories_id_seq OWNED BY public.events_repositories.id;
+
+
+--
+-- Name: events_review_comments; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.events_review_comments (
+    id bigint NOT NULL,
+    github_id integer,
+    body character varying,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL,
+    pull_request_id bigint NOT NULL,
+    owner_id bigint,
+    state public.review_comment_state DEFAULT 'active'::public.review_comment_state,
+    deleted_at timestamp without time zone
+);
+
+
+--
+-- Name: events_review_comments_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.events_review_comments_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: events_review_comments_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.events_review_comments_id_seq OWNED BY public.events_review_comments.id;
+
+
+--
+-- Name: events_reviews; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.events_reviews (
+    id bigint NOT NULL,
+    pull_request_id bigint NOT NULL,
+    owner_id bigint,
+    github_id integer,
+    body character varying,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL,
+    state public.review_state NOT NULL,
+    opened_at timestamp without time zone NOT NULL,
+    review_request_id bigint,
+    project_id bigint,
+    deleted_at timestamp without time zone
+);
+
+
+--
+-- Name: events_reviews_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.events_reviews_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: events_reviews_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.events_reviews_id_seq OWNED BY public.events_reviews.id;
+
+
+--
 -- Name: exception_hunter_error_groups; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -975,197 +1205,6 @@ ALTER SEQUENCE public.projects_id_seq OWNED BY public.projects.id;
 
 
 --
--- Name: pull_request_comments; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.pull_request_comments (
-    id bigint NOT NULL,
-    github_id integer,
-    body character varying,
-    opened_at timestamp without time zone NOT NULL,
-    deleted_at timestamp without time zone,
-    created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL,
-    pull_request_id bigint NOT NULL,
-    owner_id bigint,
-    review_request_id bigint,
-    state public.pull_request_comment_state DEFAULT 'created'::public.pull_request_comment_state
-);
-
-
---
--- Name: pull_request_comments_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.pull_request_comments_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: pull_request_comments_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.pull_request_comments_id_seq OWNED BY public.pull_request_comments.id;
-
-
---
--- Name: pull_requests; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.pull_requests (
-    id bigint NOT NULL,
-    github_id bigint NOT NULL,
-    number integer NOT NULL,
-    locked boolean NOT NULL,
-    title text NOT NULL,
-    body text,
-    closed_at timestamp without time zone,
-    merged_at timestamp without time zone,
-    draft boolean NOT NULL,
-    node_id character varying NOT NULL,
-    created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL,
-    state public.pull_request_state,
-    opened_at timestamp without time zone,
-    project_id bigint,
-    owner_id bigint,
-    html_url character varying,
-    branch character varying,
-    size integer,
-    deleted_at timestamp without time zone
-);
-
-
---
--- Name: pull_requests_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.pull_requests_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: pull_requests_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.pull_requests_id_seq OWNED BY public.pull_requests.id;
-
-
---
--- Name: pushes; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.pushes (
-    id bigint NOT NULL,
-    project_id bigint NOT NULL,
-    pull_request_id bigint,
-    sender_id bigint NOT NULL,
-    ref character varying,
-    created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL,
-    deleted_at timestamp without time zone
-);
-
-
---
--- Name: pushes_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.pushes_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: pushes_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.pushes_id_seq OWNED BY public.pushes.id;
-
-
---
--- Name: repositories; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.repositories (
-    id bigint NOT NULL,
-    action character varying,
-    html_url character varying,
-    created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL,
-    sender_id bigint NOT NULL,
-    project_id bigint NOT NULL,
-    deleted_at timestamp without time zone
-);
-
-
---
--- Name: repositories_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.repositories_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: repositories_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.repositories_id_seq OWNED BY public.repositories.id;
-
-
---
--- Name: review_comments; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.review_comments (
-    id bigint NOT NULL,
-    github_id integer,
-    body character varying,
-    created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL,
-    pull_request_id bigint NOT NULL,
-    owner_id bigint,
-    state public.review_comment_state DEFAULT 'active'::public.review_comment_state,
-    deleted_at timestamp without time zone
-);
-
-
---
--- Name: review_comments_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.review_comments_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: review_comments_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.review_comments_id_seq OWNED BY public.review_comments.id;
-
-
---
 -- Name: review_requests; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -1231,45 +1270,6 @@ CREATE SEQUENCE public.review_turnarounds_id_seq
 --
 
 ALTER SEQUENCE public.review_turnarounds_id_seq OWNED BY public.review_turnarounds.id;
-
-
---
--- Name: reviews; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.reviews (
-    id bigint NOT NULL,
-    pull_request_id bigint NOT NULL,
-    owner_id bigint,
-    github_id integer,
-    body character varying,
-    created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL,
-    state public.review_state NOT NULL,
-    opened_at timestamp without time zone NOT NULL,
-    review_request_id bigint,
-    project_id bigint,
-    deleted_at timestamp without time zone
-);
-
-
---
--- Name: reviews_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.reviews_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: reviews_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.reviews_id_seq OWNED BY public.reviews.id;
 
 
 --
@@ -1474,6 +1474,48 @@ ALTER TABLE ONLY public.events ALTER COLUMN id SET DEFAULT nextval('public.event
 
 
 --
+-- Name: events_pull_request_comments id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.events_pull_request_comments ALTER COLUMN id SET DEFAULT nextval('public.events_pull_request_comments_id_seq'::regclass);
+
+
+--
+-- Name: events_pull_requests id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.events_pull_requests ALTER COLUMN id SET DEFAULT nextval('public.events_pull_requests_id_seq'::regclass);
+
+
+--
+-- Name: events_pushes id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.events_pushes ALTER COLUMN id SET DEFAULT nextval('public.events_pushes_id_seq'::regclass);
+
+
+--
+-- Name: events_repositories id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.events_repositories ALTER COLUMN id SET DEFAULT nextval('public.events_repositories_id_seq'::regclass);
+
+
+--
+-- Name: events_review_comments id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.events_review_comments ALTER COLUMN id SET DEFAULT nextval('public.events_review_comments_id_seq'::regclass);
+
+
+--
+-- Name: events_reviews id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.events_reviews ALTER COLUMN id SET DEFAULT nextval('public.events_reviews_id_seq'::regclass);
+
+
+--
 -- Name: exception_hunter_error_groups id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -1565,41 +1607,6 @@ ALTER TABLE ONLY public.projects ALTER COLUMN id SET DEFAULT nextval('public.pro
 
 
 --
--- Name: pull_request_comments id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.pull_request_comments ALTER COLUMN id SET DEFAULT nextval('public.pull_request_comments_id_seq'::regclass);
-
-
---
--- Name: pull_requests id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.pull_requests ALTER COLUMN id SET DEFAULT nextval('public.pull_requests_id_seq'::regclass);
-
-
---
--- Name: pushes id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.pushes ALTER COLUMN id SET DEFAULT nextval('public.pushes_id_seq'::regclass);
-
-
---
--- Name: repositories id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.repositories ALTER COLUMN id SET DEFAULT nextval('public.repositories_id_seq'::regclass);
-
-
---
--- Name: review_comments id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.review_comments ALTER COLUMN id SET DEFAULT nextval('public.review_comments_id_seq'::regclass);
-
-
---
 -- Name: review_requests id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -1611,13 +1618,6 @@ ALTER TABLE ONLY public.review_requests ALTER COLUMN id SET DEFAULT nextval('pub
 --
 
 ALTER TABLE ONLY public.review_turnarounds ALTER COLUMN id SET DEFAULT nextval('public.review_turnarounds_id_seq'::regclass);
-
-
---
--- Name: reviews id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.reviews ALTER COLUMN id SET DEFAULT nextval('public.reviews_id_seq'::regclass);
 
 
 --
@@ -1729,6 +1729,54 @@ ALTER TABLE ONLY public.events
 
 
 --
+-- Name: events_pull_request_comments events_pull_request_comments_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.events_pull_request_comments
+    ADD CONSTRAINT events_pull_request_comments_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: events_pull_requests events_pull_requests_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.events_pull_requests
+    ADD CONSTRAINT events_pull_requests_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: events_pushes events_pushes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.events_pushes
+    ADD CONSTRAINT events_pushes_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: events_repositories events_repositories_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.events_repositories
+    ADD CONSTRAINT events_repositories_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: events_review_comments events_review_comments_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.events_review_comments
+    ADD CONSTRAINT events_review_comments_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: events_reviews events_reviews_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.events_reviews
+    ADD CONSTRAINT events_reviews_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: exception_hunter_error_groups exception_hunter_error_groups_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -1833,46 +1881,6 @@ ALTER TABLE ONLY public.projects
 
 
 --
--- Name: pull_request_comments pull_request_comments_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.pull_request_comments
-    ADD CONSTRAINT pull_request_comments_pkey PRIMARY KEY (id);
-
-
---
--- Name: pull_requests pull_requests_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.pull_requests
-    ADD CONSTRAINT pull_requests_pkey PRIMARY KEY (id);
-
-
---
--- Name: pushes pushes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.pushes
-    ADD CONSTRAINT pushes_pkey PRIMARY KEY (id);
-
-
---
--- Name: repositories repositories_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.repositories
-    ADD CONSTRAINT repositories_pkey PRIMARY KEY (id);
-
-
---
--- Name: review_comments review_comments_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.review_comments
-    ADD CONSTRAINT review_comments_pkey PRIMARY KEY (id);
-
-
---
 -- Name: review_requests review_requests_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -1886,14 +1894,6 @@ ALTER TABLE ONLY public.review_requests
 
 ALTER TABLE ONLY public.review_turnarounds
     ADD CONSTRAINT review_turnarounds_pkey PRIMARY KEY (id);
-
-
---
--- Name: reviews reviews_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.reviews
-    ADD CONSTRAINT reviews_pkey PRIMARY KEY (id);
 
 
 --
@@ -2035,6 +2035,160 @@ CREATE INDEX index_events_on_project_id ON public.events USING btree (project_id
 
 
 --
+-- Name: index_events_pull_request_comments_on_deleted_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_events_pull_request_comments_on_deleted_at ON public.events_pull_request_comments USING btree (deleted_at);
+
+
+--
+-- Name: index_events_pull_request_comments_on_owner_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_events_pull_request_comments_on_owner_id ON public.events_pull_request_comments USING btree (owner_id);
+
+
+--
+-- Name: index_events_pull_request_comments_on_pull_request_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_events_pull_request_comments_on_pull_request_id ON public.events_pull_request_comments USING btree (pull_request_id);
+
+
+--
+-- Name: index_events_pull_request_comments_on_review_request_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_events_pull_request_comments_on_review_request_id ON public.events_pull_request_comments USING btree (review_request_id);
+
+
+--
+-- Name: index_events_pull_request_comments_on_state; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_events_pull_request_comments_on_state ON public.events_pull_request_comments USING btree (state);
+
+
+--
+-- Name: index_events_pull_requests_on_github_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_events_pull_requests_on_github_id ON public.events_pull_requests USING btree (github_id);
+
+
+--
+-- Name: index_events_pull_requests_on_owner_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_events_pull_requests_on_owner_id ON public.events_pull_requests USING btree (owner_id);
+
+
+--
+-- Name: index_events_pull_requests_on_project_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_events_pull_requests_on_project_id ON public.events_pull_requests USING btree (project_id);
+
+
+--
+-- Name: index_events_pull_requests_on_state; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_events_pull_requests_on_state ON public.events_pull_requests USING btree (state);
+
+
+--
+-- Name: index_events_pushes_on_project_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_events_pushes_on_project_id ON public.events_pushes USING btree (project_id);
+
+
+--
+-- Name: index_events_pushes_on_pull_request_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_events_pushes_on_pull_request_id ON public.events_pushes USING btree (pull_request_id);
+
+
+--
+-- Name: index_events_pushes_on_sender_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_events_pushes_on_sender_id ON public.events_pushes USING btree (sender_id);
+
+
+--
+-- Name: index_events_repositories_on_project_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_events_repositories_on_project_id ON public.events_repositories USING btree (project_id);
+
+
+--
+-- Name: index_events_repositories_on_sender_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_events_repositories_on_sender_id ON public.events_repositories USING btree (sender_id);
+
+
+--
+-- Name: index_events_review_comments_on_owner_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_events_review_comments_on_owner_id ON public.events_review_comments USING btree (owner_id);
+
+
+--
+-- Name: index_events_review_comments_on_pull_request_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_events_review_comments_on_pull_request_id ON public.events_review_comments USING btree (pull_request_id);
+
+
+--
+-- Name: index_events_review_comments_on_state; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_events_review_comments_on_state ON public.events_review_comments USING btree (state);
+
+
+--
+-- Name: index_events_reviews_on_owner_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_events_reviews_on_owner_id ON public.events_reviews USING btree (owner_id);
+
+
+--
+-- Name: index_events_reviews_on_project_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_events_reviews_on_project_id ON public.events_reviews USING btree (project_id);
+
+
+--
+-- Name: index_events_reviews_on_pull_request_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_events_reviews_on_pull_request_id ON public.events_reviews USING btree (pull_request_id);
+
+
+--
+-- Name: index_events_reviews_on_review_request_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_events_reviews_on_review_request_id ON public.events_reviews USING btree (review_request_id);
+
+
+--
+-- Name: index_events_reviews_on_state; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_events_reviews_on_state ON public.events_reviews USING btree (state);
+
+
+--
 -- Name: index_exception_hunter_error_groups_on_message; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -2154,125 +2308,6 @@ CREATE INDEX index_projects_on_product_id ON public.projects USING btree (produc
 
 
 --
--- Name: index_pull_request_comments_on_deleted_at; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_pull_request_comments_on_deleted_at ON public.pull_request_comments USING btree (deleted_at);
-
-
---
--- Name: index_pull_request_comments_on_owner_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_pull_request_comments_on_owner_id ON public.pull_request_comments USING btree (owner_id);
-
-
---
--- Name: index_pull_request_comments_on_pull_request_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_pull_request_comments_on_pull_request_id ON public.pull_request_comments USING btree (pull_request_id);
-
-
---
--- Name: index_pull_request_comments_on_review_request_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_pull_request_comments_on_review_request_id ON public.pull_request_comments USING btree (review_request_id);
-
-
---
--- Name: index_pull_request_comments_on_state; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_pull_request_comments_on_state ON public.pull_request_comments USING btree (state);
-
-
---
--- Name: index_pull_requests_on_github_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE UNIQUE INDEX index_pull_requests_on_github_id ON public.pull_requests USING btree (github_id);
-
-
---
--- Name: index_pull_requests_on_owner_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_pull_requests_on_owner_id ON public.pull_requests USING btree (owner_id);
-
-
---
--- Name: index_pull_requests_on_project_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_pull_requests_on_project_id ON public.pull_requests USING btree (project_id);
-
-
---
--- Name: index_pull_requests_on_state; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_pull_requests_on_state ON public.pull_requests USING btree (state);
-
-
---
--- Name: index_pushes_on_project_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_pushes_on_project_id ON public.pushes USING btree (project_id);
-
-
---
--- Name: index_pushes_on_pull_request_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_pushes_on_pull_request_id ON public.pushes USING btree (pull_request_id);
-
-
---
--- Name: index_pushes_on_sender_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_pushes_on_sender_id ON public.pushes USING btree (sender_id);
-
-
---
--- Name: index_repositories_on_project_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_repositories_on_project_id ON public.repositories USING btree (project_id);
-
-
---
--- Name: index_repositories_on_sender_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_repositories_on_sender_id ON public.repositories USING btree (sender_id);
-
-
---
--- Name: index_review_comments_on_owner_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_review_comments_on_owner_id ON public.review_comments USING btree (owner_id);
-
-
---
--- Name: index_review_comments_on_pull_request_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_review_comments_on_pull_request_id ON public.review_comments USING btree (pull_request_id);
-
-
---
--- Name: index_review_comments_on_state; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_review_comments_on_state ON public.review_comments USING btree (state);
-
-
---
 -- Name: index_review_requests_on_owner_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -2315,41 +2350,6 @@ CREATE INDEX index_review_turnarounds_on_review_request_id ON public.review_turn
 
 
 --
--- Name: index_reviews_on_owner_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_reviews_on_owner_id ON public.reviews USING btree (owner_id);
-
-
---
--- Name: index_reviews_on_project_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_reviews_on_project_id ON public.reviews USING btree (project_id);
-
-
---
--- Name: index_reviews_on_pull_request_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_reviews_on_pull_request_id ON public.reviews USING btree (pull_request_id);
-
-
---
--- Name: index_reviews_on_review_request_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_reviews_on_review_request_id ON public.reviews USING btree (review_request_id);
-
-
---
--- Name: index_reviews_on_state; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_reviews_on_state ON public.reviews USING btree (state);
-
-
---
 -- Name: index_settings_on_key; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -2378,11 +2378,11 @@ CREATE INDEX index_users_projects_on_user_id ON public.users_projects USING btre
 
 
 --
--- Name: review_comments fk_rails_04feb57025; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: events_review_comments fk_rails_04feb57025; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.review_comments
-    ADD CONSTRAINT fk_rails_04feb57025 FOREIGN KEY (pull_request_id) REFERENCES public.pull_requests(id);
+ALTER TABLE ONLY public.events_review_comments
+    ADD CONSTRAINT fk_rails_04feb57025 FOREIGN KEY (pull_request_id) REFERENCES public.events_pull_requests(id);
 
 
 --
@@ -2402,10 +2402,10 @@ ALTER TABLE ONLY public.jira_issues
 
 
 --
--- Name: pull_request_comments fk_rails_161aa5ffd0; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: events_pull_request_comments fk_rails_161aa5ffd0; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.pull_request_comments
+ALTER TABLE ONLY public.events_pull_request_comments
     ADD CONSTRAINT fk_rails_161aa5ffd0 FOREIGN KEY (owner_id) REFERENCES public.users(id);
 
 
@@ -2418,11 +2418,11 @@ ALTER TABLE ONLY public.projects
 
 
 --
--- Name: pushes fk_rails_2981d8bb5a; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: events_pushes fk_rails_2981d8bb5a; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.pushes
-    ADD CONSTRAINT fk_rails_2981d8bb5a FOREIGN KEY (pull_request_id) REFERENCES public.pull_requests(id);
+ALTER TABLE ONLY public.events_pushes
+    ADD CONSTRAINT fk_rails_2981d8bb5a FOREIGN KEY (pull_request_id) REFERENCES public.events_pull_requests(id);
 
 
 --
@@ -2450,18 +2450,18 @@ ALTER TABLE ONLY public.review_turnarounds
 
 
 --
--- Name: repositories fk_rails_36d1823ddd; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: events_repositories fk_rails_36d1823ddd; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.repositories
+ALTER TABLE ONLY public.events_repositories
     ADD CONSTRAINT fk_rails_36d1823ddd FOREIGN KEY (project_id) REFERENCES public.projects(id);
 
 
 --
--- Name: pushes fk_rails_3f633d82fd; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: events_pushes fk_rails_3f633d82fd; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.pushes
+ALTER TABLE ONLY public.events_pushes
     ADD CONSTRAINT fk_rails_3f633d82fd FOREIGN KEY (project_id) REFERENCES public.projects(id);
 
 
@@ -2474,18 +2474,18 @@ ALTER TABLE ONLY public.blog_post_technologies
 
 
 --
--- Name: reviews fk_rails_4862a15e3a; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: events_reviews fk_rails_4862a15e3a; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.reviews
-    ADD CONSTRAINT fk_rails_4862a15e3a FOREIGN KEY (pull_request_id) REFERENCES public.pull_requests(id);
+ALTER TABLE ONLY public.events_reviews
+    ADD CONSTRAINT fk_rails_4862a15e3a FOREIGN KEY (pull_request_id) REFERENCES public.events_pull_requests(id);
 
 
 --
--- Name: review_comments fk_rails_4a92157916; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: events_review_comments fk_rails_4a92157916; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.review_comments
+ALTER TABLE ONLY public.events_review_comments
     ADD CONSTRAINT fk_rails_4a92157916 FOREIGN KEY (owner_id) REFERENCES public.users(id);
 
 
@@ -2498,18 +2498,18 @@ ALTER TABLE ONLY public.code_climate_project_metrics
 
 
 --
--- Name: pull_requests fk_rails_5df700b412; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: events_pull_requests fk_rails_5df700b412; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.pull_requests
+ALTER TABLE ONLY public.events_pull_requests
     ADD CONSTRAINT fk_rails_5df700b412 FOREIGN KEY (project_id) REFERENCES public.projects(id);
 
 
 --
--- Name: pull_requests fk_rails_658eb0bfb4; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: events_pull_requests fk_rails_658eb0bfb4; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.pull_requests
+ALTER TABLE ONLY public.events_pull_requests
     ADD CONSTRAINT fk_rails_658eb0bfb4 FOREIGN KEY (owner_id) REFERENCES public.users(id);
 
 
@@ -2538,10 +2538,10 @@ ALTER TABLE ONLY public.code_owner_projects
 
 
 --
--- Name: repositories fk_rails_9dbb09e26a; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: events_repositories fk_rails_9dbb09e26a; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.repositories
+ALTER TABLE ONLY public.events_repositories
     ADD CONSTRAINT fk_rails_9dbb09e26a FOREIGN KEY (sender_id) REFERENCES public.users(id);
 
 
@@ -2554,18 +2554,18 @@ ALTER TABLE ONLY public.review_requests
 
 
 --
--- Name: pushes fk_rails_bc14f07184; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: events_pushes fk_rails_bc14f07184; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.pushes
+ALTER TABLE ONLY public.events_pushes
     ADD CONSTRAINT fk_rails_bc14f07184 FOREIGN KEY (sender_id) REFERENCES public.users(id);
 
 
 --
--- Name: reviews fk_rails_bcf65590e4; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: events_reviews fk_rails_bcf65590e4; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.reviews
+ALTER TABLE ONLY public.events_reviews
     ADD CONSTRAINT fk_rails_bcf65590e4 FOREIGN KEY (owner_id) REFERENCES public.users(id);
 
 
@@ -2602,11 +2602,11 @@ ALTER TABLE ONLY public.review_requests
 
 
 --
--- Name: pull_request_comments fk_rails_e74e223f63; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: events_pull_request_comments fk_rails_e74e223f63; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.pull_request_comments
-    ADD CONSTRAINT fk_rails_e74e223f63 FOREIGN KEY (pull_request_id) REFERENCES public.pull_requests(id);
+ALTER TABLE ONLY public.events_pull_request_comments
+    ADD CONSTRAINT fk_rails_e74e223f63 FOREIGN KEY (pull_request_id) REFERENCES public.events_pull_requests(id);
 
 
 --
@@ -2630,7 +2630,7 @@ ALTER TABLE ONLY public.exception_hunter_errors
 --
 
 ALTER TABLE ONLY public.merge_times
-    ADD CONSTRAINT fk_rails_f002296adb FOREIGN KEY (pull_request_id) REFERENCES public.pull_requests(id);
+    ADD CONSTRAINT fk_rails_f002296adb FOREIGN KEY (pull_request_id) REFERENCES public.events_pull_requests(id);
 
 
 --
@@ -2638,7 +2638,7 @@ ALTER TABLE ONLY public.merge_times
 --
 
 ALTER TABLE ONLY public.review_requests
-    ADD CONSTRAINT fk_rails_feb865e207 FOREIGN KEY (pull_request_id) REFERENCES public.pull_requests(id);
+    ADD CONSTRAINT fk_rails_feb865e207 FOREIGN KEY (pull_request_id) REFERENCES public.events_pull_requests(id);
 
 
 --
@@ -2779,6 +2779,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20210726184449'),
 ('20210810122756'),
 ('20210810123929'),
-('20210810184003');
+('20210810184003'),
+('20210827172747');
 
 

--- a/spec/factories/events/pull_request_comments.rb
+++ b/spec/factories/events/pull_request_comments.rb
@@ -1,6 +1,6 @@
 # == Schema Information
 #
-# Table name: pull_request_comments
+# Table name: events_pull_request_comments
 #
 #  id                :bigint           not null, primary key
 #  body              :string
@@ -16,11 +16,11 @@
 #
 # Indexes
 #
-#  index_pull_request_comments_on_deleted_at         (deleted_at)
-#  index_pull_request_comments_on_owner_id           (owner_id)
-#  index_pull_request_comments_on_pull_request_id    (pull_request_id)
-#  index_pull_request_comments_on_review_request_id  (review_request_id)
-#  index_pull_request_comments_on_state              (state)
+#  index_events_pull_request_comments_on_deleted_at         (deleted_at)
+#  index_events_pull_request_comments_on_owner_id           (owner_id)
+#  index_events_pull_request_comments_on_pull_request_id    (pull_request_id)
+#  index_events_pull_request_comments_on_review_request_id  (review_request_id)
+#  index_events_pull_request_comments_on_state              (state)
 #
 # Foreign Keys
 #

--- a/spec/factories/events/pull_requests.rb
+++ b/spec/factories/events/pull_requests.rb
@@ -1,6 +1,6 @@
 # == Schema Information
 #
-# Table name: pull_requests
+# Table name: events_pull_requests
 #
 #  id         :bigint           not null, primary key
 #  body       :text
@@ -25,10 +25,10 @@
 #
 # Indexes
 #
-#  index_pull_requests_on_github_id   (github_id) UNIQUE
-#  index_pull_requests_on_owner_id    (owner_id)
-#  index_pull_requests_on_project_id  (project_id)
-#  index_pull_requests_on_state       (state)
+#  index_events_pull_requests_on_github_id   (github_id) UNIQUE
+#  index_events_pull_requests_on_owner_id    (owner_id)
+#  index_events_pull_requests_on_project_id  (project_id)
+#  index_events_pull_requests_on_state       (state)
 #
 # Foreign Keys
 #

--- a/spec/factories/events/pushes.rb
+++ b/spec/factories/events/pushes.rb
@@ -1,6 +1,6 @@
 # == Schema Information
 #
-# Table name: pushes
+# Table name: events_pushes
 #
 #  id              :bigint           not null, primary key
 #  deleted_at      :datetime
@@ -13,9 +13,9 @@
 #
 # Indexes
 #
-#  index_pushes_on_project_id       (project_id)
-#  index_pushes_on_pull_request_id  (pull_request_id)
-#  index_pushes_on_sender_id        (sender_id)
+#  index_events_pushes_on_project_id       (project_id)
+#  index_events_pushes_on_pull_request_id  (pull_request_id)
+#  index_events_pushes_on_sender_id        (sender_id)
 #
 # Foreign Keys
 #

--- a/spec/factories/events/repositories.rb
+++ b/spec/factories/events/repositories.rb
@@ -1,6 +1,6 @@
 # == Schema Information
 #
-# Table name: repositories
+# Table name: events_repositories
 #
 #  id         :bigint           not null, primary key
 #  action     :string
@@ -13,8 +13,8 @@
 #
 # Indexes
 #
-#  index_repositories_on_project_id  (project_id)
-#  index_repositories_on_sender_id   (sender_id)
+#  index_events_repositories_on_project_id  (project_id)
+#  index_events_repositories_on_sender_id   (sender_id)
 #
 # Foreign Keys
 #

--- a/spec/factories/events/review_comments.rb
+++ b/spec/factories/events/review_comments.rb
@@ -1,6 +1,6 @@
 # == Schema Information
 #
-# Table name: review_comments
+# Table name: events_review_comments
 #
 #  id              :bigint           not null, primary key
 #  body            :string
@@ -14,9 +14,9 @@
 #
 # Indexes
 #
-#  index_review_comments_on_owner_id         (owner_id)
-#  index_review_comments_on_pull_request_id  (pull_request_id)
-#  index_review_comments_on_state            (state)
+#  index_events_review_comments_on_owner_id         (owner_id)
+#  index_events_review_comments_on_pull_request_id  (pull_request_id)
+#  index_events_review_comments_on_state            (state)
 #
 # Foreign Keys
 #

--- a/spec/factories/events/reviews.rb
+++ b/spec/factories/events/reviews.rb
@@ -1,6 +1,6 @@
 # == Schema Information
 #
-# Table name: reviews
+# Table name: events_reviews
 #
 #  id                :bigint           not null, primary key
 #  body              :string
@@ -17,11 +17,11 @@
 #
 # Indexes
 #
-#  index_reviews_on_owner_id           (owner_id)
-#  index_reviews_on_project_id         (project_id)
-#  index_reviews_on_pull_request_id    (pull_request_id)
-#  index_reviews_on_review_request_id  (review_request_id)
-#  index_reviews_on_state              (state)
+#  index_events_reviews_on_owner_id           (owner_id)
+#  index_events_reviews_on_project_id         (project_id)
+#  index_events_reviews_on_pull_request_id    (pull_request_id)
+#  index_events_reviews_on_review_request_id  (review_request_id)
+#  index_events_reviews_on_state              (state)
 #
 # Foreign Keys
 #

--- a/spec/models/events/pull_request_comment_spec.rb
+++ b/spec/models/events/pull_request_comment_spec.rb
@@ -1,6 +1,6 @@
 # == Schema Information
 #
-# Table name: pull_request_comments
+# Table name: events_pull_request_comments
 #
 #  id                :bigint           not null, primary key
 #  body              :string
@@ -16,11 +16,11 @@
 #
 # Indexes
 #
-#  index_pull_request_comments_on_deleted_at         (deleted_at)
-#  index_pull_request_comments_on_owner_id           (owner_id)
-#  index_pull_request_comments_on_pull_request_id    (pull_request_id)
-#  index_pull_request_comments_on_review_request_id  (review_request_id)
-#  index_pull_request_comments_on_state              (state)
+#  index_events_pull_request_comments_on_deleted_at         (deleted_at)
+#  index_events_pull_request_comments_on_owner_id           (owner_id)
+#  index_events_pull_request_comments_on_pull_request_id    (pull_request_id)
+#  index_events_pull_request_comments_on_review_request_id  (review_request_id)
+#  index_events_pull_request_comments_on_state              (state)
 #
 # Foreign Keys
 #

--- a/spec/models/events/pull_request_spec.rb
+++ b/spec/models/events/pull_request_spec.rb
@@ -1,6 +1,6 @@
 # == Schema Information
 #
-# Table name: pull_requests
+# Table name: events_pull_requests
 #
 #  id         :bigint           not null, primary key
 #  body       :text
@@ -25,10 +25,10 @@
 #
 # Indexes
 #
-#  index_pull_requests_on_github_id   (github_id) UNIQUE
-#  index_pull_requests_on_owner_id    (owner_id)
-#  index_pull_requests_on_project_id  (project_id)
-#  index_pull_requests_on_state       (state)
+#  index_events_pull_requests_on_github_id   (github_id) UNIQUE
+#  index_events_pull_requests_on_owner_id    (owner_id)
+#  index_events_pull_requests_on_project_id  (project_id)
+#  index_events_pull_requests_on_state       (state)
 #
 # Foreign Keys
 #

--- a/spec/models/events/push_spec.rb
+++ b/spec/models/events/push_spec.rb
@@ -1,6 +1,6 @@
 # == Schema Information
 #
-# Table name: pushes
+# Table name: events_pushes
 #
 #  id              :bigint           not null, primary key
 #  deleted_at      :datetime
@@ -13,9 +13,9 @@
 #
 # Indexes
 #
-#  index_pushes_on_project_id       (project_id)
-#  index_pushes_on_pull_request_id  (pull_request_id)
-#  index_pushes_on_sender_id        (sender_id)
+#  index_events_pushes_on_project_id       (project_id)
+#  index_events_pushes_on_pull_request_id  (pull_request_id)
+#  index_events_pushes_on_sender_id        (sender_id)
 #
 # Foreign Keys
 #

--- a/spec/models/events/repository_spec.rb
+++ b/spec/models/events/repository_spec.rb
@@ -1,6 +1,6 @@
 # == Schema Information
 #
-# Table name: repositories
+# Table name: events_repositories
 #
 #  id         :bigint           not null, primary key
 #  action     :string
@@ -13,8 +13,8 @@
 #
 # Indexes
 #
-#  index_repositories_on_project_id  (project_id)
-#  index_repositories_on_sender_id   (sender_id)
+#  index_events_repositories_on_project_id  (project_id)
+#  index_events_repositories_on_sender_id   (sender_id)
 #
 # Foreign Keys
 #

--- a/spec/models/events/review_comment_spec.rb
+++ b/spec/models/events/review_comment_spec.rb
@@ -1,6 +1,6 @@
 # == Schema Information
 #
-# Table name: review_comments
+# Table name: events_review_comments
 #
 #  id              :bigint           not null, primary key
 #  body            :string
@@ -14,9 +14,9 @@
 #
 # Indexes
 #
-#  index_review_comments_on_owner_id         (owner_id)
-#  index_review_comments_on_pull_request_id  (pull_request_id)
-#  index_review_comments_on_state            (state)
+#  index_events_review_comments_on_owner_id         (owner_id)
+#  index_events_review_comments_on_pull_request_id  (pull_request_id)
+#  index_events_review_comments_on_state            (state)
 #
 # Foreign Keys
 #

--- a/spec/models/events/review_spec.rb
+++ b/spec/models/events/review_spec.rb
@@ -1,6 +1,6 @@
 # == Schema Information
 #
-# Table name: reviews
+# Table name: events_reviews
 #
 #  id                :bigint           not null, primary key
 #  body              :string
@@ -17,11 +17,11 @@
 #
 # Indexes
 #
-#  index_reviews_on_owner_id           (owner_id)
-#  index_reviews_on_project_id         (project_id)
-#  index_reviews_on_pull_request_id    (pull_request_id)
-#  index_reviews_on_review_request_id  (review_request_id)
-#  index_reviews_on_state              (state)
+#  index_events_reviews_on_owner_id           (owner_id)
+#  index_events_reviews_on_project_id         (project_id)
+#  index_events_reviews_on_pull_request_id    (pull_request_id)
+#  index_events_reviews_on_review_request_id  (review_request_id)
+#  index_events_reviews_on_state              (state)
 #
 # Foreign Keys
 #


### PR DESCRIPTION
## What does this PR do?
This PR is one part of the full feature. The main idea of the refactor is to rename the `Project` entity to `Repository`, because in fact this model has all the information related to Rootstrap repositories in Github.

First of all, the tables associated to the models inside `Events` folders are added a prefix for the existing namespace to avoid conflicts.


Resolves in part [EM-225](https://rootstrap.atlassian.net/browse/EM-225): Refactor: Refactor: Rename project entity.
