### PR TITLE
Department summary - Add Average of Code Coverage and Fix See Repository

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -34,7 +34,8 @@ detectors:
   LongParameterList:
     enabled: true
     exclude: ['WordpressApiMocker#stub_single_blog_post_response',
-              'CodeClimate::RepositorySummary']
+              'CodeClimate::RepositorySummary', 
+              'CodeClimate::RepositoriesSummary']
     max_params: 4
     overrides:
       initialize:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -80,6 +80,7 @@ Metrics/ParameterLists:
   CountKeywordArgs: true
   Exclude:
     - app/services/code_climate/repository_summary.rb
+    - app/services/code_climate/repositories_summary.rb
 
 Metrics/PerceivedComplexity:
   Max: 12

--- a/app/services/code_climate/repositories_summary.rb
+++ b/app/services/code_climate/repositories_summary.rb
@@ -3,6 +3,7 @@ module CodeClimate
     attr_reader :invalid_issues_count_average,
                 :wont_fix_issues_count_average,
                 :open_issues_count_average,
+                :test_coverage_average,
                 :ratings,
                 :repositories_without_cc_count
 
@@ -10,12 +11,14 @@ module CodeClimate
       invalid_issues_count_average: nil,
       wont_fix_issues_count_average: nil,
       open_issues_count_average: nil,
+      test_coverage_average: nil,
       ratings: {},
       repositories_without_cc_count: 0
     )
       @invalid_issues_count_average = invalid_issues_count_average
       @wont_fix_issues_count_average = wont_fix_issues_count_average
       @open_issues_count_average = open_issues_count_average
+      @test_coverage_average = test_coverage_average
       @ratings = ratings
       @repositories_without_cc_count = repositories_without_cc_count
     end

--- a/app/services/code_climate/repositories_summary_service.rb
+++ b/app/services/code_climate/repositories_summary_service.rb
@@ -15,6 +15,7 @@ module CodeClimate
         invalid_issues_count_average: invalid_issues_count_average.round(2),
         wont_fix_issues_count_average: wont_fix_issues_count_average.round(2),
         open_issues_count_average: open_issues_count_average.round(2),
+        test_coverage_average: test_coverage_average&.round,
         ratings: ratings,
         repositories_without_cc_count: repositories_without_cc_count
       )
@@ -36,6 +37,10 @@ module CodeClimate
 
     def open_issues_count_average
       code_climate_metrics.average(:open_issues_count)
+    end
+
+    def test_coverage_average
+      code_climate_metrics.average(:test_coverage)
     end
 
     def ratings

--- a/app/views/development_metrics/code_climate/_code_climate_department_summary.erb
+++ b/app/views/development_metrics/code_climate/_code_climate_department_summary.erb
@@ -27,6 +27,9 @@
             <span>Average of <b><%= code_climate.invalid_issues_count_average %> invalid</b> issues</span>
             <span>Average of <b><%= code_climate.wont_fix_issues_count_average %> won't fix</b> issues</span>
             <span>Average of <b><%= code_climate.open_issues_count_average %> open</b> issues</span>
+            <% if code_climate.test_coverage_average.present? -%>
+              <span>Average of <b><%= code_climate.test_coverage_average %>% </b>code coverage</span>
+            <% end -%>
           </div>
           <div>
             <%= link_to 'See report',

--- a/app/views/development_metrics/repositories.erb
+++ b/app/views/development_metrics/repositories.erb
@@ -2,7 +2,7 @@
 
 <div class="row">
   <div class="col-md-12 text-center mt-2">
-    <b><%= @repository.product[:name] %></b>
+    <b><%= @repository.product[:name] if @repository.product.present? %></b>
   </div>
   <%= render 'development_metrics/navigation', product: @repository.product %>
 

--- a/app/views/shared/_column-labels.erb
+++ b/app/views/shared/_column-labels.erb
@@ -1,6 +1,6 @@
 <div class='p-3 chart-container'>
   <span class='metric-title'><%= metric_name %></span>
-  <div id='chart-2' class='chart'>
+  <div id='chart-3' class='chart'>
     <%= column_chart metric,
         ytitle: "Story points",
         xtitle: "Sprints",

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -826,9 +826,9 @@ CREATE TABLE public.external_pull_requests (
     external_repository_id bigint NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
-    number integer,
     opened_at timestamp without time zone,
-    state public.external_pull_request_state
+    state public.external_pull_request_state,
+    number integer
 );
 
 

--- a/spec/services/code_climate/repositories_summary_service/repositories_summary_service_spec.rb
+++ b/spec/services/code_climate/repositories_summary_service/repositories_summary_service_spec.rb
@@ -19,6 +19,7 @@ describe CodeClimate::RepositoriesSummaryService do
            invalid_issues_count: 0,
            wont_fix_issues_count: 0,
            open_issues_count: 0,
+           test_coverage: 80,
            code_climate_rate: 'A',
            snapshot_time: 2.weeks.ago
 
@@ -27,6 +28,7 @@ describe CodeClimate::RepositoriesSummaryService do
            invalid_issues_count: 2,
            wont_fix_issues_count: 4,
            open_issues_count: 6,
+           test_coverage: 90,
            code_climate_rate: 'Z',
            snapshot_time: 2.weeks.ago
   end
@@ -50,6 +52,10 @@ describe CodeClimate::RepositoriesSummaryService do
 
     it 'shows the open issues count in the selected department' do
       expect(repositories_summary.open_issues_count_average).to eq(3)
+    end
+
+    it 'shows the test coverage in the selected department' do
+      expect(repositories_summary.test_coverage_average).to eq(85)
     end
 
     it 'shows the total of "A" repositories in the selected department' do
@@ -80,6 +86,10 @@ describe CodeClimate::RepositoriesSummaryService do
       expect(repositories_summary.open_issues_count_average).to be_nil
     end
 
+    it 'shows no test coverage' do
+      expect(repositories_summary.test_coverage_average).to be_nil
+    end
+
     it 'shows no total of "A" repositories' do
       expect(repositories_summary.repositories_rated_with('A')).to eq(0)
     end
@@ -102,6 +112,10 @@ describe CodeClimate::RepositoriesSummaryService do
 
     it 'shows the open issues count in the selected department' do
       expect(repositories_summary.open_issues_count_average).to eq(3)
+    end
+
+    it 'shows the test coverage in the selected department' do
+      expect(repositories_summary.test_coverage_average).to eq(85)
     end
 
     it 'shows the total of "A" repositories in the selected department' do
@@ -132,6 +146,10 @@ describe CodeClimate::RepositoriesSummaryService do
       expect(repositories_summary.open_issues_count_average).to be_nil
     end
 
+    it 'shows no test coverage' do
+      expect(repositories_summary.test_coverage_average).to be_nil
+    end
+
     it 'shows no total of "A" repositories' do
       expect(repositories_summary.repositories_rated_with('A')).to eq(0)
     end
@@ -152,6 +170,10 @@ describe CodeClimate::RepositoriesSummaryService do
 
     it 'shows the open issues count in the selected department' do
       expect(repositories_summary.open_issues_count_average).to eq(3)
+    end
+
+    it 'shows the test coverage in the selected department' do
+      expect(repositories_summary.test_coverage_average).to eq(85)
     end
 
     it 'shows the total of "A" repositories in the selected department' do
@@ -180,6 +202,10 @@ describe CodeClimate::RepositoriesSummaryService do
 
     it 'shows no open issues count' do
       expect(repositories_summary.open_issues_count_average).to be_nil
+    end
+
+    it 'shows no test coverage' do
+      expect(repositories_summary.test_coverage_average).to be_nil
     end
 
     it 'shows no total of "A" repositories' do

--- a/spec/services/code_climate/repositories_summary_service_spec.rb
+++ b/spec/services/code_climate/repositories_summary_service_spec.rb
@@ -36,6 +36,10 @@ describe CodeClimate::RepositoriesSummaryService do
       code_climate_metrics.map(&:open_issues_count).sum / code_climate_metrics.size.to_f
     end
 
+    let(:test_coverage_average) do
+      (code_climate_metrics.map(&:test_coverage).sum / code_climate_metrics.size.to_f).round
+    end
+
     let(:ratings) do
       code_climate_metrics.each_with_object(Hash.new(0)) do |code_climate_metric, ratings|
         ratings[code_climate_metric.code_climate_rate] += 1
@@ -59,6 +63,10 @@ describe CodeClimate::RepositoriesSummaryService do
       expect(subject.open_issues_count_average).to eq(open_issues_count_average)
     end
 
+    it 'returns the correct test coverage average' do
+      expect(subject.test_coverage_average).to eq(test_coverage_average)
+    end
+
     it 'returns the correct ratings' do
       expect(subject.ratings).to eq(ratings)
     end
@@ -76,6 +84,7 @@ describe CodeClimate::RepositoriesSummaryService do
           invalid_issues_count: nil,
           open_issues_count: nil,
           wont_fix_issues_count: nil,
+          test_coverage: nil,
           snapshot_time: nil,
           repository: third_repository
         )
@@ -97,6 +106,10 @@ describe CodeClimate::RepositoriesSummaryService do
         code_climate_metrics_with_data.map(&:open_issues_count).sum / 2.0
       end
 
+      let(:test_coverage_average) do
+        (code_climate_metrics_with_data.map(&:test_coverage).sum / 2.to_f).round
+      end
+
       let(:ratings) do
         ratings = Hash.new(0)
         ratings[first_code_climate_repository.code_climate_rate] += 1
@@ -114,6 +127,10 @@ describe CodeClimate::RepositoriesSummaryService do
 
       it 'does not count it for the open issues average' do
         expect(subject.open_issues_count_average).to eq(open_issues_count_average)
+      end
+
+      it 'does not count it for the test coverage average' do
+        expect(subject.test_coverage_average).to eq(test_coverage_average)
       end
 
       it 'does not count it for the ratings' do

--- a/spec/services/code_climate/repositories_summary_spec.rb
+++ b/spec/services/code_climate/repositories_summary_spec.rb
@@ -7,6 +7,7 @@ describe CodeClimate::RepositoriesSummary do
         invalid_issues_count_average
         wont_fix_issues_count_average
         open_issues_count_average
+        test_coverage_average
         ratings
       ]
     end
@@ -16,6 +17,7 @@ describe CodeClimate::RepositoriesSummary do
         invalid_issues_count_average: 1,
         wont_fix_issues_count_average: 3,
         open_issues_count_average: 0,
+        test_coverage_average: 90,
         ratings: { 'A': 1, 'B': 2 }
       )
     end


### PR DESCRIPTION
## What does this PR do?
In View by department:

- Add average of code coverage of a department
Resolves [#EM-118](https://rootstrap.atlassian.net/browse/EM-118)

- Fix error in See Repository button
Resolves [#EM-251](https://rootstrap.atlassian.net/browse/EM-251)

![Screen Shot 2021-09-10 at 16 17 46](https://user-images.githubusercontent.com/18470980/132906625-ef8f2db1-37b5-4711-97c4-4c45968cf6c7.png)

