### PR TITLE
Add meta tags headers for link unfurling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,3 +36,6 @@ JIRA_ENVIRONMENT_FIELD=customfield_10000
 JIRA_ROOT_URL=http://localhost:2990
 JIRA_AGILE_URL=http://localhost:2990
 JIRA_REPORTS_URL=http://localhost:2990
+
+# Quichckart
+QUICKCHART_URL=https://quickchart.io/chart/create

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -120,3 +120,7 @@ Style/BlockComments:
 SkipsModelValidations:
   Exclude:
     - app/services/processors/org_users_updater.rb
+
+Rails/HelperInstanceVariable:
+  Exclude:
+    - app/helpers/meta_tags_helper.rb

--- a/app/helpers/meta_tags_helper.rb
+++ b/app/helpers/meta_tags_helper.rb
@@ -1,0 +1,186 @@
+module MetaTagsHelper
+  def meta_title
+    title_for_metrics
+  end
+
+  def meta_description
+    description_for_metrics
+  end
+
+  def meta_image
+    generate_url_image if current_page?(products_metrics_development_metrics_path)
+  end
+
+  private
+
+  def title_for_metrics
+    if current_page?(products_development_metrics_path)
+      product_name.present? ? "#{product_name} summary" : default_description
+    elsif current_page?(products_metrics_development_metrics_path)
+      product_name + ' - ' + MetricDefinition.where(code: @query_metric_name).first&.name
+    else
+      title_for_pages
+    end
+  end
+
+  def title_for_pages
+    if current_page?(repositories_development_metrics_path)
+      "#{@repository[:name]} summary"
+    elsif current_page?(open_source_index_path)
+      'Open Source repositories'
+    elsif current_page?(departments_development_metrics_path)
+      @department.present? ? "#{@department[:name]} department metrics" : 'Departments'
+    elsif current_page?(tech_blog_path)
+      'Tech Blog visits'
+    else
+      default_description
+    end
+  end
+
+  def description_for_metrics
+    if current_page?(products_development_metrics_path)
+      product_name.present? ? product_summary_description : default_description
+    elsif current_page?(products_metrics_development_metrics_path)
+      product_description
+    elsif current_page?(repositories_development_metrics_path)
+      "#{@repository[:name]} summary"
+    else
+      description_for_pages
+    end
+  end
+
+  def description_for_pages
+    if current_page?(open_source_index_path)
+      "#{@total_repositories} open source #{'repository'.pluralize(@total_repositories)}"
+    elsif current_page?(departments_development_metrics_path)
+      @department.present? ? "#{@department[:name]} department metrics" : 'Departments'
+    elsif current_page?(tech_blog_path)
+      "#{@month_to_date_visits} visits this month"
+    else
+      default_description
+    end
+  end
+
+  def product_name
+    @product_name ||= @product[:name] if @product.present?
+  end
+
+  def default_description
+    'Engineering Metrics'
+  end
+
+  def product_description
+    separator?(false)
+
+    description = ''
+
+    description += defect_escape_rate_description if defect_escape_rate_description.present?
+    description += development_cycle_description if development_cycle_description.present?
+    description += planned_to_done_description if planned_to_done_description.present?
+
+    description = default_description if description.nil?
+
+    description
+  end
+
+  def product_summary_description
+    separator?(true)
+
+    description = 'Summary - '
+
+    description += defect_escape_rate_description if defect_escape_rate_description.present?
+    description += development_cycle_description if development_cycle_description.present?
+    description += planned_to_done_description if planned_to_done_description.present?
+
+    description = default_description if description == 'Summary - '
+
+    description
+  end
+
+  def defect_escape_rate_description
+    return unless @show_defect_escape_rate
+
+    data = @defect_escape_rate[:per_defect_escape_values].first[:data]
+
+    return unless @show_defect_escape_rate && data.present?
+
+    desc = 'Overall ' + @defect_escape_rate_definition.name + ': ' + data[:rate].to_s + '%'
+    desc += ' -' if @separator
+    desc
+  end
+
+  def development_cycle_description
+    return unless @show_development_cycle
+
+    average = @development_cycle[:per_development_cycle_average].first[:data][:average]
+
+    return if average.blank?
+
+    desc = 'Overall ' + @development_cycle_definition.name + ': ' + average.to_s + '%'
+    desc += ' -' if @separator
+    desc
+  end
+
+  def planned_to_done_description
+    return unless @show_planned_to_done
+
+    data = @planned_to_done[:per_planned_to_done_average].first[:data]
+
+    return if data.blank?
+
+    'Overall ' + @planned_to_done_definition.name + ': ' + data[:average].to_s + '%'
+  end
+
+  def separator?(separator)
+    @separator = separator
+  end
+
+  def generate_url_image
+    defect_escape_rate_image || development_cycle_image || planned_to_done_image
+  end
+
+  def defect_escape_rate_image
+    return unless @show_defect_escape_rate
+
+    data = @defect_escape_rate[:per_defect_escape_values].first[:data]
+
+    return unless @show_defect_escape_rate && data.present?
+
+    Builders::Chartkick::GenerateChartImage
+      .new(@product[:name], data, '%', 'bar').generate_url
+  end
+
+  def development_cycle_image
+    return unless @show_development_cycle
+
+    data = @development_cycle[:per_development_cycle_values].first[:data]
+
+    return if data.blank?
+
+    Builders::Chartkick::GenerateChartImage
+      .new(@product[:name], data, 'days', 'line').generate_url
+  end
+
+  def planned_to_done_image
+    return unless @show_planned_to_done
+
+    data = @planned_to_done[:per_planned_to_done_values].first[:data]
+
+    return if data.blank?
+
+    Builders::Chartkick::GenerateChartImage
+      .new(@product[:name], planned_to_done_values, 'points', 'bar').generate_url_mutiple_bar
+  end
+
+  def planned_to_done_values
+    @planned_to_done[:per_planned_to_done_values]
+      .first[:data]
+      .group_by { |sprint| sprint[:name] }
+      .map do |label, points|
+        {
+          name: label,
+          data: points.map { |sprint| sprint[:data] }.reduce(&:merge)
+        }
+      end
+  end
+end

--- a/app/helpers/meta_tags_helper.rb
+++ b/app/helpers/meta_tags_helper.rb
@@ -1,19 +1,5 @@
 module MetaTagsHelper
   def meta_title
-    title_for_metrics
-  end
-
-  def meta_description
-    description_for_metrics
-  end
-
-  def meta_image
-    generate_url_image if current_page?(products_metrics_development_metrics_path)
-  end
-
-  private
-
-  def title_for_metrics
     if current_page?(products_development_metrics_path)
       product_name.present? ? "#{product_name} summary" : default_description
     elsif current_page?(products_metrics_development_metrics_path)
@@ -22,6 +8,24 @@ module MetaTagsHelper
       title_for_pages
     end
   end
+
+  def meta_description
+    if current_page?(products_development_metrics_path)
+      product_name.present? ? product_summary_description : default_description
+    elsif current_page?(products_metrics_development_metrics_path)
+      product_description
+    elsif current_page?(repositories_development_metrics_path)
+      "#{@repository[:name]} summary"
+    else
+      description_for_pages
+    end
+  end
+
+  def meta_image
+    generate_url_image if current_page?(products_metrics_development_metrics_path)
+  end
+
+  private
 
   def title_for_pages
     if current_page?(repositories_development_metrics_path)
@@ -34,18 +38,6 @@ module MetaTagsHelper
       'Tech Blog visits'
     else
       default_description
-    end
-  end
-
-  def description_for_metrics
-    if current_page?(products_development_metrics_path)
-      product_name.present? ? product_summary_description : default_description
-    elsif current_page?(products_metrics_development_metrics_path)
-      product_description
-    elsif current_page?(repositories_development_metrics_path)
-      "#{@repository[:name]} summary"
-    else
-      description_for_pages
     end
   end
 

--- a/app/helpers/meta_tags_helper.rb
+++ b/app/helpers/meta_tags_helper.rb
@@ -1,7 +1,11 @@
 module MetaTagsHelper
   def meta_title
     if current_page?(products_development_metrics_path)
-      product_name.present? ? "#{product_name} summary" : default_description
+      if product_name.present?
+        I18n.t('helpers.meta_tags.products_metrics_title', product_name: product_name)
+      else
+        default_description
+      end
     elsif current_page?(products_metrics_development_metrics_path)
       product_name + ' - ' + MetricDefinition.where(code: @query_metric_name).first&.name
     else
@@ -15,7 +19,7 @@ module MetaTagsHelper
     elsif current_page?(products_metrics_development_metrics_path)
       product_description
     elsif current_page?(repositories_development_metrics_path)
-      "#{@repository[:name]} summary"
+      I18n.t('helpers.meta_tags.repository_metrics_title', repository_name: @repository[:name])
     else
       description_for_pages
     end
@@ -29,13 +33,13 @@ module MetaTagsHelper
 
   def title_for_pages
     if current_page?(repositories_development_metrics_path)
-      "#{@repository[:name]} summary"
+      I18n.t('helpers.meta_tags.repository_metrics_title', repository_name: @repository[:name])
     elsif current_page?(open_source_index_path)
-      'Open Source repositories'
+      I18n.t('helpers.meta_tags.open_source_title')
     elsif current_page?(departments_development_metrics_path)
-      @department.present? ? "#{@department[:name]} department metrics" : 'Departments'
+      department_title
     elsif current_page?(tech_blog_path)
-      'Tech Blog visits'
+      I18n.t('helpers.meta_tags.tech_blog_title')
     else
       default_description
     end
@@ -45,9 +49,13 @@ module MetaTagsHelper
     if current_page?(open_source_index_path)
       "#{@total_repositories} open source #{'repository'.pluralize(@total_repositories)}"
     elsif current_page?(departments_development_metrics_path)
-      @department.present? ? "#{@department[:name]} department metrics" : 'Departments'
+      if @department.present?
+        I18n.t('helpers.meta_tags.departments_title', department_name: @department[:name])
+      else
+        I18n.t('helpers.meta_tags.default_departments_title')
+      end
     elsif current_page?(tech_blog_path)
-      "#{@month_to_date_visits} visits this month"
+      I18n.t('helpers.meta_tags.tech_blog_description', month_to_date_visits: @month_to_date_visits)
     else
       default_description
     end
@@ -58,7 +66,15 @@ module MetaTagsHelper
   end
 
   def default_description
-    'Engineering Metrics'
+    I18n.t('helpers.meta_tags.default_description')
+  end
+
+  def department_title
+    if @department.present?
+      I18n.t('helpers.meta_tags.departments_title', department_name: @department[:name])
+    else
+      I18n.t('helpers.meta_tags.default_departments_title')
+    end
   end
 
   def product_description

--- a/app/services/builders/chartkick/generate_chart_image.rb
+++ b/app/services/builders/chartkick/generate_chart_image.rb
@@ -86,6 +86,7 @@ module Builders
             {
               "label": @label_name,
               "fill": false,
+              "lineTension": 0.4,
               "data": @data.values
             }
           ]

--- a/app/services/builders/chartkick/generate_chart_image.rb
+++ b/app/services/builders/chartkick/generate_chart_image.rb
@@ -1,8 +1,6 @@
 module Builders
   module Chartkick
     class GenerateChartImage
-      QUICKCHART_URL = 'https://quickchart.io/chart/create'.freeze
-
       def initialize(label_name, data, suffix, type)
         @label_name = label_name
         @data = data
@@ -11,9 +9,7 @@ module Builders
       end
 
       def generate_url
-        response = Faraday.post(QUICKCHART_URL,
-                                request_body.to_json,
-                                'Content-Type': 'application/json')
+        response = get_response(request_body)
 
         response_body = JSON.parse(response.body)
 
@@ -25,9 +21,7 @@ module Builders
       end
 
       def generate_url_mutiple_bar
-        response = Faraday.post(QUICKCHART_URL,
-                                request_body_multiple.to_json,
-                                'Content-Type': 'application/json')
+        response = get_response(request_body_multiple)
 
         response_body = JSON.parse(response.body)
 
@@ -39,6 +33,12 @@ module Builders
       end
 
       private
+
+      def get_response(request_body)
+        Faraday.post(ENV['QUICKCHART_URL'],
+                     request_body.to_json,
+                     'Content-Type': 'application/json')
+      end
 
       def request_body
         {

--- a/app/services/builders/chartkick/generate_chart_image.rb
+++ b/app/services/builders/chartkick/generate_chart_image.rb
@@ -1,0 +1,116 @@
+module Builders
+  module Chartkick
+    class GenerateChartImage
+      QUICKCHART_URL = 'https://quickchart.io/chart/create'.freeze
+
+      def initialize(label_name, data, suffix, type)
+        @label_name = label_name
+        @data = data
+        @suffix = suffix
+        @type = type
+      end
+
+      def generate_url
+        response = Faraday.post(QUICKCHART_URL,
+                                request_body.to_json,
+                                'Content-Type': 'application/json')
+
+        response_body = JSON.parse(response.body)
+
+        return unless response.status == 200 && response_body['success']
+
+        response_body['url']
+      rescue Faraday::ServerError => exception
+        ExceptionHunter.track(exception)
+      end
+
+      def generate_url_mutiple_bar
+        response = Faraday.post(QUICKCHART_URL,
+                                request_body_multiple.to_json,
+                                'Content-Type': 'application/json')
+
+        response_body = JSON.parse(response.body)
+
+        return unless response.status == 200 && response_body['success']
+
+        response_body['url']
+      rescue Faraday::ServerError => exception
+        ExceptionHunter.track(exception)
+      end
+
+      private
+
+      def request_body
+        {
+          "backgroundColor": '#fff',
+          "width": 500,
+          "height": 300,
+          "devicePixelRatio": 1.0,
+          "chart": {
+            "type": @type,
+            "options": {
+              "plugins": {
+                "tickFormat": {
+                  "suffix": @suffix
+                }
+              }
+            },
+            "data": single_data
+          }
+        }
+      end
+
+      def request_body_multiple
+        {
+          "backgroundColor": '#fff',
+          "width": 500,
+          "height": 300,
+          "chart": {
+            "type": @type,
+            "options": {
+              "plugins": {
+                "tickFormat": {
+                  "suffix": @suffix
+                }
+              }
+            },
+            "data": multiple_data
+          }
+        }
+      end
+
+      def single_data
+        {
+          "labels": @data.keys,
+          "datasets": [
+            {
+              "label": @label_name,
+              "fill": false,
+              "data": @data.values
+            }
+          ]
+        }
+      end
+
+      def multiple_data
+        first_chart = @data.first
+        first_chart_data = first_chart[:data]
+        second_chart = @data.second
+
+        {
+          "labels": first_chart_data.keys,
+          "datasets": [
+            {
+              "label": first_chart[:name],
+              "data": first_chart_data.values
+            },
+            {
+              "label": second_chart[:name],
+              "data": second_chart[:data].values
+            }
+          ]
+        }
+      end
+    end
+  end
+end

--- a/app/views/layouts/sidebar_metrics.html.erb
+++ b/app/views/layouts/sidebar_metrics.html.erb
@@ -5,6 +5,10 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
+    <meta property="og:title" content="<%= meta_title %>" />
+    <meta property="og:description" content="<%= meta_description %>" />
+    <meta property="og:image" content="<%= meta_image %>" />
+
     <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
   </head>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -36,3 +36,13 @@ en:
         message: 'Hey! check this out: [Open Source metrics](%{url}) 🚀'
       code_climate_error:
         message: 'Hey! Check this out: [Code Climate error] Repository: %{repository} - Error: %{error}'
+  helpers:
+    meta_tags:
+      default_description: 'Engineering Metrics'
+      products_metrics_title: '%{product_name} summary'
+      repository_metrics_title: '%{repository_name} summary'
+      open_source_title: 'Open Source repositories'
+      tech_blog_title: 'Tech Blog visits'
+      tech_blog_description: '%{month_to_date_visits} visits this month'
+      default_departments_title: 'Departments'
+      departments_title: '%{department_name} department metrics'

--- a/spec/helpers/meta_tags_helper_spec.rb
+++ b/spec/helpers/meta_tags_helper_spec.rb
@@ -5,7 +5,7 @@ describe MetaTagsHelper, type: :helper do
   let(:repository) { create(:repository) }
   let(:ruby) { Language.find_or_create_by(name: 'ruby') }
   let(:department) { ruby.department }
-  let(:default_text) { 'Engineering Metrics' }
+  let(:default_text) { I18n.t('helpers.meta_tags.default_description') }
 
   describe '.meta_title' do
     context 'when request to products_development_metrics_path' do
@@ -23,7 +23,8 @@ describe MetaTagsHelper, type: :helper do
       context 'when product has been selected' do
         it 'returns the correct title' do
           assign(:product, product)
-          expect(helper.meta_title).to eq(product.name + ' summary')
+          expect(helper.meta_title).to eq(I18n.t('helpers.meta_tags.products_metrics_title',
+                                                 product_name: product.name))
         end
       end
     end
@@ -60,7 +61,8 @@ describe MetaTagsHelper, type: :helper do
 
       it 'returns the correct title' do
         assign(:repository, repository)
-        expect(helper.meta_title).to eq(repository.name + ' summary')
+        expect(helper.meta_title).to eq(I18n.t('helpers.meta_tags.repository_metrics_title',
+                                               repository_name: repository.name))
       end
     end
 
@@ -80,7 +82,7 @@ describe MetaTagsHelper, type: :helper do
       end
 
       it 'returns the correct title' do
-        expect(helper.meta_title).to eq('Open Source repositories')
+        expect(helper.meta_title).to eq(I18n.t('helpers.meta_tags.open_source_title'))
       end
     end
 
@@ -104,14 +106,15 @@ describe MetaTagsHelper, type: :helper do
 
       context 'when no department has been selected' do
         it 'returns the correct title' do
-          expect(helper.meta_title).to eq('Departments')
+          expect(helper.meta_title).to eq(I18n.t('helpers.meta_tags.default_departments_title'))
         end
       end
 
       context 'when department has been selected' do
         it 'returns the correct title' do
           assign(:department, department)
-          expect(helper.meta_title).to eq(department.name + ' department metrics')
+          expect(helper.meta_title).to eq(I18n.t('helpers.meta_tags.departments_title',
+                                                 department_name: department.name))
         end
       end
     end
@@ -138,7 +141,7 @@ describe MetaTagsHelper, type: :helper do
       end
 
       it 'returns the correct title' do
-        expect(helper.meta_title).to eq('Tech Blog visits')
+        expect(helper.meta_title).to eq(I18n.t('helpers.meta_tags.tech_blog_title'))
       end
     end
   end
@@ -221,7 +224,8 @@ describe MetaTagsHelper, type: :helper do
 
       it 'returns the correct description' do
         assign(:repository, repository)
-        expect(helper.meta_description).to eq(repository.name + ' summary')
+        expect(helper.meta_description).to eq(I18n.t('helpers.meta_tags.repository_metrics_title',
+                                                     repository_name: repository.name))
       end
     end
 
@@ -266,14 +270,15 @@ describe MetaTagsHelper, type: :helper do
 
       context 'when no department has been selected' do
         it 'returns the correct description' do
-          expect(helper.meta_title).to eq('Departments')
+          expect(helper.meta_title).to eq(I18n.t('helpers.meta_tags.default_departments_title'))
         end
       end
 
       context 'when department has been selected' do
         it 'returns the correct description' do
           assign(:department, department)
-          expect(helper.meta_description).to eq(department.name + ' department metrics')
+          expect(helper.meta_description).to eq(I18n.t('helpers.meta_tags.departments_title',
+                                                       department_name: department.name))
         end
       end
     end
@@ -314,7 +319,8 @@ describe MetaTagsHelper, type: :helper do
 
       it 'returns the correct description' do
         assign(:month_to_date_visits, 5)
-        expect(helper.meta_description).to eq('5 visits this month')
+        expect(helper.meta_description).to eq(I18n.t('helpers.meta_tags.tech_blog_description',
+                                                     month_to_date_visits: 5))
       end
     end
   end

--- a/spec/helpers/meta_tags_helper_spec.rb
+++ b/spec/helpers/meta_tags_helper_spec.rb
@@ -1,0 +1,321 @@
+require 'rails_helper'
+
+describe MetaTagsHelper, type: :helper do
+  let(:product) { create(:product) }
+  let(:repository) { create(:repository) }
+  let(:ruby) { Language.find_or_create_by(name: 'ruby') }
+  let(:department) { ruby.department }
+  let(:default_text) { 'Engineering Metrics' }
+
+  describe '.meta_title' do
+    context 'when request to products_development_metrics_path' do
+      before do
+        allow(helper).to receive(:current_page?)
+          .with(products_development_metrics_path).and_return(true)
+      end
+
+      context 'when no product has been selected' do
+        it 'returns the correct title' do
+          expect(helper.meta_title).to eq(default_text)
+        end
+      end
+
+      context 'when product has been selected' do
+        it 'returns the correct title' do
+          assign(:product, product)
+          expect(helper.meta_title).to eq(product.name + ' summary')
+        end
+      end
+    end
+
+    context 'when request to products_metrics_development_metrics_path' do
+      let!(:metric_definition) { create(:metric_definition, code: :defect_escape_rate) }
+
+      before do
+        allow(helper).to receive(:current_page?)
+          .with(products_development_metrics_path).and_return(false)
+
+        allow(helper).to receive(:current_page?)
+          .with(products_metrics_development_metrics_path).and_return(true)
+      end
+
+      it 'returns the correct title' do
+        assign(:query_metric_name, :defect_escape_rate)
+        assign(:product, product)
+        expect(helper.meta_title).to eq(product.name + ' - ' + metric_definition.name)
+      end
+    end
+
+    context 'when request to repositories_development_metrics_path' do
+      before do
+        allow(helper).to receive(:current_page?)
+          .with(products_development_metrics_path).and_return(false)
+
+        allow(helper).to receive(:current_page?)
+          .with(products_metrics_development_metrics_path).and_return(false)
+
+        allow(helper).to receive(:current_page?)
+          .with(repositories_development_metrics_path).and_return(true)
+      end
+
+      it 'returns the correct title' do
+        assign(:repository, repository)
+        expect(helper.meta_title).to eq(repository.name + ' summary')
+      end
+    end
+
+    context 'when request to open_source_index_path' do
+      before do
+        allow(helper).to receive(:current_page?)
+          .with(products_development_metrics_path).and_return(false)
+
+        allow(helper).to receive(:current_page?)
+          .with(products_metrics_development_metrics_path).and_return(false)
+
+        allow(helper).to receive(:current_page?)
+          .with(repositories_development_metrics_path).and_return(false)
+
+        allow(helper).to receive(:current_page?)
+          .with(open_source_index_path).and_return(true)
+      end
+
+      it 'returns the correct title' do
+        expect(helper.meta_title).to eq('Open Source repositories')
+      end
+    end
+
+    context 'when request to departments_development_metrics_path' do
+      before do
+        allow(helper).to receive(:current_page?)
+          .with(products_development_metrics_path).and_return(false)
+
+        allow(helper).to receive(:current_page?)
+          .with(products_metrics_development_metrics_path).and_return(false)
+
+        allow(helper).to receive(:current_page?)
+          .with(repositories_development_metrics_path).and_return(false)
+
+        allow(helper).to receive(:current_page?)
+          .with(open_source_index_path).and_return(false)
+
+        allow(helper).to receive(:current_page?)
+          .with(departments_development_metrics_path).and_return(true)
+      end
+
+      context 'when no department has been selected' do
+        it 'returns the correct title' do
+          expect(helper.meta_title).to eq('Departments')
+        end
+      end
+
+      context 'when department has been selected' do
+        it 'returns the correct title' do
+          assign(:department, department)
+          expect(helper.meta_title).to eq(department.name + ' department metrics')
+        end
+      end
+    end
+
+    context 'when request to tech_blog_path' do
+      before do
+        allow(helper).to receive(:current_page?)
+          .with(products_development_metrics_path).and_return(false)
+
+        allow(helper).to receive(:current_page?)
+          .with(products_metrics_development_metrics_path).and_return(false)
+
+        allow(helper).to receive(:current_page?)
+          .with(repositories_development_metrics_path).and_return(false)
+
+        allow(helper).to receive(:current_page?)
+          .with(open_source_index_path).and_return(false)
+
+        allow(helper).to receive(:current_page?)
+          .with(departments_development_metrics_path).and_return(false)
+
+        allow(helper).to receive(:current_page?)
+          .with(tech_blog_path).and_return(true)
+      end
+
+      it 'returns the correct title' do
+        expect(helper.meta_title).to eq('Tech Blog visits')
+      end
+    end
+  end
+
+  describe '.meta_description' do
+    let(:repository_count) { 5 }
+    let!(:repositories) { create_list(:repository, repository_count, :open_source) }
+
+    let!(:metric_definition) { create(:metric_definition, code: :defect_escape_rate) }
+
+    let(:rate) do
+      {
+        per_defect_escape_values:
+          [
+            data: {
+              rate: 66
+            }
+          ]
+      }
+    end
+
+    context 'when request to products_development_metrics_path' do
+      before do
+        allow(helper).to receive(:current_page?)
+          .with(products_development_metrics_path).and_return(true)
+      end
+
+      context 'when no product has been selected' do
+        it 'returns the correct description' do
+          expect(helper.meta_description).to eq(default_text)
+        end
+      end
+
+      context 'when product has been selected' do
+        let(:expected_description) { 'Summary - Overall ' + metric_definition.name + ': 66% -' }
+
+        it 'returns the correct description' do
+          assign(:product, product)
+          assign(:show_defect_escape_rate, true)
+          assign(:defect_escape_rate_definition, metric_definition)
+          assign(:defect_escape_rate, rate)
+
+          expect(helper.meta_description).to eq(expected_description)
+        end
+      end
+    end
+
+    context 'when request to products_metrics_development_metrics_path' do
+      let(:expected_description) { 'Overall ' + metric_definition.name + ': 66%' }
+
+      before do
+        allow(helper).to receive(:current_page?)
+          .with(products_development_metrics_path).and_return(false)
+
+        allow(helper).to receive(:current_page?)
+          .with(products_metrics_development_metrics_path).and_return(true)
+      end
+
+      it 'returns the correct title' do
+        assign(:product, product)
+        assign(:show_defect_escape_rate, true)
+        assign(:defect_escape_rate_definition, metric_definition)
+        assign(:defect_escape_rate, rate)
+
+        expect(helper.meta_description).to eq(expected_description)
+      end
+    end
+
+    context 'when request to repositories_development_metrics_path' do
+      before do
+        allow(helper).to receive(:current_page?)
+          .with(products_development_metrics_path).and_return(false)
+
+        allow(helper).to receive(:current_page?)
+          .with(products_metrics_development_metrics_path).and_return(false)
+
+        allow(helper).to receive(:current_page?)
+          .with(repositories_development_metrics_path).and_return(true)
+      end
+
+      it 'returns the correct description' do
+        assign(:repository, repository)
+        expect(helper.meta_description).to eq(repository.name + ' summary')
+      end
+    end
+
+    context 'when request to open_source_index_path' do
+      before do
+        allow(helper).to receive(:current_page?)
+          .with(products_development_metrics_path).and_return(false)
+
+        allow(helper).to receive(:current_page?)
+          .with(products_metrics_development_metrics_path).and_return(false)
+
+        allow(helper).to receive(:current_page?)
+          .with(repositories_development_metrics_path).and_return(false)
+
+        allow(helper).to receive(:current_page?)
+          .with(open_source_index_path).and_return(true)
+      end
+
+      it 'returns the correct description' do
+        assign(:total_repositories, repository_count)
+        expect(helper.meta_description).to eq("#{repository_count} open source repositories")
+      end
+    end
+
+    context 'when request to departments_development_metrics_path' do
+      before do
+        allow(helper).to receive(:current_page?)
+          .with(products_development_metrics_path).and_return(false)
+
+        allow(helper).to receive(:current_page?)
+          .with(products_metrics_development_metrics_path).and_return(false)
+
+        allow(helper).to receive(:current_page?)
+          .with(repositories_development_metrics_path).and_return(false)
+
+        allow(helper).to receive(:current_page?)
+          .with(open_source_index_path).and_return(false)
+
+        allow(helper).to receive(:current_page?)
+          .with(departments_development_metrics_path).and_return(true)
+      end
+
+      context 'when no department has been selected' do
+        it 'returns the correct description' do
+          expect(helper.meta_title).to eq('Departments')
+        end
+      end
+
+      context 'when department has been selected' do
+        it 'returns the correct description' do
+          assign(:department, department)
+          expect(helper.meta_description).to eq(department.name + ' department metrics')
+        end
+      end
+    end
+
+    context 'when request to tech_blog_path' do
+      let(:technology) { create(:technology) }
+
+      let(:this_month_metric) do
+        create(
+          :metric,
+          ownable: technology,
+          interval: Metric.intervals[:monthly],
+          name: Metric.names[:blog_visits],
+          value: 5,
+          value_timestamp: Time.zone.now.end_of_month
+        )
+      end
+
+      before do
+        allow(helper).to receive(:current_page?)
+          .with(products_development_metrics_path).and_return(false)
+
+        allow(helper).to receive(:current_page?)
+          .with(products_metrics_development_metrics_path).and_return(false)
+
+        allow(helper).to receive(:current_page?)
+          .with(repositories_development_metrics_path).and_return(false)
+
+        allow(helper).to receive(:current_page?)
+          .with(open_source_index_path).and_return(false)
+
+        allow(helper).to receive(:current_page?)
+          .with(departments_development_metrics_path).and_return(false)
+
+        allow(helper).to receive(:current_page?)
+          .with(tech_blog_path).and_return(true)
+      end
+
+      it 'returns the correct description' do
+        assign(:month_to_date_visits, 5)
+        expect(helper.meta_description).to eq('5 visits this month')
+      end
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -88,4 +88,5 @@ RSpec.configure do |config|
   config.include JiraApiMock
   config.include CodeClimateApiMocker
   config.include SlackApiMocker
+  config.include QuickchartApiMocker
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -83,6 +83,7 @@ RSpec.configure do |config|
   config.include Devise::Test::IntegrationHelpers, type: :request
   config.include Devise::Test::IntegrationHelpers, type: :feature
 
+  config.include EnvMock
   config.include WordpressApiMocker
   config.include GithubApiMock
   config.include JiraApiMock

--- a/spec/services/builders/chartkick/generate_chart_image_spec.rb
+++ b/spec/services/builders/chartkick/generate_chart_image_spec.rb
@@ -1,0 +1,143 @@
+require 'rails_helper'
+
+describe Builders::Chartkick::GenerateChartImage do
+  let(:url) { Faker::Internet.url }
+  let(:product) { create(:product) }
+  let(:label_name) { product.name }
+
+  shared_examples_for 'url_image_generation' do
+    context 'when request payload is correct' do
+      before { stub_url_generation(payload, url) }
+
+      it 'returns a correct url' do
+        expect(subject).to eq(url)
+      end
+    end
+
+    context 'when request payload is not correct' do
+      before { stub_failed_url_generation(payload) }
+
+      it 'notifies the error to exception hunter' do
+        expect(subject).to be_nil
+      end
+    end
+
+    context 'when request is not successful' do
+      before { stub_exception_url_generation(payload) }
+
+      it 'notifies the error to exception hunter' do
+        expect(ExceptionHunter).to receive(:track).with(Faraday::ServerError)
+
+        subject
+      end
+    end
+  end
+
+  context '.generate_url' do
+    let(:defect_escape_rate) do
+      {
+        per_defect_escape_rate:
+          [
+            data: {
+              '2021-07-26': 50,
+              '2021-08-02': 40
+            }
+          ]
+      }
+    end
+
+    let(:data) { defect_escape_rate[:per_defect_escape_rate].first[:data] }
+
+    let(:payload) do
+      {
+        "backgroundColor": '#fff',
+        "width": 500,
+        "height": 300,
+        "devicePixelRatio": 1.0,
+        "chart": {
+          "type": 'bar',
+          "options": {
+            "plugins": {
+              "tickFormat": {
+                "suffix": '%'
+              }
+            }
+          },
+          "data": {
+            "labels": data.keys,
+            "datasets": [
+              {
+                "label": product.name,
+                "fill": false,
+                "data": data.values
+              }
+            ]
+          }
+        }
+      }
+    end
+
+    subject { described_class.send(:new, label_name, data, '%', 'bar').generate_url }
+
+    it_behaves_like 'url_image_generation'
+  end
+
+  context '.generate_url_mutiple_bar' do
+    let(:jira_sprint1) { create(:jira_sprint) }
+    let(:jira_sprint2) { create(:jira_sprint) }
+
+    let(:data) do
+      [
+        {
+          name: 'Commitment',
+          data: {
+            jira_sprint1.name => jira_sprint1.points_committed,
+            jira_sprint2.name => jira_sprint2.points_committed
+          }
+        },
+        {
+          name: 'Completed',
+          data: {
+            jira_sprint1.name => jira_sprint1.points_completed,
+            jira_sprint2.name => jira_sprint2.points_completed
+          }
+        }
+      ]
+    end
+
+    let(:payload) do
+      {
+        "backgroundColor": '#fff',
+        "width": 500,
+        "height": 300,
+        "chart": {
+          "type": 'bar',
+          "options": {
+            "plugins": {
+              "tickFormat": {
+                "suffix": '%'
+              }
+            }
+          },
+          "data": {
+            "labels": data.first[:data].keys,
+            "datasets": [
+              {
+                "label": data.first[:name],
+                "data": data.first[:data].values
+              },
+              {
+                "label": data.second[:name],
+                "data": data.second[:data].values
+              }
+            ]
+          }
+        }
+      }
+    end
+
+    subject { described_class.send(:new, label_name, data, '%', 'bar').generate_url_mutiple_bar }
+
+    it_behaves_like 'url_image_generation'
+  end
+end

--- a/spec/services/builders/chartkick/generate_chart_image_spec.rb
+++ b/spec/services/builders/chartkick/generate_chart_image_spec.rb
@@ -69,6 +69,7 @@ describe Builders::Chartkick::GenerateChartImage do
               {
                 "label": product.name,
                 "fill": false,
+                "lineTension": 0.4,
                 "data": data.values
               }
             ]

--- a/spec/support/helpers/env_mocker.rb
+++ b/spec/support/helpers/env_mocker.rb
@@ -1,0 +1,41 @@
+module EnvMock
+  def stub_envs
+    stub_env('JIRA_ADMIN_USER', jira_admin_user)
+    stub_env('JIRA_ADMIN_TOKEN', jira_admin_token)
+    stub_env('JIRA_ENVIRONMENT_FIELD', jira_environment_field)
+    stub_env('JIRA_ROOT_URL', jira_root_url)
+    stub_env('JIRA_AGILE_URL', jira_agile_url)
+    stub_env('JIRA_REPORTS_URL', jira_reports_url)
+    stub_env('QUICKCHART_URL', quickchart_url)
+  end
+
+  private
+
+  def jira_admin_user
+    'adminuser'
+  end
+
+  def jira_admin_token
+    '123ir123r91238ry123rihb'
+  end
+
+  def jira_environment_field
+    'customfield_10000'
+  end
+
+  def jira_root_url
+    'https://name.atlassian.net/rest/api/3/'
+  end
+
+  def jira_agile_url
+    'https://name.atlassian.net/rest/agile/latest/'
+  end
+
+  def jira_reports_url
+    'https://name.atlassian.net/rest/greenhopper/latest/'
+  end
+
+  def quickchart_url
+    'https://quickchart.io/chart/create'
+  end
+end

--- a/spec/support/helpers/jira_api_mocker.rb
+++ b/spec/support/helpers/jira_api_mocker.rb
@@ -68,39 +68,4 @@ module JiraApiMock
     stub_request(:get, "#{ENV['JIRA_ROOT_URL']}search?jql=project=#{jira_project_key}%20AND%20issuetype!=Bug&fields=#{ENV['JIRA_ENVIRONMENT_FIELD']},created,resolutiondate,issuetype&expand=changelog")
       .to_raise(Faraday::ForbiddenError, 'Unauthorized user')
   end
-
-  def stub_envs
-    stub_env('JIRA_ADMIN_USER', jira_admin_user)
-    stub_env('JIRA_ADMIN_TOKEN', jira_admin_token)
-    stub_env('JIRA_ENVIRONMENT_FIELD', jira_environment_field)
-    stub_env('JIRA_ROOT_URL', jira_root_url)
-    stub_env('JIRA_AGILE_URL', jira_agile_url)
-    stub_env('JIRA_REPORTS_URL', jira_reports_url)
-  end
-
-  private
-
-  def jira_admin_user
-    'adminuser'
-  end
-
-  def jira_admin_token
-    '123ir123r91238ry123rihb'
-  end
-
-  def jira_environment_field
-    'customfield_10000'
-  end
-
-  def jira_root_url
-    'https://name.atlassian.net/rest/api/3/'
-  end
-
-  def jira_agile_url
-    'https://name.atlassian.net/rest/agile/latest/'
-  end
-
-  def jira_reports_url
-    'https://name.atlassian.net/rest/greenhopper/latest/'
-  end
 end

--- a/spec/support/helpers/quickchart_api_mocker.rb
+++ b/spec/support/helpers/quickchart_api_mocker.rb
@@ -1,0 +1,34 @@
+module QuickchartApiMocker
+  def stub_url_generation(payload, url)
+    response_body = {
+      'success': 'true',
+      'url': url
+    }
+
+    stub_request(:post, 'https://quickchart.io/chart/create')
+      .with(body: payload.to_json)
+      .to_return(
+        body: JSON.generate(response_body),
+        status: 200
+      )
+  end
+
+  def stub_failed_url_generation(payload)
+    response_body = {
+      'success': 'false'
+    }
+
+    stub_request(:post, 'https://quickchart.io/chart/create')
+      .with(body: payload.to_json)
+      .to_return(
+        body: JSON.generate(response_body),
+        status: 200
+      )
+  end
+
+  def stub_exception_url_generation(payload)
+    stub_request(:post, 'https://quickchart.io/chart/create')
+      .with(body: payload.to_json)
+      .to_raise(Faraday::ServerError)
+  end
+end

--- a/spec/support/helpers/quickchart_api_mocker.rb
+++ b/spec/support/helpers/quickchart_api_mocker.rb
@@ -1,11 +1,13 @@
 module QuickchartApiMocker
   def stub_url_generation(payload, url)
+    stub_envs
+
     response_body = {
       'success': 'true',
       'url': url
     }
 
-    stub_request(:post, 'https://quickchart.io/chart/create')
+    stub_request(:post, ENV['QUICKCHART_URL'])
       .with(body: payload.to_json)
       .to_return(
         body: JSON.generate(response_body),
@@ -14,11 +16,13 @@ module QuickchartApiMocker
   end
 
   def stub_failed_url_generation(payload)
+    stub_envs
+
     response_body = {
       'success': 'false'
     }
 
-    stub_request(:post, 'https://quickchart.io/chart/create')
+    stub_request(:post, ENV['QUICKCHART_URL'])
       .with(body: payload.to_json)
       .to_return(
         body: JSON.generate(response_body),
@@ -27,7 +31,9 @@ module QuickchartApiMocker
   end
 
   def stub_exception_url_generation(payload)
-    stub_request(:post, 'https://quickchart.io/chart/create')
+    stub_envs
+
+    stub_request(:post, ENV['QUICKCHART_URL'])
       .with(body: payload.to_json)
       .to_raise(Faraday::ServerError)
   end


### PR DESCRIPTION
## What does this PR do?
This PR adds meta tags for better link unfurling. In this first version, title and description are customized for each page. But at the moment, a preview image can be seen only in product metrics page.

The chart image generation is done with [Quickchart](https://quickchart.io/) API. This library generate an image from a javascript chart like the ones generated in the views with Chartkick.

**Here are some examples previews:**

When sharing product dashboard:

<img width="571" alt="Screen Shot 2021-09-10 at 16 45 19" src="https://user-images.githubusercontent.com/13893921/132909040-1f64c8e8-befd-4208-8828-7310689abc62.png">

When sharing defect escape rate metric detail:

<img width="403" alt="Screen Shot 2021-09-10 at 16 50 30" src="https://user-images.githubusercontent.com/13893921/132909662-efc23835-9fdd-4e92-b160-cf65d9ed3ddf.png">

When sharing development cycle metric detail:

<img width="403" alt="Screen Shot 2021-09-10 at 17 23 40" src="https://user-images.githubusercontent.com/13893921/132913416-a265b43d-35ad-46fd-afc3-db98ca9fd62d.png">


When sharing planned to done ratio metric detail:

<img width="420" alt="Screen Shot 2021-09-10 at 17 01 37" src="https://user-images.githubusercontent.com/13893921/132911003-554af2f2-9321-4e6a-aa3f-cbe6429e9842.png">

## Notes:
Create the following env variable after deploying `QUICKCHART_URL` with value https://quickchart.io/chart/create.


Resolves #[EM-216](https://rootstrap.atlassian.net/browse/EM-216): Add OG meta tags for better link unfurling.
