### PR TITLE
Add success rate for repository metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,11 +51,15 @@ Either assign superuser permissions to `postgres` or update the env vars: `GITHU
 
 ## Settings
 
-### Success Rates Department Settings
-
-- In order to change Department Success Rates time limit setting, create a new `Setting` with key prefix `success_rate`, followed by the department name and the metric name.
-- Example: `Setting.create!(key: 'success_rate_backend_merge_time', value: '12')`
-Possible values: 12 | 24 (default) | 36 | 48 | 60 | 72
+### Success Rates Settings
+- Department
+  - In order to change Department Success Rates time limit setting, create a new `Setting` with key prefix `success_rate`, followed by the department name and the metric name.
+  - Example: `Setting.create!(key: 'success_rate_backend_merge_time', value: '12')`
+  Possible values: 12 | 24 (default) | 36 | 48 | 60 | 72
+- Repository
+  - In order to change Repository Success Rates time limit setting, create a new `Setting` with key prefix `success_rate_repository`, followed by repository name the metric name.
+  - Example: `Setting.create!(key: 'success_rate_rs-code-review-metrics_merge_time', value: '12')`
+  Possible values: 12 | 24 (default) | 36 | 48 | 60 | 72
 
 ### Enabled Features Settings
 Possible values: true | false (default)

--- a/app/controllers/development_metrics_controller.rb
+++ b/app/controllers/development_metrics_controller.rb
@@ -15,8 +15,11 @@ class DevelopmentMetricsController < ApplicationController
   def repositories
     return if metric_params.blank?
 
-    build_metrics(repository.id, Repository.name)
+    entity_name = Repository.name
+
+    build_metrics(repository.id, entity_name)
     build_metrics_definitions
+    build_success_rates(entity_name)
 
     @code_owners = repository.code_owners.pluck(:login)
     @code_climate = code_climate_repository_summary
@@ -25,8 +28,10 @@ class DevelopmentMetricsController < ApplicationController
   def departments
     return if metric_params.blank?
 
-    build_metrics(department.id, Department.name)
-    build_success_rates
+    entity_name = Department.name
+
+    build_metrics(department.id, entity_name)
+    build_success_rates(entity_name)
     @code_climate = code_climate_department_summary
     @overview = department_overview
   end
@@ -41,10 +46,11 @@ class DevelopmentMetricsController < ApplicationController
 
   private
 
-  def build_success_rates
-    @merge_time_success_rate = @merge_time[:per_department_distribution].first[:success_rate]
-    @review_turnaround_success_rate = @review_turnaround[:per_department_distribution]
-                                      .first[:success_rate]
+  def build_success_rates(entity_name)
+    key = "per_#{entity_name.downcase}_distribution".to_sym
+
+    @merge_time_success_rate = @merge_time[key].first[:success_rate]
+    @review_turnaround_success_rate = @review_turnaround[key].first[:success_rate]
   end
 
   def build_metrics(entity_id, entity_name)

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -18,8 +18,8 @@ class Setting < ApplicationRecord
 
   validates :key, uniqueness: true, presence: true
 
-  scope :success_rate, lambda { |department_name, metric_name|
-    where(key: "#{SUCCESS_PREFIX}_#{department_name}_#{metric_name}")
+  scope :success_rate, lambda { |entity_name, metric_name|
+    where(key: "#{SUCCESS_PREFIX}_#{entity_name}_#{metric_name}")
   }
 
   scope :enabled, lambda { |feature_name|

--- a/app/services/builders/chartkick/base.rb
+++ b/app/services/builders/chartkick/base.rb
@@ -27,6 +27,18 @@ module Builders
         end
         entities_by_interval.sort_by { |key, _| key.slice(/[0-9]*[+-]/).to_i }
       end
+
+      def build_success_rate(entity_name, metric_name, intervals)
+        detail = Builders::Chartkick::Helpers::SuccessRate.call(entity_name,
+                                                                metric_name,
+                                                                intervals)
+        return unless detail
+
+        { rate: detail.rate,
+          successful: detail.successful,
+          total: detail.total,
+          metric_detail: detail.metric_detail }
+      end
     end
   end
 end

--- a/app/services/builders/chartkick/department_distribution_data.rb
+++ b/app/services/builders/chartkick/department_distribution_data.rb
@@ -2,25 +2,14 @@ module Builders
   module Chartkick
     class DepartmentDistributionData < Builders::Chartkick::Base
       def call
+        intervals = build_distribution_data(records)
+
         [{ name: department_name,
-           data: build_distribution_data(records),
-           success_rate: build_success_rate(records) }]
+           data: intervals,
+           success_rate: build_success_rate(department_name, metric_name, intervals) }]
       end
 
       private
-
-      def build_success_rate(entities)
-        intervals = build_distribution_data(entities)
-        detail = Builders::Chartkick::Helpers::SuccessRate.call(department_name,
-                                                                metric_name,
-                                                                intervals)
-        return unless detail
-
-        { rate: detail.rate,
-          successful: detail.successful,
-          total: detail.total,
-          metric_detail: detail.metric_detail }
-      end
 
       def department_name
         @department_name ||= ::Department.find(@entity_id).name

--- a/app/services/builders/chartkick/helpers/success_rate.rb
+++ b/app/services/builders/chartkick/helpers/success_rate.rb
@@ -2,13 +2,13 @@ module Builders
   module Chartkick
     module Helpers
       class SuccessRate < BaseService
-        attr_reader :department_name, :metric_name, :intervals
+        attr_reader :entity_name, :metric_name, :intervals
 
         RateDetails = Struct.new(:rate, :successful, :total, :metric_detail)
         MetricSetting = Struct.new(:name, :value)
 
-        def initialize(department_name, metric_name, intervals)
-          @department_name = department_name
+        def initialize(entity_name, metric_name, intervals)
+          @entity_name = entity_name
           @metric_name = metric_name.to_s
           @intervals = intervals
         end
@@ -42,11 +42,11 @@ module Builders
         end
 
         def metric_setting
-          @metric_setting ||= SettingsService.success_rate(department_name, metric_name)
+          @metric_setting ||= SettingsService.success_rate(entity_name, metric_name)
         end
 
         def metric_key
-          @metric_key ||= Setting::SUCCESS_PREFIX + '_' + department_name + '_' + metric_name
+          @metric_key ||= Setting::SUCCESS_PREFIX + '_' + entity_name + '_' + metric_name
         end
 
         def rate

--- a/app/services/builders/chartkick/repository_distribution_data.rb
+++ b/app/services/builders/chartkick/repository_distribution_data.rb
@@ -1,33 +1,20 @@
 module Builders
   module Chartkick
     class RepositoryDistributionData < Builders::Chartkick::Base
-      REPOSITORY = 'repository'.freeze
-
       def call
-        repository_name = ::Repository.find(@entity_id).name
+        intervals = build_distribution_data(retrieve_records)
 
         [{
           name: repository_name,
-          data: build_distribution_data(retrieve_records),
-          success_rate: build_success_rate(retrieve_records)
+          data: intervals,
+          success_rate: build_success_rate(repository_name, metric_name, intervals)
         }]
       end
 
       private
 
-      def build_success_rate(entities)
-        intervals = build_distribution_data(entities)
-
-        detail = Builders::Chartkick::Helpers::SuccessRate.call(REPOSITORY,
-                                                                metric_name,
-                                                                intervals)
-
-        return unless detail
-
-        { rate: detail.rate,
-          successful: detail.successful,
-          total: detail.total,
-          metric_detail: detail.metric_detail }
+      def repository_name
+        @repository_name ||= ::Repository.find(@entity_id).name
       end
 
       def retrieve_records

--- a/app/services/builders/chartkick/repository_distribution_data.rb
+++ b/app/services/builders/chartkick/repository_distribution_data.rb
@@ -1,13 +1,34 @@
 module Builders
   module Chartkick
     class RepositoryDistributionData < Builders::Chartkick::Base
+      REPOSITORY = 'repository'.freeze
+
       def call
         repository_name = ::Repository.find(@entity_id).name
 
-        [{ name: repository_name, data: build_distribution_data(retrieve_records) }]
+        [{
+          name: repository_name,
+          data: build_distribution_data(retrieve_records),
+          success_rate: build_success_rate(retrieve_records)
+        }]
       end
 
       private
+
+      def build_success_rate(entities)
+        intervals = build_distribution_data(entities)
+
+        detail = Builders::Chartkick::Helpers::SuccessRate.call(REPOSITORY,
+                                                                metric_name,
+                                                                intervals)
+
+        return unless detail
+
+        { rate: detail.rate,
+          successful: detail.successful,
+          total: detail.total,
+          metric_detail: detail.metric_detail }
+      end
 
       def retrieve_records
         metric.retrieve_records(entity_id: @entity_id, time_range: @query[:value_timestamp])

--- a/app/views/development_metrics/repositories.erb
+++ b/app/views/development_metrics/repositories.erb
@@ -25,7 +25,14 @@
     <% if @repository %>
       <div class="metrics shadow-box">
         <div class='row'>
-          <h4 class="p-3" style='margin-left:10px;'><%= @review_turnaround_definition && @review_turnaround_definition[:name] %></h4>
+          <h4 class="p-3" style='margin-left:10px;'>
+            <%= @review_turnaround_definition && @review_turnaround_definition[:name] %>
+            <% if @review_turnaround_success_rate.present? %>
+              <span class="badge badge-info success_rate_btn">
+                <%= @review_turnaround_success_rate[:rate] %>% success rate
+              </span>
+            <% end %>
+          </h4>
           <span data-placement='right' class='metric_tooltip' style='margin-top: 1.5%;' aria-hidden='true' data-toggle='tooltip' title='<%= @review_turnaround_definition && @review_turnaround_definition[:explanation] %>'>?</span>
         </div>
         <div class="graph">
@@ -40,7 +47,14 @@
 
       <div class="metrics shadow-box">
         <div class='row'>
-          <h4 class="p-3" style='margin-left:10px;'><%= @merge_time_definition && @merge_time_definition[:name] %></h4>
+          <h4 class="p-3" style='margin-left:10px;'>
+            <%= @merge_time_definition && @merge_time_definition[:name] %>
+            <% if @merge_time_success_rate.present? %>
+              <span class="badge badge-info success_rate_btn">
+                <%= @merge_time_success_rate[:rate] %>% success rate
+              </span>
+            <% end %>
+          </h4>
           <span data-placement='right' class='metric_tooltip' style='margin-top: 1.5%;' aria-hidden='true' data-toggle='tooltip' title='<%= @merge_time_definition && @merge_time_definition[:explanation] %>'>?</span>
         </div>
         <div class="graph">

--- a/spec/services/builders/chartkick/repository_distribution_data_spec.rb
+++ b/spec/services/builders/chartkick/repository_distribution_data_spec.rb
@@ -24,12 +24,14 @@ RSpec.describe Builders::Chartkick::RepositoryDistributionData do
         let(:metric_name) { :merge_time }
 
         it_behaves_like 'merge time data distribution'
+        it_behaves_like 'success rate'
       end
 
       context 'when name is review turnaround' do
         let(:metric_name) { :review_turnaround }
 
         it_behaves_like 'review turnaround data distribution'
+        it_behaves_like 'success rate'
       end
 
       context 'when name is pull request size' do


### PR DESCRIPTION
## What does this PR do?
This PR add success rate for repository metrics. In order to make success rate time limit configurable based on metric, it takes the value from a setting or the default value (24 hours).

#### Preview:
<img width="595" alt="Screen Shot 2021-09-13 at 13 00 55" src="https://user-images.githubusercontent.com/13893921/133117649-2bdd8c68-2e72-470f-a1ff-262af5d02bbf.png">

## Notes:
Create the following settings after deploying with value 24: success_rate_[repository-name]_review_turnaround, success_rate_[repository-name]_merge_time.

Resolves [#EM-250](https://rootstrap.atlassian.net/browse/EM-250): Success rate for project metrics
