### PR TITLE
Adds retry when review request id is already been taken

### DIFF
--- a/app/exceptions/reviews/review_request_uniqueness_error.rb
+++ b/app/exceptions/reviews/review_request_uniqueness_error.rb
@@ -1,0 +1,4 @@
+module Reviews
+  class ReviewRequestUniquenessError < StandardError
+  end
+end

--- a/app/jobs/request_handler_job.rb
+++ b/app/jobs/request_handler_job.rb
@@ -4,7 +4,8 @@ class RequestHandlerJob < ApplicationJob
              Reviews::NoReviewRequestError,
              PullRequests::RequestTeamAsReviewerError
 
-  retry_on PullRequests::GithubUniquenessError
+  retry_on PullRequests::GithubUniquenessError,
+           Reviews::ReviewRequestUniquenessError
 
   def perform(payload, event)
     GithubService.call(payload: payload, event: event)

--- a/app/models/review_turnaround.rb
+++ b/app/models/review_turnaround.rb
@@ -23,5 +23,5 @@ class ReviewTurnaround < ApplicationRecord
   belongs_to :review_request
 
   validates :value, presence: true
-  validates :review_request_id, uniqueness: true
+  validates :review_request_id, uniqueness: true, strict: Reviews::ReviewRequestUniquenessError
 end

--- a/spec/models/review_turnaround_spec.rb
+++ b/spec/models/review_turnaround_spec.rb
@@ -32,7 +32,19 @@ RSpec.describe ReviewTurnaround, type: :model do
       expect(subject).to_not be_valid
     end
 
-    it { is_expected.to validate_uniqueness_of(:review_request_id) }
     it { is_expected.to belong_to(:review_request) }
+
+    context 'when review request id is already been taken' do
+      let(:review_request) { create(:review_request, id: 100) }
+      let!(:review_turnaround) { create(:review_turnaround, review_request: review_request) }
+
+      it 'raise uniqueness exception' do
+        subject.review_request_id = 100
+
+        expect {
+          subject.save!
+        }.to raise_error(Reviews::ReviewRequestUniquenessError)
+      end
+    end
   end
 end


### PR DESCRIPTION
## What does this PR do?
This PR retry `request_handler_job` in case review request id has already been taken with a custom exception.

Resolves [#EM-253](https://rootstrap.atlassian.net/browse/EM-253): Validation failed: Review request has already been taken
