### PR TITLE
Remove dependant destroy to repository events associations

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -125,3 +125,7 @@ SkipsModelValidations:
 Rails/HelperInstanceVariable:
   Exclude:
     - app/helpers/meta_tags_helper.rb
+
+Rails/HasManyOrHasOneDependent:
+  Exclude:
+    - app/models/repository.rb

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -4,7 +4,6 @@
 #
 #  id              :bigint           not null, primary key
 #  data            :jsonb
-#  deleted_at      :datetime
 #  handleable_type :string
 #  name            :string
 #  type            :string
@@ -24,8 +23,6 @@
 #
 
 class Event < ApplicationRecord
-  acts_as_paranoid
-
   TYPES = %w[pull_request review review_comment push repository].freeze
 
   belongs_to :handleable, polymorphic: true, optional: true

--- a/app/models/events/pull_request.rb
+++ b/app/models/events/pull_request.rb
@@ -6,7 +6,6 @@
 #  body          :text
 #  branch        :string
 #  closed_at     :datetime
-#  deleted_at    :datetime
 #  draft         :boolean          not null
 #  html_url      :string
 #  locked        :boolean          not null
@@ -38,8 +37,6 @@
 #
 module Events
   class PullRequest < ApplicationRecord
-    acts_as_paranoid
-
     enum state: { open: 'open', closed: 'closed' }
 
     belongs_to :repository, class_name: '::Repository', inverse_of: :pull_requests

--- a/app/models/events/pull_request_comment.rb
+++ b/app/models/events/pull_request_comment.rb
@@ -4,7 +4,6 @@
 #
 #  id                :bigint           not null, primary key
 #  body              :string
-#  deleted_at        :datetime
 #  opened_at         :datetime         not null
 #  state             :enum             default("created")
 #  created_at        :datetime         not null
@@ -16,7 +15,6 @@
 #
 # Indexes
 #
-#  index_events_pull_request_comments_on_deleted_at         (deleted_at)
 #  index_events_pull_request_comments_on_owner_id           (owner_id)
 #  index_events_pull_request_comments_on_pull_request_id    (pull_request_id)
 #  index_events_pull_request_comments_on_review_request_id  (review_request_id)
@@ -25,13 +23,11 @@
 # Foreign Keys
 #
 #  fk_rails_...  (owner_id => users.id)
-#  fk_rails_...  (pull_request_id => pull_requests.id)
+#  fk_rails_...  (pull_request_id => events_pull_requests.id)
 #
 
 module Events
   class PullRequestComment < ApplicationRecord
-    acts_as_paranoid
-
     enum state: { created: 'created', edited: 'edited', deleted: 'deleted' }
 
     has_many :events, as: :handleable, dependent: :destroy

--- a/app/models/events/push.rb
+++ b/app/models/events/push.rb
@@ -3,7 +3,6 @@
 # Table name: events_pushes
 #
 #  id              :bigint           not null, primary key
-#  deleted_at      :datetime
 #  ref             :string
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
@@ -27,8 +26,6 @@
 
 module Events
   class Push < ApplicationRecord
-    acts_as_paranoid
-
     belongs_to :repository
     belongs_to :pull_request, class_name: 'Events::PullRequest', optional: true
     belongs_to :sender, class_name: 'User', foreign_key: :sender_id, inverse_of: :pushes

--- a/app/models/events/repository.rb
+++ b/app/models/events/repository.rb
@@ -4,7 +4,6 @@
 #
 #  id            :bigint           not null, primary key
 #  action        :string
-#  deleted_at    :datetime
 #  html_url      :string
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
@@ -25,8 +24,6 @@
 
 module Events
   class Repository < ApplicationRecord
-    acts_as_paranoid
-
     enum action: {
       created: 'created',
       deleted: 'deleted',

--- a/app/models/events/review.rb
+++ b/app/models/events/review.rb
@@ -4,7 +4,6 @@
 #
 #  id                :bigint           not null, primary key
 #  body              :string
-#  deleted_at        :datetime
 #  opened_at         :datetime         not null
 #  state             :enum             not null
 #  created_at        :datetime         not null
@@ -32,8 +31,6 @@
 
 module Events
   class Review < ApplicationRecord
-    acts_as_paranoid
-
     enum state: { approved: 'approved',
                   commented: 'commented',
                   changes_requested: 'changes_requested',

--- a/app/models/events/review_comment.rb
+++ b/app/models/events/review_comment.rb
@@ -4,7 +4,6 @@
 #
 #  id              :bigint           not null, primary key
 #  body            :string
-#  deleted_at      :datetime
 #  state           :enum             default("active")
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
@@ -21,13 +20,11 @@
 # Foreign Keys
 #
 #  fk_rails_...  (owner_id => users.id)
-#  fk_rails_...  (pull_request_id => pull_requests.id)
+#  fk_rails_...  (pull_request_id => events_pull_requests.id)
 #
 
 module Events
   class ReviewComment < ApplicationRecord
-    acts_as_paranoid
-
     enum state: { active: 'active', removed: 'removed' }
 
     has_many :events, as: :handleable, dependent: :destroy

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -37,18 +37,15 @@ class Repository < ApplicationRecord
   belongs_to :language
   belongs_to :product, optional: true
 
-  has_many :events, dependent: :destroy
+  has_many :events
   has_many :repositories,
            class_name: 'Events::Repository',
-           dependent: :destroy,
            inverse_of: :repository
   has_many :pull_requests,
            class_name: 'Events::PullRequest',
-           dependent: :destroy,
            inverse_of: :repository
   has_many :reviews,
            class_name: 'Events::Review',
-           dependent: :destroy,
            inverse_of: :repository
   has_many :review_requests,
            dependent: :destroy,

--- a/db/migrate/20210916151310_remove_deleted_at_to_events.rb
+++ b/db/migrate/20210916151310_remove_deleted_at_to_events.rb
@@ -1,0 +1,11 @@
+class RemoveDeletedAtToEvents < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :events, :deleted_at
+    remove_column :events_pull_request_comments, :deleted_at
+    remove_column :events_pull_requests, :deleted_at
+    remove_column :events_pushes, :deleted_at
+    remove_column :events_repositories, :deleted_at
+    remove_column :events_review_comments, :deleted_at
+    remove_column :events_reviews, :deleted_at
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -486,8 +486,7 @@ CREATE TABLE public.events (
     data jsonb,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
-    repository_id bigint NOT NULL,
-    deleted_at timestamp without time zone
+    repository_id bigint NOT NULL
 );
 
 
@@ -519,7 +518,6 @@ CREATE TABLE public.events_pull_request_comments (
     github_id integer,
     body character varying,
     opened_at timestamp without time zone NOT NULL,
-    deleted_at timestamp without time zone,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
     pull_request_id bigint NOT NULL,
@@ -571,8 +569,7 @@ CREATE TABLE public.events_pull_requests (
     owner_id bigint,
     html_url character varying,
     branch character varying,
-    size integer,
-    deleted_at timestamp without time zone
+    size integer
 );
 
 
@@ -606,8 +603,7 @@ CREATE TABLE public.events_pushes (
     sender_id bigint NOT NULL,
     ref character varying,
     created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL,
-    deleted_at timestamp without time zone
+    updated_at timestamp(6) without time zone NOT NULL
 );
 
 
@@ -641,8 +637,7 @@ CREATE TABLE public.events_repositories (
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
     sender_id bigint NOT NULL,
-    repository_id bigint NOT NULL,
-    deleted_at timestamp without time zone
+    repository_id bigint NOT NULL
 );
 
 
@@ -677,8 +672,7 @@ CREATE TABLE public.events_review_comments (
     updated_at timestamp(6) without time zone NOT NULL,
     pull_request_id bigint NOT NULL,
     owner_id bigint,
-    state public.review_comment_state DEFAULT 'active'::public.review_comment_state,
-    deleted_at timestamp without time zone
+    state public.review_comment_state DEFAULT 'active'::public.review_comment_state
 );
 
 
@@ -716,8 +710,7 @@ CREATE TABLE public.events_reviews (
     state public.review_state NOT NULL,
     opened_at timestamp without time zone NOT NULL,
     review_request_id bigint,
-    repository_id bigint,
-    deleted_at timestamp without time zone
+    repository_id bigint
 );
 
 
@@ -2092,13 +2085,6 @@ CREATE INDEX index_events_on_repository_id ON public.events USING btree (reposit
 
 
 --
--- Name: index_events_pull_request_comments_on_deleted_at; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_events_pull_request_comments_on_deleted_at ON public.events_pull_request_comments USING btree (deleted_at);
-
-
---
 -- Name: index_events_pull_request_comments_on_owner_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -2939,6 +2925,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20210830200129'),
 ('20210830211654'),
 ('20210902140638'),
-('20210902182225');
+('20210902182225'),
+('20210916151310');
 
 

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -4,7 +4,6 @@
 #
 #  id              :bigint           not null, primary key
 #  data            :jsonb
-#  deleted_at      :datetime
 #  handleable_type :string
 #  name            :string
 #  type            :string

--- a/spec/factories/events/pull_request_comments.rb
+++ b/spec/factories/events/pull_request_comments.rb
@@ -4,7 +4,6 @@
 #
 #  id                :bigint           not null, primary key
 #  body              :string
-#  deleted_at        :datetime
 #  opened_at         :datetime         not null
 #  state             :enum             default("created")
 #  created_at        :datetime         not null
@@ -16,7 +15,6 @@
 #
 # Indexes
 #
-#  index_events_pull_request_comments_on_deleted_at         (deleted_at)
 #  index_events_pull_request_comments_on_owner_id           (owner_id)
 #  index_events_pull_request_comments_on_pull_request_id    (pull_request_id)
 #  index_events_pull_request_comments_on_review_request_id  (review_request_id)
@@ -25,7 +23,7 @@
 # Foreign Keys
 #
 #  fk_rails_...  (owner_id => users.id)
-#  fk_rails_...  (pull_request_id => pull_requests.id)
+#  fk_rails_...  (pull_request_id => events_pull_requests.id)
 #
 
 FactoryBot.define do

--- a/spec/factories/events/pull_requests.rb
+++ b/spec/factories/events/pull_requests.rb
@@ -6,7 +6,6 @@
 #  body          :text
 #  branch        :string
 #  closed_at     :datetime
-#  deleted_at    :datetime
 #  draft         :boolean          not null
 #  html_url      :string
 #  locked        :boolean          not null

--- a/spec/factories/events/pushes.rb
+++ b/spec/factories/events/pushes.rb
@@ -3,7 +3,6 @@
 # Table name: events_pushes
 #
 #  id              :bigint           not null, primary key
-#  deleted_at      :datetime
 #  ref             :string
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null

--- a/spec/factories/events/repositories.rb
+++ b/spec/factories/events/repositories.rb
@@ -4,7 +4,6 @@
 #
 #  id            :bigint           not null, primary key
 #  action        :string
-#  deleted_at    :datetime
 #  html_url      :string
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null

--- a/spec/factories/events/review_comments.rb
+++ b/spec/factories/events/review_comments.rb
@@ -4,7 +4,6 @@
 #
 #  id              :bigint           not null, primary key
 #  body            :string
-#  deleted_at      :datetime
 #  state           :enum             default("active")
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
@@ -21,7 +20,7 @@
 # Foreign Keys
 #
 #  fk_rails_...  (owner_id => users.id)
-#  fk_rails_...  (pull_request_id => pull_requests.id)
+#  fk_rails_...  (pull_request_id => events_pull_requests.id)
 #
 
 FactoryBot.define do

--- a/spec/factories/events/reviews.rb
+++ b/spec/factories/events/reviews.rb
@@ -4,7 +4,6 @@
 #
 #  id                :bigint           not null, primary key
 #  body              :string
-#  deleted_at        :datetime
 #  opened_at         :datetime         not null
 #  state             :enum             not null
 #  created_at        :datetime         not null

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -4,7 +4,6 @@
 #
 #  id              :bigint           not null, primary key
 #  data            :jsonb
-#  deleted_at      :datetime
 #  handleable_type :string
 #  name            :string
 #  type            :string

--- a/spec/models/events/pull_request_comment_spec.rb
+++ b/spec/models/events/pull_request_comment_spec.rb
@@ -4,7 +4,6 @@
 #
 #  id                :bigint           not null, primary key
 #  body              :string
-#  deleted_at        :datetime
 #  opened_at         :datetime         not null
 #  state             :enum             default("created")
 #  created_at        :datetime         not null
@@ -16,7 +15,6 @@
 #
 # Indexes
 #
-#  index_events_pull_request_comments_on_deleted_at         (deleted_at)
 #  index_events_pull_request_comments_on_owner_id           (owner_id)
 #  index_events_pull_request_comments_on_pull_request_id    (pull_request_id)
 #  index_events_pull_request_comments_on_review_request_id  (review_request_id)
@@ -25,7 +23,7 @@
 # Foreign Keys
 #
 #  fk_rails_...  (owner_id => users.id)
-#  fk_rails_...  (pull_request_id => pull_requests.id)
+#  fk_rails_...  (pull_request_id => events_pull_requests.id)
 #
 
 require 'rails_helper'

--- a/spec/models/events/pull_request_spec.rb
+++ b/spec/models/events/pull_request_spec.rb
@@ -6,7 +6,6 @@
 #  body          :text
 #  branch        :string
 #  closed_at     :datetime
-#  deleted_at    :datetime
 #  draft         :boolean          not null
 #  html_url      :string
 #  locked        :boolean          not null

--- a/spec/models/events/push_spec.rb
+++ b/spec/models/events/push_spec.rb
@@ -3,7 +3,6 @@
 # Table name: events_pushes
 #
 #  id              :bigint           not null, primary key
-#  deleted_at      :datetime
 #  ref             :string
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null

--- a/spec/models/events/repository_spec.rb
+++ b/spec/models/events/repository_spec.rb
@@ -4,7 +4,6 @@
 #
 #  id            :bigint           not null, primary key
 #  action        :string
-#  deleted_at    :datetime
 #  html_url      :string
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null

--- a/spec/models/events/review_comment_spec.rb
+++ b/spec/models/events/review_comment_spec.rb
@@ -4,7 +4,6 @@
 #
 #  id              :bigint           not null, primary key
 #  body            :string
-#  deleted_at      :datetime
 #  state           :enum             default("active")
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
@@ -21,7 +20,7 @@
 # Foreign Keys
 #
 #  fk_rails_...  (owner_id => users.id)
-#  fk_rails_...  (pull_request_id => pull_requests.id)
+#  fk_rails_...  (pull_request_id => events_pull_requests.id)
 #
 
 require 'rails_helper'

--- a/spec/models/events/review_spec.rb
+++ b/spec/models/events/review_spec.rb
@@ -4,7 +4,6 @@
 #
 #  id                :bigint           not null, primary key
 #  body              :string
-#  deleted_at        :datetime
 #  opened_at         :datetime         not null
 #  state             :enum             not null
 #  created_at        :datetime         not null

--- a/spec/models/repository_spec.rb
+++ b/spec/models/repository_spec.rb
@@ -168,4 +168,62 @@ describe Repository, type: :model do
       expect(subject.full_name).to eq("#{org_name}/#{subject.name}")
     end
   end
+
+  describe '#destroy' do
+    let(:repository) { build(:repository) }
+    let!(:event_pull_request) { create(:event_pull_request, repository: repository) }
+    let!(:event_push) { create(:push, repository: repository) }
+    let!(:event_repository) { create(:event_repository, repository: repository) }
+    let!(:event_review) { create(:event_review, repository: repository) }
+
+    subject { repository.destroy }
+
+    it 'sets deleted_at to current time' do
+      subject
+
+      expect(repository.deleted_at).to be_within(1.second).of Time.zone.now
+    end
+
+    it 'does not delete the events' do
+      expect {
+        subject
+      }.not_to change { Event.count }
+    end
+
+    it 'does not delete the events_pull_request_comments' do
+      expect {
+        subject
+      }.not_to change { Events::PullRequestComment.count }
+    end
+
+    it 'does not delete the events_pull_requests' do
+      expect {
+        subject
+      }.not_to change { Events::PullRequest.count }
+    end
+
+    it 'does not delete the events_pushes' do
+      expect {
+        subject
+      }.not_to change { Events::Push.count }
+    end
+
+    it 'does not delete the events_repositories' do
+      expect {
+        subject
+      }.not_to change { Events::Repository.count }
+    end
+
+    it 'does not delete the events_review_comments' do
+      expect {
+        subject
+      }.not_to change { Events::ReviewComment.count }
+    end
+
+    it 'does not delete the events_reviews' do
+      expect {
+        subject
+      }.not_to change { Events::Review.count }
+    end
+  end
 end


### PR DESCRIPTION
## What does this PR do?
This PR removes the `:dependant` option to the association `events` in the `repository` model, because when deleting a repository from the admin page it ends in a timeout. This is due to all the events associated to a repository that needs to be updated.


Resolves [#EM-254](https://rootstrap.atlassian.net/browse/EM-254): Keep events associations when deleting repositories.
