### PR TITLE
[EM-300] Add see details report to pr size metric

### DIFF
--- a/app/controllers/pull_requests/pull_request_size_prs_repository_controller.rb
+++ b/app/controllers/pull_requests/pull_request_size_prs_repository_controller.rb
@@ -1,0 +1,7 @@
+module PullRequests
+  class PullRequestSizePrsRepositoryController < PullRequestsController
+    def repository
+      Builders::Distribution::PullRequests::PullRequestSizeRepository
+    end
+  end
+end

--- a/app/controllers/pull_requests/pull_requests_controller.rb
+++ b/app/controllers/pull_requests/pull_requests_controller.rb
@@ -3,15 +3,20 @@ module PullRequests
     layout 'sidebar_metrics'
     include LoadSettings
     include DateValidator
+    include RepositoryValidator
+
+    before_action :verify_repository_existence
 
     def index
       validate_from_to(from: metric_params[:from], to: metric_params[:to])
       @pull_requests = repository.call(
         from: @from,
         to: @to,
-        repository_name: params[:repository_name]
+        repository_name: @repository_name
       )
     end
+
+    private
 
     def metric_params
       params.require(:metric).permit(:to, :from)

--- a/app/services/builders/distribution/pull_requests/pull_request_size_repository.rb
+++ b/app/services/builders/distribution/pull_requests/pull_request_size_repository.rb
@@ -4,8 +4,8 @@ module Builders
       class PullRequestSizeRepository < BaseService
         def initialize(repository_name:, from:, to:)
           @repository_name = repository_name
-          @from = from.to_datetime.beginning_of_day
-          @to = to.to_datetime.end_of_day
+          @from = from&.to_datetime&.beginning_of_day
+          @to = to&.to_datetime&.end_of_day
         end
 
         def call

--- a/app/services/builders/distribution/pull_requests/pull_request_size_repository.rb
+++ b/app/services/builders/distribution/pull_requests/pull_request_size_repository.rb
@@ -10,8 +10,9 @@ module Builders
 
         def call
           pr_sizes.each_with_object(hash_of_arrays) { |pull_req, hash|
-            interval = Metrics::IntervalResolver::PrSize.call(pull_req.size)
-            pr_values = { html_url: pull_req.html_url, value: pull_req.size }
+            value = pull_req.size
+            interval = Metrics::IntervalResolver::PrSize.call(value)
+            pr_values = { html_url: pull_req.html_url, value: value }
             hash[interval] << pr_values
           }.sort.to_h
         end
@@ -19,11 +20,11 @@ module Builders
         private
 
         def pr_sizes
-          @pull_requests ||= ::Events::PullRequest.where(created_at: @from..@to)
-                                          .joins(:repository)
-                                          .where(repositories: { name: @repository_name })
-                                          .where.not(events_pull_requests: { html_url: nil })
-                                          .order(:size)
+          @pr_sizes ||= ::Events::PullRequest.where(created_at: @from..@to)
+                                             .joins(:repository)
+                                             .where(repositories: { name: @repository_name })
+                                             .where.not(events_pull_requests: { html_url: nil })
+                                             .order(:size)
         end
 
         def hash_of_arrays

--- a/app/services/builders/distribution/pull_requests/pull_request_size_repository.rb
+++ b/app/services/builders/distribution/pull_requests/pull_request_size_repository.rb
@@ -1,0 +1,35 @@
+module Builders
+  module Distribution
+    module PullRequests
+      class PullRequestSizeRepository < BaseService
+        def initialize(repository_name:, from:, to:)
+          @repository_name = repository_name
+          @from = from.to_datetime.beginning_of_day
+          @to = to.to_datetime.end_of_day
+        end
+
+        def call
+          pr_sizes.each_with_object(hash_of_arrays) { |pull_req, hash|
+            interval = Metrics::IntervalResolver::PrSize.call(pull_req.size)
+            pr_values = { html_url: pull_req.html_url, value: pull_req.size }
+            hash[interval] << pr_values
+          }.sort.to_h
+        end
+
+        private
+
+        def pr_sizes
+          @pull_requests ||= ::Events::PullRequest.where(created_at: @from..@to)
+                                          .joins(:repository)
+                                          .where(repositories: { name: @repository_name })
+                                          .where.not(events_pull_requests: { html_url: nil })
+                                          .order(:size)
+        end
+
+        def hash_of_arrays
+          Hash.new { |hash, key| hash[key] = [] }
+        end
+      end
+    end
+  end
+end

--- a/app/services/repository_validator.rb
+++ b/app/services/repository_validator.rb
@@ -1,0 +1,8 @@
+module RepositoryValidator
+  def verify_repository_existence
+    repository = Repository.find_by!(name: params[:repository_name])
+    @repository_name = repository.name
+  rescue ActiveRecord::RecordNotFound => exception
+    flash.now[:alert] = exception.message
+  end
+end

--- a/app/views/development_metrics/repositories.erb
+++ b/app/views/development_metrics/repositories.erb
@@ -83,13 +83,22 @@
       </div>
       <div class="metrics">
         <div class='row'>
-          <div class="box-title" >
-            <%= @pull_request_size_definition && @pull_request_size_definition[:name] %>
-            <span data-placement='right' class='metric_tooltip' aria-hidden='true' data-toggle='tooltip' title='<%= @pull_request_size_definition && @pull_request_size_definition[:explanation] %>'>¡</span>
+          <div class="col-md-11">
+            <div class="box-title" >
+              <%= @pull_request_size_definition && @pull_request_size_definition[:name] %>
+              <span data-placement='right' class='metric_tooltip' aria-hidden='true' data-toggle='tooltip' title='<%= @pull_request_size_definition && @pull_request_size_definition[:explanation] %>'>¡</span>
+            </div>
+            <div class="graph">
+              <%= render 'development_metrics/pull_request_size/main_metric', pull_request_size: @pull_request_size %>
+            </div>
           </div>
-        </div>
-        <div class="graph">
-          <%= render 'development_metrics/pull_request_size/main_metric', pull_request_size: @pull_request_size %>
+        <div class="col-md-1">
+          <div class="distribution-report-button mr-5">
+            <%= link_to 'See details',
+                        repository_pull_request_size_prs_repository_index_path(@repository.name, { metric: { from: params&.dig(:metric, :from), to: params&.dig(:metric, :to) }}),
+                        class: 'btn btn-detail'
+            %>
+            </div>
         </div>
       </div>
     <% else %>

--- a/app/views/pull_requests/pull_request_size_prs_repository/index.erb
+++ b/app/views/pull_requests/pull_request_size_prs_repository/index.erb
@@ -2,14 +2,14 @@
   <div class="metrics-container">
     <div class="row title_sidebar">
         <div class="col-md-6">
-          <b class="rute_title_grey"><%= params[:repository_name] +'/'%></b>
+          <b class="rute_title_grey"><%= @repository_name %>/</b>
           <b class="rute_title">Pull Request Size</b>
         </div>
           <div class="col-md-6 interval d-flex flex-row-reverse">
             <%= simple_form_for :metric, url: repository_pull_request_size_prs_repository_index_path, method: 'GET', html: {
                                                             id: 'nav-filter-form', style:"display: flex;"} do |f|%>
 
-                <%= hidden_field_tag 'repository_name', params[:repository_name] %>
+                <%= hidden_field_tag 'repository_name', @repository_name %>
                 <%= render 'shared/interval-filter', form: f %>
             <% end %>
           </div>

--- a/app/views/pull_requests/pull_request_size_prs_repository/index.erb
+++ b/app/views/pull_requests/pull_request_size_prs_repository/index.erb
@@ -1,0 +1,18 @@
+<%= render 'development_metrics/development_metrics_sidebar', enabled_users_section: @enabled_users_section %>
+  <div class="metrics-container">
+    <div class="row title_sidebar">
+        <div class="col-md-6">
+          <b class="rute_title_grey"><%= params[:repository_name] +'/'%></b>
+          <b class="rute_title">Pull Request Size</b>
+        </div>
+          <div class="col-md-6 interval d-flex flex-row-reverse">
+            <%= simple_form_for :metric, url: repository_pull_request_size_prs_repository_index_path, method: 'GET', html: {
+                                                            id: 'nav-filter-form', style:"display: flex;"} do |f|%>
+
+                <%= hidden_field_tag 'repository_name', params[:repository_name] %>
+                <%= render 'shared/interval-filter', form: f %>
+            <% end %>
+          </div>
+    </div>
+    <%= render partial: 'shared/pull_request_list' , locals: { pull_requests: @pull_requests, kpi_label: 'lines' } %>
+</div>

--- a/app/views/pull_requests/time_to_merge_prs/index.erb
+++ b/app/views/pull_requests/time_to_merge_prs/index.erb
@@ -22,5 +22,5 @@
       <% end %>
     </div>
   </div>
-  <%= render partial: 'shared/pull_request_list' , locals: { pull_requests: @pull_requests} %>
+  <%= render partial: 'shared/pull_request_list' , locals: { pull_requests: @pull_requests, kpi_label: 'hours' } %>
 </div>

--- a/app/views/pull_requests/time_to_merge_prs_repository/index.erb
+++ b/app/views/pull_requests/time_to_merge_prs_repository/index.erb
@@ -15,5 +15,5 @@
             <% end %>
           </div>
     </div>
-    <%= render partial: 'shared/pull_request_list' , locals: { pull_requests: @pull_requests} %>
+    <%= render partial: 'shared/pull_request_list' , locals: { pull_requests: @pull_requests, kpi_label: 'hours' } %>
 </div>

--- a/app/views/pull_requests/time_to_merge_prs_repository/index.erb
+++ b/app/views/pull_requests/time_to_merge_prs_repository/index.erb
@@ -2,7 +2,7 @@
   <div class="metrics-container">
     <div class="row title_sidebar">
         <div class="col-md-6">
-          <b class="rute_title_grey"><%= params[:repository_name] +'/'%></b>
+          <b class="rute_title_grey"><%= @repository_name %>/</b>
           <b class="rute_title">Merge Time</b>
         </div>
           <div class="col-md-6 interval d-flex flex-row-reverse">
@@ -10,7 +10,7 @@
                                                             id: 'nav-filter-form', style:"display: flex;"} do |f|%>
 
 
-                <%= hidden_field_tag 'repository_name', params[:repository_name] %>
+                <%= hidden_field_tag 'repository_name', @repository_name %>
                 <%= render 'shared/interval-filter', form: f %>
             <% end %>
           </div>

--- a/app/views/pull_requests/time_to_second_review_prs/index.erb
+++ b/app/views/pull_requests/time_to_second_review_prs/index.erb
@@ -22,5 +22,5 @@
       <% end %>
     </div>
   </div>
-  <%= render partial: 'shared/pull_request_list' , locals: { pull_requests: @pull_requests} %>
+  <%= render partial: 'shared/pull_request_list' , locals: { pull_requests: @pull_requests, kpi_label: 'hours' } %>
 </div>

--- a/app/views/pull_requests/time_to_second_review_prs_repository/index.erb
+++ b/app/views/pull_requests/time_to_second_review_prs_repository/index.erb
@@ -13,5 +13,5 @@
         <% end %>
     </div>
   </div>
-  <%= render partial: 'shared/pull_request_list' , locals: { pull_requests: @pull_requests} %>
+  <%= render partial: 'shared/pull_request_list' , locals: { pull_requests: @pull_requests, kpi_label: 'hours' } %>
 </div>

--- a/app/views/pull_requests/time_to_second_review_prs_repository/index.erb
+++ b/app/views/pull_requests/time_to_second_review_prs_repository/index.erb
@@ -2,13 +2,13 @@
 <div class="metrics-container">
   <div class="row title_sidebar">
     <div class="col-md-6">
-      <b class="rute_title_grey"><%= params[:repository_name] +'/'%></b>
+      <b class="rute_title_grey"><%= @repository_name %>/</b>
       <b class="rute_title">Time to second review</b>
     </div>
     <div class="col-md-6 interval d-flex flex-row-reverse">
       <%= simple_form_for :metric, url: repository_time_to_second_review_prs_repository_index_path, method: 'GET', html: {
                                                       id: 'nav-filter-form', style:"display: flex;"} do |f|%>
-          <%= hidden_field_tag 'repository_name', params[:repository_name] %>
+          <%= hidden_field_tag 'repository_name', @repository_name %>
           <%= render 'shared/interval-filter', form: f %>
         <% end %>
     </div>

--- a/app/views/shared/_pull_request_list.erb
+++ b/app/views/shared/_pull_request_list.erb
@@ -5,14 +5,14 @@
           <div class="accordion-item">
             <h2 class="accordion-header" id="heading<%= index %>" >
               <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" aria-expanded="false" data-bs-target="#collapse<%= index %>" aria-controls="collapse<%= index %>">
-                <%= range %> hours
+                <%= range %> <%= kpi_label %>
               </button>
             </h2>
             <div id="collapse<%= index %>" class="accordion-collapse collapse" aria-labelledby="headingOne" data-bs-parent="#accordionPullRequests">
               <% pr.each do |pr_values| %>
                 <div class="accordion-body pt-2 pb-1">
                   <%= link_to nil, pr_values[:html_url], target: '_blank' %>
-                    <span class="hours-pr">  (<%= pr_values[:value] %> hours)  </span>
+                    <span class="hours-pr">  (<%= pr_values[:value] %> <%= kpi_label %>)  </span>
                 </div>
               <% end %>
             </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,7 @@ Rails.application.routes.draw do
       resources :repositories, only: [], param: :name do
         resources :time_to_merge_prs_repository, only: :index, module: :pull_requests
         resources :time_to_second_review_prs_repository, only: :index, module: :pull_requests
+        resources :pull_request_size_prs_repository, only: :index, module: :pull_requests
       end
       resources :users, only: [] do
         resources :repositories, only: :index, controller: 'users/repositories'

--- a/spec/requests/pull_requests/pull_request_size_prs_repository/index_spec.rb
+++ b/spec/requests/pull_requests/pull_request_size_prs_repository/index_spec.rb
@@ -1,0 +1,85 @@
+require 'rails_helper'
+
+RSpec.describe 'Pull Request Size PRs Repository' do
+  let(:repository) { create(:repository) }
+  let(:from) { 4.weeks.ago }
+  let(:to) { Time.zone.now }
+  let(:wednesday) { Time.zone.today.last_week(:thursday) }
+  let(:subject) do
+    get repository_pull_request_size_prs_repository_index_path(
+      repository_name: repository.name
+    ), params: params
+  end
+
+  let!(:first_pull_request) do
+    create(:pull_request,
+           repository: repository,
+           html_url: 'test_pr_url_one',
+           opened_at: wednesday - 6.hours)
+  end
+
+  let!(:second_pull_request) do
+    create(:pull_request,
+           repository: repository,
+           html_url: 'test_pr_url_two',
+           opened_at: wednesday - 14.hours)
+  end
+
+  let!(:third_pull_request) do
+    create(:pull_request,
+           repository: repository,
+           html_url: 'test_pr_url_three',
+           opened_at: wednesday - 26.hours)
+  end
+
+  let!(:fourth_pull_request) do
+    create(:pull_request,
+           repository: repository,
+           size: Faker::Number.within(range: 100..200),
+           html_url: 'test_pr_url_four',
+           opened_at: wednesday - 14.hours)
+  end
+
+  let!(:fifth_pull_request) do
+    create(:pull_request,
+           repository: repository,
+           size: Faker::Number.within(range: 500..600),
+           html_url: 'test_pr_url_five',
+           opened_at: wednesday - 26.hours)
+  end
+
+  before do
+    first_pull_request.update!(merged_at: wednesday)
+    second_pull_request.update!(merged_at: wednesday)
+    third_pull_request.update!(merged_at: wednesday)
+    fourth_pull_request.update!(merged_at: wednesday)
+    fifth_pull_request.update!(merged_at: wednesday)
+  end
+
+  context 'With correct params' do
+    let(:params) do
+      {
+        metric: {
+          from: from,
+          to: to
+        }
+      }
+    end
+
+    before { subject }
+
+    it 'renders pull requests index view' do
+      expect(response).to render_template(:index)
+    end
+
+    it 'returns pull requests variable with data' do
+      expect(assigns(:pull_requests)).not_to be_empty
+    end
+
+    it 'returns ony one PR from each range' do
+      expect(assigns(:pull_requests)['100-199'].count).to eq(1)
+      expect(assigns(:pull_requests)['500-599'].count).to eq(1)
+      expect(assigns(:pull_requests)['1000+'].count).to eq(3)
+    end
+  end
+end

--- a/spec/requests/pull_requests/pull_request_size_prs_repository/index_spec.rb
+++ b/spec/requests/pull_requests/pull_request_size_prs_repository/index_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe 'Pull Request Size PRs Repository' do
     create(:pull_request,
            repository: repository,
            html_url: 'test_pr_url_one',
+           size: Faker::Number.within(range: 1000..5000),
            opened_at: wednesday - 6.hours)
   end
 
@@ -22,6 +23,7 @@ RSpec.describe 'Pull Request Size PRs Repository' do
     create(:pull_request,
            repository: repository,
            html_url: 'test_pr_url_two',
+           size: Faker::Number.within(range: 1000..5000),
            opened_at: wednesday - 14.hours)
   end
 
@@ -29,6 +31,7 @@ RSpec.describe 'Pull Request Size PRs Repository' do
     create(:pull_request,
            repository: repository,
            html_url: 'test_pr_url_three',
+           size: Faker::Number.within(range: 1000..5000),
            opened_at: wednesday - 26.hours)
   end
 

--- a/spec/requests/pull_requests/pull_request_size_prs_repository/index_spec.rb
+++ b/spec/requests/pull_requests/pull_request_size_prs_repository/index_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe 'Pull Request Size PRs Repository' do
       expect(assigns(:pull_requests)).not_to be_empty
     end
 
-    it 'returns ony one PR from each range' do
+    it 'returns only one PR from each range' do
       expect(assigns(:pull_requests)['100-199'].count).to eq(1)
       expect(assigns(:pull_requests)['500-599'].count).to eq(1)
       expect(assigns(:pull_requests)['1000+'].count).to eq(3)

--- a/spec/services/builders/distribution/pull_requests/pull_request_size_repository_spec.rb
+++ b/spec/services/builders/distribution/pull_requests/pull_request_size_repository_spec.rb
@@ -1,0 +1,101 @@
+require 'rails_helper'
+
+RSpec.describe Builders::Distribution::PullRequests::PullRequestSizeRepository do
+  describe '.call' do
+    before { travel_to Time.zone.parse('2020-08-20') }
+    let(:from) { 4.weeks.ago }
+    let(:to) { Time.zone.now }
+    let(:repository_one) { create(:repository) }
+    let(:repository_two) { create(:repository) }
+
+    let!(:first_pull_request) do
+      create(:pull_request,
+             repository: repository_one,
+             html_url: 'test_pr_url_one',
+             opened_at: 6.hours.ago)
+    end
+
+    let!(:second_pull_request) do
+      create(:pull_request,
+             repository: repository_two,
+             html_url: 'test_pr_url_two',
+             opened_at: 14.hours.ago)
+    end
+
+    let!(:third_pull_request) do
+      create(:pull_request,
+             repository: repository_one,
+             html_url: 'test_pr_url_three',
+             opened_at: 26.hours.ago)
+    end
+
+    let!(:fourth_pull_request) do
+      create(:pull_request,
+            repository: repository_one,
+            size: Faker::Number.within(range: 0..100),
+            html_url: 'test_pr_url_four',
+            opened_at: 26.hours.ago)
+    end
+
+    let!(:fifth_pull_request) do
+      create(:pull_request,
+            repository: repository_two,
+            size: Faker::Number.within(range: 100..200),
+            html_url: 'test_pr_url_five',
+            opened_at: 15.hours.ago)
+    end
+
+    before do
+      first_pull_request.update!(merged_at: Time.zone.now)
+      second_pull_request.update!(merged_at: Time.zone.now)
+      third_pull_request.update!(merged_at: Time.zone.now)
+      fourth_pull_request.update!(merged_at: Time.zone.now)
+      fifth_pull_request.update!(merged_at: Time.zone.now)
+    end
+
+    context 'with correct params' do
+      subject do
+        described_class.call(
+          repository_name: repository_one.name,
+          from: from,
+          to: to
+        )
+      end
+
+      it 'returns data for pull request with 1000+ lines' do
+        expect(subject).to have_key('1000+')
+      end
+
+      it 'returns data for pull request with 1-99 lines' do
+        expect(subject).to have_key('1-99')
+      end
+
+      it 'does not return any data for pull request with 100-200 lines' do
+        expect(subject).not_to have_key('100-199')
+      end
+    end
+
+    context 'when pull request has html_url attribute nil' do
+      let!(:pull_request_html_url_nil) do
+        create(:pull_request,
+               repository: repository_one,
+               size: Faker::Number.within(range: 700..800),
+               html_url: nil,
+               opened_at: 40.hours.ago,
+               merged_at: Time.zone.now)
+      end
+
+      subject do
+        described_class.call(
+          repository_name: repository_one.name,
+          from: from,
+          to: to
+        )
+      end
+
+      it 'does not add the pull request to the data' do
+        expect(subject).not_to have_key('700-799')
+      end
+    end
+  end
+end

--- a/spec/services/builders/distribution/pull_requests/pull_request_size_repository_spec.rb
+++ b/spec/services/builders/distribution/pull_requests/pull_request_size_repository_spec.rb
@@ -31,18 +31,18 @@ RSpec.describe Builders::Distribution::PullRequests::PullRequestSizeRepository d
 
     let!(:fourth_pull_request) do
       create(:pull_request,
-            repository: repository_one,
-            size: Faker::Number.within(range: 0..100),
-            html_url: 'test_pr_url_four',
-            opened_at: 26.hours.ago)
+             repository: repository_one,
+             size: Faker::Number.within(range: 0..100),
+             html_url: 'test_pr_url_four',
+             opened_at: 26.hours.ago)
     end
 
     let!(:fifth_pull_request) do
       create(:pull_request,
-            repository: repository_two,
-            size: Faker::Number.within(range: 100..200),
-            html_url: 'test_pr_url_five',
-            opened_at: 15.hours.ago)
+             repository: repository_two,
+             size: Faker::Number.within(range: 100..200),
+             html_url: 'test_pr_url_five',
+             opened_at: 15.hours.ago)
     end
 
     before do

--- a/spec/services/builders/distribution/pull_requests/pull_request_size_repository_spec.rb
+++ b/spec/services/builders/distribution/pull_requests/pull_request_size_repository_spec.rb
@@ -75,6 +75,24 @@ RSpec.describe Builders::Distribution::PullRequests::PullRequestSizeRepository d
       end
     end
 
+    context 'without date params' do
+      subject do
+        described_class.call(
+          repository_name: repository_one.name,
+          from: nil,
+          to: nil
+        )
+      end
+
+      it 'returns data for pull request with 1000+ lines' do
+        expect(subject).to have_key('1000+')
+      end
+
+      it 'returns data for pull request with 1-99 lines' do
+        expect(subject).to have_key('1-99')
+      end
+    end
+
     context 'when pull request has html_url attribute nil' do
       let!(:pull_request_html_url_nil) do
         create(:pull_request,


### PR DESCRIPTION
## What does this PR do?

- Add "See Details" button to the "PR Size" metric chart.
- Creates a new service and view for listing the pull requests that compounds the metric chart.

Resolves #XX

[EM-300 Implement Details Report for PR Size metric](https://rootstrap.atlassian.net/jira/software/projects/EM/boards/42?selectedIssue=EM-300)
