### PR TITLE
fix/see-details-pr-size-view-error

### DIFF
--- a/app/services/builders/distribution/pull_requests/pull_request_size_repository.rb
+++ b/app/services/builders/distribution/pull_requests/pull_request_size_repository.rb
@@ -23,7 +23,10 @@ module Builders
           @pr_sizes ||= ::Events::PullRequest.where(created_at: @from..@to)
                                              .joins(:repository)
                                              .where(repositories: { name: @repository_name })
-                                             .where.not(events_pull_requests: { html_url: nil })
+                                             .where.not(
+                                               events_pull_requests: { html_url: nil },
+                                               size: nil
+                                             )
                                              .order(:size)
         end
 

--- a/spec/services/builders/distribution/pull_requests/pull_request_size_repository_spec.rb
+++ b/spec/services/builders/distribution/pull_requests/pull_request_size_repository_spec.rb
@@ -115,5 +115,27 @@ RSpec.describe Builders::Distribution::PullRequests::PullRequestSizeRepository d
         expect(subject).not_to have_key('700-799')
       end
     end
+
+    context 'when pull request has size attribute nil' do
+      let!(:pull_request_html_url_nil) do
+        create(:pull_request,
+               repository: repository_one,
+               size: nil,
+               opened_at: 40.hours.ago,
+               merged_at: Time.zone.now)
+      end
+
+      subject do
+        described_class.call(
+          repository_name: repository_one.name,
+          from: from,
+          to: to
+        )
+      end
+
+      it 'does not add the pull request to the data' do
+        expect(subject).not_to have_key('700-799')
+      end
+    end
   end
 end


### PR DESCRIPTION
## What does this PR do?
The intention of this fix is to avoid that, when listing the detail of PRs in the `PR size` section, it does not include PRs that are `Closed`.

![Screen Shot 2022-05-05 at 17 03 50](https://user-images.githubusercontent.com/56528396/167016564-f95dbe61-2d47-4534-ab47-cb63044f0189.png)

Resolves #XX
