### PR TITLE
[EM-353] empty chart state

### DIFF
--- a/app/views/development_metrics/repositories.erb
+++ b/app/views/development_metrics/repositories.erb
@@ -2,8 +2,8 @@
   <div class="metrics-container">
     <div class="row title_sidebar">
         <div class="col-md-6">
-          <b class="rute_title_grey"><%= @repository.product[:name] +'/'%></b>
-          <b class="rute_title"><%= @repository.name  if @repository.product.present? %></b>
+          <strong class="rute_title_grey"><%= @repository.product[:name] +'/'%></strong>
+          <strong class="rute_title"><%= @repository.name  if @repository.product.present? %></strong>
         </div>
         <div class="col-md-6 interval d-flex flex-row-reverse">
           <%= render 'shared/repository/nav-filter' do |f| %>
@@ -42,7 +42,11 @@
            </div>
         </div>
         <div class="graph">
+          <% if !@review_turnaround[:per_repository][0][:data].empty? %>
           <%= render 'development_metrics/review_turnaround/main_metric', review_turnaround: @review_turnaround %>
+          <% else %>
+          <p>No data in this time period</p>
+          <% end %>
         </div>
         <% if @enabled_repository_per_user_graph %>
           <div class="graph details">

--- a/app/views/development_metrics/repositories.erb
+++ b/app/views/development_metrics/repositories.erb
@@ -80,7 +80,7 @@
         </div>
         <div class="graph">
         <% if !@merge_time[:per_repository][0][:data].empty? && !@merge_time[:per_repository_distribution][0][:data].empty? %>
-        <%= render 'development_metrics/merge_time/main_metric', merge_time: @merge_time %>
+            <%= render 'development_metrics/merge_time/main_metric', merge_time: @merge_time %>
         <% else %>
             <div class="p-3 text-center">
               <span class="text-danger extra-padding"><h5>No data to display for the selected period</h5></span>

--- a/app/views/development_metrics/repositories.erb
+++ b/app/views/development_metrics/repositories.erb
@@ -45,7 +45,9 @@
           <% if !@review_turnaround[:per_repository][0][:data].empty? && !@review_turnaround[:per_repository_distribution][0][:data].empty? %>
           <%= render 'development_metrics/review_turnaround/main_metric', review_turnaround: @review_turnaround %>
           <% else %>
-          <p>No data in this time period</p>
+            <div class='p-3 text-center'>
+              <span class="text-danger extra-padding"><h5>No data to display for the selected period</h5></span>
+            </div>
           <% end %>
         </div>
         <% if @enabled_repository_per_user_graph %>
@@ -80,7 +82,9 @@
         <% if !@merge_time[:per_repository][0][:data].empty? && !@merge_time[:per_repository_distribution][0][:data].empty? %>
         <%= render 'development_metrics/merge_time/main_metric', merge_time: @merge_time %>
         <% else %>
-        <p>No data in this time period</p>
+            <div class="p-3 text-center">
+              <span class="text-danger extra-padding"><h5>No data to display for the selected period</h5></span>
+            </div>
         <% end %>
         </div>
         <% if @enabled_repository_per_user_graph %>
@@ -100,7 +104,9 @@
               <% if !@pull_request_size[:per_repository_distribution][0][:data].empty? %>
               <%= render 'development_metrics/pull_request_size/main_metric', pull_request_size: @pull_request_size %>
                 <% else %>
-              <p>No data in this time period</p>
+                <div class="p-3 text-center">
+                  <span class="text-danger extra-padding"><h5>No data to display for the selected period</h5></span>
+                </div>
               <% end %>
             </div>
           </div>

--- a/app/views/development_metrics/repositories.erb
+++ b/app/views/development_metrics/repositories.erb
@@ -36,13 +36,13 @@
             <div class="distribution-report-button mr-5">
               <%= link_to 'See details',
                           repository_time_to_second_review_prs_repository_index_path(@repository.name, { metric: { from: params&.dig(:metric, :from), to: params&.dig(:metric, :to) }}),
-                          class: 'btn btn-detail'
+                          class: 'btn btn-detail' unless @review_turnaround[:per_repository_distribution][0][:data].empty?
               %>
              </div>
            </div>
         </div>
         <div class="graph">
-          <% if !@review_turnaround[:per_repository][0][:data].empty? %>
+          <% if !@review_turnaround[:per_repository][0][:data].empty? && !@review_turnaround[:per_repository_distribution][0][:data].empty? %>
           <%= render 'development_metrics/review_turnaround/main_metric', review_turnaround: @review_turnaround %>
           <% else %>
           <p>No data in this time period</p>
@@ -71,13 +71,17 @@
             <div class="distribution-report-button mr-5">
               <%= link_to 'See details',
                           repository_time_to_merge_prs_repository_index_path(@repository.name, { metric: { from: params&.dig(:metric, :from), to: params&.dig(:metric, :to) }}),
-                          class: 'btn btn-detail'
+                          class: 'btn btn-detail' unless @merge_time[:per_repository_distribution][0][:data].empty?
               %>
             </div>
           </div>
         </div>
         <div class="graph">
-          <%= render 'development_metrics/merge_time/main_metric', merge_time: @merge_time %>
+        <% if !@merge_time[:per_repository][0][:data].empty? && !@merge_time[:per_repository_distribution][0][:data].empty? %>
+        <%= render 'development_metrics/merge_time/main_metric', merge_time: @merge_time %>
+        <% else %>
+        <p>No data in this time period</p>
+        <% end %>
         </div>
         <% if @enabled_repository_per_user_graph %>
           <div class="graph details">
@@ -93,14 +97,18 @@
               <span data-placement='right' class='metric_tooltip' aria-hidden='true' data-toggle='tooltip' title='<%= @pull_request_size_definition && @pull_request_size_definition[:explanation] %>'>¡</span>
             </div>
             <div class="graph">
+              <% if !@pull_request_size[:per_repository_distribution][0][:data].empty? %>
               <%= render 'development_metrics/pull_request_size/main_metric', pull_request_size: @pull_request_size %>
+                <% else %>
+              <p>No data in this time period</p>
+              <% end %>
             </div>
           </div>
         <div class="col-md-1">
           <div class="distribution-report-button mr-5">
             <%= link_to 'See details',
                         repository_pull_request_size_prs_repository_index_path(@repository.name, { metric: { from: params&.dig(:metric, :from), to: params&.dig(:metric, :to) }}),
-                        class: 'btn btn-detail'
+                        class: 'btn btn-detail' unless @pull_request_size[:per_repository_distribution][0][:data].empty?
             %>
             </div>
         </div>


### PR DESCRIPTION
## What does this PR do?

It adds an empty state to the metrics view when there is no data available to display.

Resolves [EM-353](https://rootstrap.atlassian.net/browse/EM-353)
