### PR TITLE
[EM-312] Make completed review turnaround to ignore weekends

### DIFF
--- a/app/services/builders/completed_review_turnaround.rb
+++ b/app/services/builders/completed_review_turnaround.rb
@@ -12,7 +12,8 @@ module Builders
     end
 
     def caculate_completed_turnaround
-      @review.opened_at.to_i - @review.pull_request.opened_at.to_i
+      weekend_in_seconds = WeekendSecondsInterval.call(start_date: @review.opened_at, end_date: @review.pull_request.opened_at)
+      (@review.opened_at.to_i - @review.pull_request.opened_at.to_i) - weekend_in_seconds
     end
   end
 end

--- a/spec/services/builders/completed_review_turnaround_spec.rb
+++ b/spec/services/builders/completed_review_turnaround_spec.rb
@@ -16,7 +16,8 @@ RSpec.describe Builders::CompletedReviewTurnaround do
     end
 
     let(:correct_value) do
-      review.opened_at.to_i - pr.opened_at.to_i
+      weekend_in_seconds = WeekendSecondsInterval.call(start_date: review.opened_at, end_date: pr.opened_at)
+      (review.opened_at.to_i - pr.opened_at.to_i) - weekend_in_seconds
     end
 
     shared_examples 'the corresponding completed review turnaround is created' do


### PR DESCRIPTION
## What does this PR do?

When a completed review turnaround record is created (Time to second review) the value field (time it took to create that record) should ignore weekends.

Resolves [EM-312](https://rootstrap.atlassian.net/browse/EM-312)
