### PR TITLE
parameterize product name for correct integration with HTML ids

### DIFF
--- a/app/views/development_metrics/_products_list.erb
+++ b/app/views/development_metrics/_products_list.erb
@@ -5,12 +5,12 @@
       <li class="mb-1" data-turbolinks-permanent>
 
         <%= link_to products_development_metrics_path({product_name: product.name, metric: { from: initial_from, to: initial_to }}) do %>
-          <button class="btn btn-toggle align-items-center sidebar_font rounded collapsed" data-bs-toggle="collapse" data-bs-target="#<%= product.name %>-collapse" aria-expanded="true">
+          <button class="btn btn-toggle align-items-center sidebar_font rounded collapsed" data-bs-toggle="collapse" data-bs-target="#<%= product.name.parameterize %>-collapse" aria-expanded="true">
             <%= product.name %>
           </button>
         <% end %>
 
-        <div data-turbolinks-permanent class="collapse" id="<%= product.name %>-collapse">
+        <div data-turbolinks-permanent class="collapse" id="<%= product.name.parameterize %>-collapse">
             <ul class="btn-toggle-nav list-unstyled fw-normal pb-1">
               <% product.repositories.sort_by(&:name).each do |repository|%>
                 <a href='<%= (repositories_development_metrics_path({repository_name: repository.name, metric: { from: initial_from, to: initial_to, }})) %>' class='btn btn-toggle sidebar_font' role='button'><%= repository.name %></a>


### PR DESCRIPTION
## What does this PR do?

This PR fix the issue of products whose name contains spaces to not show in the sidebar of the app


Resolves [EM-361](https://rootstrap.atlassian.net/browse/EM-361)
