### PR TITLE
Add relation to pull request in review turnarounds

### DIFF
--- a/app/models/completed_review_turnaround.rb
+++ b/app/models/completed_review_turnaround.rb
@@ -7,14 +7,17 @@
 #  value             :integer
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
+#  pull_request_id   :bigint
 #  review_request_id :bigint           not null
 #
 # Indexes
 #
+#  index_completed_review_turnarounds_on_pull_request_id    (pull_request_id)
 #  index_completed_review_turnarounds_on_review_request_id  (review_request_id)
 #
 # Foreign Keys
 #
+#  fk_rails_...  (pull_request_id => events_pull_requests.id)
 #  fk_rails_...  (review_request_id => review_requests.id)
 #
 
@@ -24,6 +27,7 @@ class CompletedReviewTurnaround < ApplicationRecord
   include EntityTimeRepresentation
 
   belongs_to :review_request
+  belongs_to :pull_request, class_name: 'Events::PullRequest'
 
   validates :value, presence: true
   validates :review_request_id, uniqueness: true

--- a/app/models/review_turnaround.rb
+++ b/app/models/review_turnaround.rb
@@ -6,14 +6,17 @@
 #  value             :integer
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
+#  pull_request_id   :bigint
 #  review_request_id :bigint           not null
 #
 # Indexes
 #
+#  index_review_turnarounds_on_pull_request_id    (pull_request_id)
 #  index_review_turnarounds_on_review_request_id  (review_request_id)
 #
 # Foreign Keys
 #
+#  fk_rails_...  (pull_request_id => events_pull_requests.id)
 #  fk_rails_...  (review_request_id => review_requests.id)
 #
 
@@ -21,6 +24,7 @@ class ReviewTurnaround < ApplicationRecord
   include EntityTimeRepresentation
 
   belongs_to :review_request
+  belongs_to :pull_request, class_name: 'Events::PullRequest'
 
   validates :value, presence: true
   validates :review_request_id, uniqueness: true, strict: Reviews::ReviewRequestUniquenessError

--- a/app/services/builders/completed_review_turnaround.rb
+++ b/app/services/builders/completed_review_turnaround.rb
@@ -7,7 +7,8 @@ module Builders
     def call
       ::CompletedReviewTurnaround.create!(
         review_request_id: @review.review_request_id,
-        value: calculate_completed_turnaround
+        value: calculate_completed_turnaround,
+        pull_request: @review.pull_request
       )
     end
 

--- a/app/services/builders/review_turnaround.rb
+++ b/app/services/builders/review_turnaround.rb
@@ -5,7 +5,9 @@ module Builders
     end
 
     def call
-      ::ReviewTurnaround.create!(review_request: @review_request, value: calculate_turnaround)
+      ::ReviewTurnaround.create!(review_request: @review_request,
+                                 value: calculate_turnaround,
+                                 pull_request: @review_request.pull_request)
     end
 
     private

--- a/app/services/processors/completed_review_turnaround_pull_request_backfiller.rb
+++ b/app/services/processors/completed_review_turnaround_pull_request_backfiller.rb
@@ -1,0 +1,9 @@
+module Processors
+  class CompletedReviewTurnaroundPullRequestBackfiller < BaseService
+    def call
+      CompletedReviewTurnaround.find_each do |review|
+        review.update(pull_request: review.review_request.pull_request)
+      end
+    end
+  end
+end

--- a/app/services/processors/review_turnaround_pull_request_backfiller.rb
+++ b/app/services/processors/review_turnaround_pull_request_backfiller.rb
@@ -1,0 +1,9 @@
+module Processors
+  class ReviewTurnaroundPullRequestBackfiller < BaseService
+    def call
+      ReviewTurnaround.find_each do |review|
+        review.update(pull_request: review.review_request.pull_request)
+      end
+    end
+  end
+end

--- a/db/migrate/20221228101900_add_pull_request_to_completed_review_turnaround.rb
+++ b/db/migrate/20221228101900_add_pull_request_to_completed_review_turnaround.rb
@@ -1,0 +1,6 @@
+
+class AddPullRequestToCompletedReviewTurnaround < ActiveRecord::Migration[6.0]
+  def change
+    add_reference :completed_review_turnarounds, :pull_request, foreign_key: { to_table: :events_pull_requests }
+  end
+end

--- a/db/migrate/20221228121949_add_pull_request_to_review_turnaround.rb
+++ b/db/migrate/20221228121949_add_pull_request_to_review_turnaround.rb
@@ -1,0 +1,5 @@
+class AddPullRequestToReviewTurnaround < ActiveRecord::Migration[6.0]
+  def change
+    add_reference :review_turnarounds, :pull_request, foreign_key: { to_table: :events_pull_requests }
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -458,7 +458,8 @@ CREATE TABLE public.completed_review_turnarounds (
     value integer,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
-    deleted_at timestamp without time zone
+    deleted_at timestamp without time zone,
+    pull_request_id bigint
 );
 
 
@@ -858,9 +859,9 @@ CREATE TABLE public.external_pull_requests (
     external_repository_id bigint NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
+    number integer,
     opened_at timestamp without time zone,
-    state public.external_pull_request_state,
-    number integer
+    state public.external_pull_request_state
 );
 
 
@@ -1324,7 +1325,8 @@ CREATE TABLE public.review_turnarounds (
     review_request_id bigint NOT NULL,
     value integer,
     created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
+    updated_at timestamp(6) without time zone NOT NULL,
+    pull_request_id bigint
 );
 
 
@@ -2126,6 +2128,13 @@ CREATE INDEX index_code_owner_repositories_on_user_id ON public.code_owner_repos
 
 
 --
+-- Name: index_completed_review_turnarounds_on_pull_request_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_completed_review_turnarounds_on_pull_request_id ON public.completed_review_turnarounds USING btree (pull_request_id);
+
+
+--
 -- Name: index_completed_review_turnarounds_on_review_request_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -2469,6 +2478,13 @@ CREATE INDEX index_review_requests_on_state ON public.review_requests USING btre
 
 
 --
+-- Name: index_review_turnarounds_on_pull_request_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_review_turnarounds_on_pull_request_id ON public.review_turnarounds USING btree (pull_request_id);
+
+
+--
 -- Name: index_review_turnarounds_on_review_request_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -2541,6 +2557,14 @@ ALTER TABLE ONLY public.jira_issues
 
 ALTER TABLE ONLY public.events_pull_request_comments
     ADD CONSTRAINT fk_rails_161aa5ffd0 FOREIGN KEY (owner_id) REFERENCES public.users(id);
+
+
+--
+-- Name: completed_review_turnarounds fk_rails_200ab21dcf; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.completed_review_turnarounds
+    ADD CONSTRAINT fk_rails_200ab21dcf FOREIGN KEY (pull_request_id) REFERENCES public.events_pull_requests(id);
 
 
 --
@@ -2693,6 +2717,14 @@ ALTER TABLE ONLY public.events_pull_requests
 
 ALTER TABLE ONLY public.events_reviews
     ADD CONSTRAINT fk_rails_65b0ea4a71 FOREIGN KEY (repository_id) REFERENCES public.repositories(id);
+
+
+--
+-- Name: review_turnarounds fk_rails_7bc2fb6ebc; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.review_turnarounds
+    ADD CONSTRAINT fk_rails_7bc2fb6ebc FOREIGN KEY (pull_request_id) REFERENCES public.events_pull_requests(id);
 
 
 --
@@ -3020,6 +3052,8 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20210902182225'),
 ('20210915145551'),
 ('20210916151310'),
-('20220412181602');
+('20220412181602'),
+('20221228101900'),
+('20221228121949');
 
 

--- a/lib/tasks/set_pull_request_to_review_turnarounds.rake
+++ b/lib/tasks/set_pull_request_to_review_turnarounds.rake
@@ -1,0 +1,15 @@
+namespace :one_time do
+  desc ' it sets pull_request to review turnarounds'
+  task set_pull_request_to_review_turnaround: :environment do
+    puts 'Setting pull_request to review_turnarounds...'
+    Processors::ReviewTurnaroundPullRequestBackfiller.call
+    puts 'Done!'
+  end
+
+  desc 'it sets pull_request to completed review turnarounds'
+  task set_pull_request_to_completed_review_turnaround: :environment do
+    puts 'Setting pull_request to completed_review_turnarounds...'
+    Processors::CompletedReviewTurnaroundPullRequestBackfiller.call
+    puts 'Done!'
+  end
+end

--- a/spec/factories/completed_review_turnarounds.rb
+++ b/spec/factories/completed_review_turnarounds.rb
@@ -7,14 +7,17 @@
 #  value             :integer
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
+#  pull_request_id   :bigint
 #  review_request_id :bigint           not null
 #
 # Indexes
 #
+#  index_completed_review_turnarounds_on_pull_request_id    (pull_request_id)
 #  index_completed_review_turnarounds_on_review_request_id  (review_request_id)
 #
 # Foreign Keys
 #
+#  fk_rails_...  (pull_request_id => events_pull_requests.id)
 #  fk_rails_...  (review_request_id => review_requests.id)
 #
 
@@ -23,5 +26,6 @@ FactoryBot.define do
     value { Faker::Number.number(digits: 4) }
 
     association :review_request
+    association :pull_request
   end
 end

--- a/spec/factories/review_turnaround.rb
+++ b/spec/factories/review_turnaround.rb
@@ -3,5 +3,6 @@ FactoryBot.define do
     value { Faker::Number.number(digits: 4) }
 
     association :review_request
+    association :pull_request
   end
 end

--- a/spec/models/review_turnaround_spec.rb
+++ b/spec/models/review_turnaround_spec.rb
@@ -6,14 +6,17 @@
 #  value             :integer
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
+#  pull_request_id   :bigint
 #  review_request_id :bigint           not null
 #
 # Indexes
 #
+#  index_review_turnarounds_on_pull_request_id    (pull_request_id)
 #  index_review_turnarounds_on_review_request_id  (review_request_id)
 #
 # Foreign Keys
 #
+#  fk_rails_...  (pull_request_id => events_pull_requests.id)
 #  fk_rails_...  (review_request_id => review_requests.id)
 #
 

--- a/spec/services/builders/chartkick/users_repository_data_spec.rb
+++ b/spec/services/builders/chartkick/users_repository_data_spec.rb
@@ -15,7 +15,9 @@ RSpec.describe Builders::Chartkick::UsersRepositoryData do
 
       let(:review_request) { create(:review_request) }
       let!(:completed_review_turnaround) do
-        create(:completed_review_turnaround, review_request: review_request)
+        create(:completed_review_turnaround,
+               review_request: review_request,
+               pull_request: review_request.pull_request)
       end
       let!(:users_repository) do
         create(:users_repository, repository_id: review_request.repository_id,

--- a/spec/services/processors/completed_review_turnaround_pull_request_backfiller_spec.rb
+++ b/spec/services/processors/completed_review_turnaround_pull_request_backfiller_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe Processors::CompletedReviewTurnaroundPullRequestBackfiller do
+  describe '.call' do
+    let(:ruby_lang) { Language.find_by(name: 'ruby') }
+    let!(:repository) { create(:repository, language: ruby_lang) }
+    let!(:review_request) { create(:review_request, repository: repository) }
+    let(:completed_review_turnaround) do
+      build(:completed_review_turnaround,
+            review_request: review_request,
+            pull_request: nil)
+    end
+
+    before { completed_review_turnaround.save!(validate: false) }
+    it 'updates pull_request foreign_key in the completed review turnaround records' do
+      expect { described_class.call }.to change {
+                                           completed_review_turnaround.reload.pull_request_id
+                                         }
+        .from(nil)
+        .to(completed_review_turnaround.review_request.pull_request_id)
+    end
+  end
+end

--- a/spec/services/processors/review_turnaround_pull_request_backfiller_spec.rb
+++ b/spec/services/processors/review_turnaround_pull_request_backfiller_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe Processors::ReviewTurnaroundPullRequestBackfiller do
+  describe '.call' do
+    let(:ruby_lang) { Language.find_by(name: 'ruby') }
+    let!(:repository) { create(:repository, language: ruby_lang) }
+    let!(:review_request) { create(:review_request, repository: repository) }
+    let(:review_turnaround) do
+      build(:review_turnaround,
+            review_request: review_request,
+            pull_request: nil)
+    end
+
+    before { review_turnaround.save!(validate: false) }
+    it 'updates pull_request foreign_key in the completed review turnaround records' do
+      expect { described_class.call }.to change { review_turnaround.reload.pull_request_id }
+        .from(nil)
+        .to(review_turnaround.review_request.pull_request_id)
+    end
+  end
+end


### PR DESCRIPTION
## What does  it do?

Creates relationships for `completed_review_turnarounds` and `review_turnarounds` with `pull_requests`. After deploying there will be another Pr adding the pertinent constraint to those tables

## After deploy

run the following commands (rake tasks):
`rake one_time:set_pull_request_to_review_turnaround`
`rake one_time:set_pull_request_to_completed_review_turnaround`


