### PR TITLE
Fix return empty array when the url for the username is invalid

### DIFF
--- a/app/services/github_client/user.rb
+++ b/app/services/github_client/user.rb
@@ -12,6 +12,7 @@ module GithubClient
       events.flatten.select { |event| event[:type] == 'PullRequestEvent' }
     rescue URI::InvalidURIError, Faraday::ResourceNotFound => exception
       handle_exception(exception)
+      []
     end
 
     private
@@ -37,7 +38,9 @@ module GithubClient
 
     def handle_exception(exception)
       Honeybadger.notify(exception)
-      Rails.logger.error(exception)
+      Rails.logger.error(
+        "Failed to retrieve pull request events for user #{@username}: #{exception.message}"
+      )
     end
   end
 end

--- a/app/services/jira_client/repository.rb
+++ b/app/services/jira_client/repository.rb
@@ -31,6 +31,7 @@ module JiraClient
       @sprints
     rescue Faraday::ResourceNotFound, Faraday::ForbiddenError => exception
       raised_exception(exception)
+      []
     end
 
     private


### PR DESCRIPTION
## What does this PR do?
In the previous pr I removed accidentally the [] array when the url is invalid
<img width="734" alt="image" src="https://github.com/user-attachments/assets/f082cf3c-1bf7-4a3f-b717-b93d36193b6d">


Resolves #XX
