### PR TITLE
External pull request processor job error

### DIFF
--- a/app/services/builders/external_pull_request.rb
+++ b/app/services/builders/external_pull_request.rb
@@ -79,7 +79,7 @@ module Builders
       end
 
       def call
-        Builders::ExternalPullRequest.call(pull_request_data) if pull_request_data
+        Builders::ExternalPullRequest.call(pull_request_data) if pull_request_data.present?
       end
 
       private
@@ -87,16 +87,13 @@ module Builders
       def pull_request_data
         GithubClient::PullRequest.new(pull_request).get
       rescue Faraday::ResourceNotFound => exception
-        # Log the error
         Rails.logger.error("Failed to fetch pull request data: #{exception.message}")
 
-        # Notify error monitoring system
         Honeybadger.notify(exception, context: {
                              repository_full_name: @repository_full_name,
                              pull_request_number: @pull_request_number
                            })
 
-        # Return nil or handle accordingly
         nil
       end
 

--- a/app/services/processors/external/pull_requests.rb
+++ b/app/services/processors/external/pull_requests.rb
@@ -6,7 +6,6 @@ module Processors
       end
 
       def call
-        # #byebug
         external_pull_requests_events = CompanyMemberEventsDiscriminator.call(events)
 
         external_pull_requests_events.each do |pull_request_event|

--- a/app/services/processors/external/pull_requests.rb
+++ b/app/services/processors/external/pull_requests.rb
@@ -6,6 +6,7 @@ module Processors
       end
 
       def call
+        # #byebug
         external_pull_requests_events = CompanyMemberEventsDiscriminator.call(events)
 
         external_pull_requests_events.each do |pull_request_event|


### PR DESCRIPTION
## What does this PR do?
This pr is to fix this error
![image](https://github.com/user-attachments/assets/063cb9b9-9599-4b27-85a5-1b30ef38deb3)

This job processes external pull request information for all employees. For this specific user, when fetching all events from their GitHub account, the job encounters a public [event](https://api.github.com/users/tamarasuarezrod/events/public) that is a pull request linked to a repository that no longer exists—it may have been deleted or something similar. This causes the job to crash because the generated [URL is invalid](https://api.github.com/repos/mialergia/mia-mobile). What I’ve done now is log and notify the failure to process that particular pull request, but ensure that the job continues processing other external pull requests for this user or others.

Resolves #XX
