### PR TITLE
Change github ids to bigint

### DIFF
--- a/app/models/events/pull_request_comment.rb
+++ b/app/models/events/pull_request_comment.rb
@@ -8,7 +8,7 @@
 #  state             :enum             default("created")
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
-#  github_id         :integer
+#  github_id         :bigint
 #  owner_id          :bigint
 #  pull_request_id   :bigint           not null
 #  review_request_id :bigint

--- a/app/models/events/review.rb
+++ b/app/models/events/review.rb
@@ -8,7 +8,7 @@
 #  state             :enum             not null
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
-#  github_id         :integer
+#  github_id         :bigint
 #  owner_id          :bigint
 #  pull_request_id   :bigint           not null
 #  repository_id     :bigint

--- a/app/models/events/review_comment.rb
+++ b/app/models/events/review_comment.rb
@@ -7,7 +7,7 @@
 #  state           :enum             default("active")
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
-#  github_id       :integer
+#  github_id       :bigint
 #  owner_id        :bigint
 #  pull_request_id :bigint           not null
 #

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -10,7 +10,7 @@
 #  relevance   :enum             default("unassigned"), not null
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
-#  github_id   :integer          not null
+#  github_id   :bigint           not null
 #  language_id :bigint
 #  product_id  :bigint
 #

--- a/db/migrate/20250430195652_change_reviews_github_id_to_bigint.rb
+++ b/db/migrate/20250430195652_change_reviews_github_id_to_bigint.rb
@@ -1,0 +1,5 @@
+class ChangeReviewsGithubIdToBigint < ActiveRecord::Migration[7.1]
+  def change
+    change_column :events_reviews, :github_id, :bigint
+  end
+end

--- a/db/migrate/20250430195657_change_review_comments_github_id_to_bigint.rb
+++ b/db/migrate/20250430195657_change_review_comments_github_id_to_bigint.rb
@@ -1,0 +1,5 @@
+class ChangeReviewCommentsGithubIdToBigint < ActiveRecord::Migration[7.1]
+  def change
+    change_column :events_review_comments, :github_id, :bigint
+  end
+end

--- a/db/migrate/20250430195700_change_pull_request_comments_github_id_to_bigint.rb
+++ b/db/migrate/20250430195700_change_pull_request_comments_github_id_to_bigint.rb
@@ -1,0 +1,5 @@
+class ChangePullRequestCommentsGithubIdToBigint < ActiveRecord::Migration[7.1]
+  def change
+    change_column :events_pull_request_comments, :github_id, :bigint
+  end
+end

--- a/db/migrate/20250430195706_change_repositories_github_id_to_bigint.rb
+++ b/db/migrate/20250430195706_change_repositories_github_id_to_bigint.rb
@@ -1,0 +1,5 @@
+class ChangeRepositoriesGithubIdToBigint < ActiveRecord::Migration[7.1]
+  def change
+    change_column :repositories, :github_id, :bigint
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -10,13 +10,6 @@ SET client_min_messages = warning;
 SET row_security = off;
 
 --
--- Name: public; Type: SCHEMA; Schema: -; Owner: -
---
-
--- *not* creating schema, since initdb creates it
-
-
---
 -- Name: pg_stat_statements; Type: EXTENSION; Schema: -; Owner: -
 --
 
@@ -576,7 +569,7 @@ ALTER SEQUENCE public.events_id_seq OWNED BY public.events.id;
 
 CREATE TABLE public.events_pull_request_comments (
     id bigint NOT NULL,
-    github_id integer,
+    github_id bigint,
     body character varying,
     opened_at timestamp without time zone NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
@@ -727,7 +720,7 @@ ALTER SEQUENCE public.events_repositories_id_seq OWNED BY public.events_reposito
 
 CREATE TABLE public.events_review_comments (
     id bigint NOT NULL,
-    github_id integer,
+    github_id bigint,
     body character varying,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
@@ -764,7 +757,7 @@ CREATE TABLE public.events_reviews (
     id bigint NOT NULL,
     pull_request_id bigint NOT NULL,
     owner_id bigint,
-    github_id integer,
+    github_id bigint,
     body character varying,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
@@ -880,9 +873,9 @@ CREATE TABLE public.external_pull_requests (
     external_repository_id bigint NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
-    number integer,
     opened_at timestamp without time zone,
-    state public.external_pull_request_state
+    state public.external_pull_request_state,
+    number integer
 );
 
 
@@ -1269,7 +1262,7 @@ ALTER SEQUENCE public.products_id_seq OWNED BY public.products.id;
 
 CREATE TABLE public.repositories (
     id bigint NOT NULL,
-    github_id integer NOT NULL,
+    github_id bigint NOT NULL,
     name character varying,
     description character varying,
     created_at timestamp(6) without time zone NOT NULL,
@@ -2667,6 +2660,7 @@ ALTER TABLE ONLY public.events_pushes
     ADD CONSTRAINT fk_rails_3f633d82fd FOREIGN KEY (repository_id) REFERENCES public.repositories(id);
 
 
+
 --
 -- Name: events_pushes fk_rails_4767e99b87; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
@@ -2938,6 +2932,10 @@ ALTER TABLE ONLY public.review_requests
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20250430195706'),
+('20250430195700'),
+('20250430195657'),
+('20250430195652'),
 ('20240829142623'),
 ('20240627133952'),
 ('20221228121949'),

--- a/spec/factories/events/pull_request_comments.rb
+++ b/spec/factories/events/pull_request_comments.rb
@@ -8,7 +8,7 @@
 #  state             :enum             default("created")
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
-#  github_id         :integer
+#  github_id         :bigint
 #  owner_id          :bigint
 #  pull_request_id   :bigint           not null
 #  review_request_id :bigint

--- a/spec/factories/events/review_comments.rb
+++ b/spec/factories/events/review_comments.rb
@@ -7,7 +7,7 @@
 #  state           :enum             default("active")
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
-#  github_id       :integer
+#  github_id       :bigint
 #  owner_id        :bigint
 #  pull_request_id :bigint           not null
 #

--- a/spec/factories/events/reviews.rb
+++ b/spec/factories/events/reviews.rb
@@ -8,7 +8,7 @@
 #  state             :enum             not null
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
-#  github_id         :integer
+#  github_id         :bigint
 #  owner_id          :bigint
 #  pull_request_id   :bigint           not null
 #  repository_id     :bigint

--- a/spec/factories/repositories.rb
+++ b/spec/factories/repositories.rb
@@ -10,7 +10,7 @@
 #  relevance   :enum             default("unassigned"), not null
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
-#  github_id   :integer          not null
+#  github_id   :bigint           not null
 #  language_id :bigint
 #  product_id  :bigint
 #

--- a/spec/models/events/pull_request_comment_spec.rb
+++ b/spec/models/events/pull_request_comment_spec.rb
@@ -8,7 +8,7 @@
 #  state             :enum             default("created")
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
-#  github_id         :integer
+#  github_id         :bigint
 #  owner_id          :bigint
 #  pull_request_id   :bigint           not null
 #  review_request_id :bigint

--- a/spec/models/events/review_comment_spec.rb
+++ b/spec/models/events/review_comment_spec.rb
@@ -7,7 +7,7 @@
 #  state           :enum             default("active")
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
-#  github_id       :integer
+#  github_id       :bigint
 #  owner_id        :bigint
 #  pull_request_id :bigint           not null
 #

--- a/spec/models/events/review_spec.rb
+++ b/spec/models/events/review_spec.rb
@@ -8,7 +8,7 @@
 #  state             :enum             not null
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
-#  github_id         :integer
+#  github_id         :bigint
 #  owner_id          :bigint
 #  pull_request_id   :bigint           not null
 #  repository_id     :bigint

--- a/spec/models/repository_spec.rb
+++ b/spec/models/repository_spec.rb
@@ -10,7 +10,7 @@
 #  relevance   :enum             default("unassigned"), not null
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
-#  github_id   :integer          not null
+#  github_id   :bigint           not null
 #  language_id :bigint
 #  product_id  :bigint
 #


### PR DESCRIPTION
# Change GitHub IDs to bigint

## Problem
GitHub IDs can sometimes exceed the maximum value that can be stored in a 32-bit integer. This caused integer overflow errors when attempting to store large GitHub IDs in our database.

![Screenshot 2025-04-30 at 5 17 28 PM](https://github.com/user-attachments/assets/d3e8d96e-9933-4666-a77d-aade178d2b5e)


## Changes
- Changed `github_id` column type from `integer` to `bigint` in:
  - `events_pull_request_comments`
  - `events_review_comments`
  - `events_reviews`
  - `repositories`