### PR TITLE
Add review coverage model

### DIFF
--- a/app/models/events/pull_request.rb
+++ b/app/models/events/pull_request.rb
@@ -66,14 +66,5 @@ module Events
               :locked,
               inclusion: { in: [true, false] }
     validates :github_id, uniqueness: true, strict: PullRequests::GithubUniquenessError
-
-    after_validation :build_metrics, on: :update, if: :merged_at_changed?
-
-    private
-
-    def build_metrics
-      Builders::MergeTime.call(self)
-      Builders::ReviewCoverage.call(self)
-    end
   end
 end

--- a/app/models/events/pull_request.rb
+++ b/app/models/events/pull_request.rb
@@ -52,6 +52,7 @@ module Events
                                      dependent: :destroy, inverse_of: :pull_request
     has_many :events, as: :handleable, dependent: :destroy
     has_one :merge_time, dependent: :destroy
+    has_one :review_coverage, dependent: :destroy
 
     validates :state, inclusion: { in: states.keys }
     validates :github_id,
@@ -66,12 +67,13 @@ module Events
               inclusion: { in: [true, false] }
     validates :github_id, uniqueness: true, strict: PullRequests::GithubUniquenessError
 
-    after_validation :build_merge_time, on: :update, if: :merged_at_changed?
+    after_validation :build_metrics, on: :update, if: :merged_at_changed?
 
     private
 
-    def build_merge_time
+    def build_metrics
       Builders::MergeTime.call(self)
+      Builders::ReviewCoverage.call(self)
     end
   end
 end

--- a/app/models/metric_definition.rb
+++ b/app/models/metric_definition.rb
@@ -19,7 +19,8 @@ class MetricDefinition < ApplicationRecord
                defect_escape_rate: 'defect_escape_rate',
                pull_request_size: 'pull_request_size',
                development_cycle: 'development_cycle',
-               planned_to_done: 'planned_to_done' }
+               planned_to_done: 'planned_to_done',
+               review_coverage: 'review_coverage' }
 
   validates :code, uniqueness: true
   validates :name, presence: true, uniqueness: true

--- a/app/models/review_coverage.rb
+++ b/app/models/review_coverage.rb
@@ -22,18 +22,19 @@
 
 class ReviewCoverage < ApplicationRecord
   acts_as_paranoid
-  
+
   belongs_to :pull_request, class_name: 'Events::PullRequest'
-  
+
   validates :total_files_changed, :files_with_comments_count, presence: true
   validates :pull_request_id, uniqueness: true
-  validates :total_files_changed, :files_with_comments_count, numericality: { greater_than_or_equal_to: 0 }
-  
+  validates :total_files_changed, :files_with_comments_count,
+            numericality: { greater_than_or_equal_to: 0 }
+
   before_save :calculate_coverage_percentage
-  
+
   private
-  
+
   def calculate_coverage_percentage
     self.coverage_percentage = (files_with_comments_count.to_f / total_files_changed).round(2)
   end
-end 
+end

--- a/app/models/review_coverage.rb
+++ b/app/models/review_coverage.rb
@@ -1,0 +1,39 @@
+# == Schema Information
+#
+# Table name: review_coverages
+#
+#  id                        :bigint           not null, primary key
+#  coverage_percentage       :decimal(, )      not null
+#  deleted_at                :datetime
+#  files_with_comments_count :integer          not null
+#  total_files_changed       :integer          not null
+#  created_at                :datetime         not null
+#  updated_at                :datetime         not null
+#  pull_request_id           :bigint           not null
+#
+# Indexes
+#
+#  index_review_coverages_on_pull_request_id  (pull_request_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (pull_request_id => events_pull_requests.id)
+#
+
+class ReviewCoverage < ApplicationRecord
+  acts_as_paranoid
+  
+  belongs_to :pull_request, class_name: 'Events::PullRequest'
+  
+  validates :total_files_changed, :files_with_comments_count, presence: true
+  validates :pull_request_id, uniqueness: true
+  validates :total_files_changed, :files_with_comments_count, numericality: { greater_than_or_equal_to: 0 }
+  
+  before_save :calculate_coverage_percentage
+  
+  private
+  
+  def calculate_coverage_percentage
+    self.coverage_percentage = (files_with_comments_count.to_f / total_files_changed).round(2)
+  end
+end 

--- a/app/models/review_coverage.rb
+++ b/app/models/review_coverage.rb
@@ -29,12 +29,4 @@ class ReviewCoverage < ApplicationRecord
   validates :pull_request_id, uniqueness: true
   validates :total_files_changed, :files_with_comments_count,
             numericality: { greater_than_or_equal_to: 0 }
-
-  before_save :calculate_coverage_percentage
-
-  private
-
-  def calculate_coverage_percentage
-    self.coverage_percentage = (files_with_comments_count.to_f / total_files_changed).round(2)
-  end
 end

--- a/app/services/action_handlers/pull_request.rb
+++ b/app/services/action_handlers/pull_request.rb
@@ -16,7 +16,11 @@ module ActionHandlers
     end
 
     def merged
-      @entity.update!(merged_at: Time.current)
+      ActiveRecord::Base.transaction do
+        @entity.update!(merged_at: Time.current)
+        Builders::MergeTime.call(@entity)
+        Builders::ReviewCoverage.call(@entity)
+      end
     end
 
     def closed

--- a/app/services/builders/review_coverage.rb
+++ b/app/services/builders/review_coverage.rb
@@ -8,18 +8,24 @@ module Builders
       ::ReviewCoverage.create!(
         pull_request: @pull_request,
         total_files_changed: total_files,
-        files_with_comments_count: files_with_comments_count
+        files_with_comments_count: files_with_comments_count,
+        coverage_percentage: coverage_percentage
       )
     end
 
     private
 
     def total_files
-      github_client.files.count
+      @total_files ||= github_client.files.count
     end
 
     def files_with_comments_count
-      github_client.comments.map { |comment| { filename: comment[:path] } }.uniq.count
+      @files_with_comments_count ||=
+        github_client.comments.map { |comment| { filename: comment[:path] } }.uniq.count
+    end
+
+    def coverage_percentage
+      (files_with_comments_count.to_f / total_files).round(2)
     end
 
     def github_client

--- a/app/services/builders/review_coverage.rb
+++ b/app/services/builders/review_coverage.rb
@@ -26,4 +26,4 @@ module Builders
       @github_client ||= GithubClient::PullRequest.new(@pull_request)
     end
   end
-end 
+end

--- a/app/services/builders/review_coverage.rb
+++ b/app/services/builders/review_coverage.rb
@@ -1,0 +1,29 @@
+module Builders
+  class ReviewCoverage < BaseService
+    def initialize(pull_request)
+      @pull_request = pull_request
+    end
+
+    def call
+      ::ReviewCoverage.create!(
+        pull_request: @pull_request,
+        total_files_changed: total_files,
+        files_with_comments_count: files_with_comments_count
+      )
+    end
+
+    private
+
+    def total_files
+      github_client.files.count
+    end
+
+    def files_with_comments_count
+      github_client.comments.map { |comment| { filename: comment[:path] } }.uniq.count
+    end
+
+    def github_client
+      @github_client ||= GithubClient::PullRequest.new(@pull_request)
+    end
+  end
+end 

--- a/app/services/github_client/pull_request.rb
+++ b/app/services/github_client/pull_request.rb
@@ -18,6 +18,11 @@ module GithubClient
       get_all_paginated_items(url, MAX_FILES_PER_PAGE)
     end
 
+    def comments
+      url = "repos/#{repository.full_name}/pulls/#{pull_request.number}/comments"
+      get_all_paginated_items(url, MAX_FILES_PER_PAGE)
+    end
+
     private
 
     attr_reader :pull_request

--- a/app/services/github_client/pull_request.rb
+++ b/app/services/github_client/pull_request.rb
@@ -16,15 +16,29 @@ module GithubClient
     def files
       url = "repositories/#{repository.github_id}/pulls/#{pull_request.number}/files"
       get_all_paginated_items(url, MAX_FILES_PER_PAGE)
+    rescue Faraday::Error => exception
+      handle_exception(exception)
+      []
     end
 
     def comments
       url = "repos/#{repository.full_name}/pulls/#{pull_request.number}/comments"
       get_all_paginated_items(url, MAX_FILES_PER_PAGE)
+    rescue Faraday::Error => exception
+      handle_exception(exception)
+      []
     end
 
     private
 
     attr_reader :pull_request
+
+    def handle_exception(exception)
+      Honeybadger.notify(exception)
+      Rails.logger.error(
+        "Failed to retrieve data for pull request #{pull_request.number} " \
+        "from repository #{repository.full_name}: #{exception.message}"
+      )
+    end
   end
 end

--- a/db/migrate/20250429002929_create_review_coverages.rb
+++ b/db/migrate/20250429002929_create_review_coverages.rb
@@ -1,0 +1,13 @@
+class CreateReviewCoverages < ActiveRecord::Migration[7.1]
+  def change
+    create_table :review_coverages do |t|
+      t.references :pull_request, null: false, foreign_key: { to_table: :events_pull_requests }
+      t.integer :total_files_changed, null: false
+      t.integer :files_with_comments_count, null: false
+      t.decimal :coverage_percentage, null: false
+      t.datetime :deleted_at
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250430151601_add_review_coverage_to_metric_name_type.rb
+++ b/db/migrate/20250430151601_add_review_coverage_to_metric_name_type.rb
@@ -1,0 +1,18 @@
+class AddReviewCoverageToMetricNameType < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def up
+    execute <<-SQL
+      ALTER TYPE metric_name ADD VALUE 'review_coverage';
+    SQL
+  end
+
+  def down
+    execute <<-SQL
+      ALTER TYPE metric_name RENAME TO metric_name_old;
+      CREATE TYPE metric_name AS ENUM ('review_turnaround', 'blog_visits', 'merge_time', 'blog_post_count', 'open_source_visits', 'defect_escape_rate', 'pull_request_size', 'development_cycle');
+      ALTER TABLE metrics ALTER COLUMN name TYPE metric_name USING name::text::metric_name;
+      DROP TYPE metric_name_old;
+    SQL
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -151,4 +151,5 @@ if Rails.env.development?
   MetricDefinition.create!(code: :pull_request_size, explanation: 'Measures the lines of code added by each PR. The smaller the PR, the easier it is to review, which speeds up the review process..', name: 'PR Size')
   MetricDefinition.create!(code: :development_cycle, explanation: 'It measures how much time the team spends working on a task.', name: 'Development Cycle')
   MetricDefinition.create!(code: :planned_to_done, explanation: 'The planned-to-done ratio measures what percentage of the tasks you set out for your team were completed satisfactorily.', name: 'Planned to Done Ratio')
+  MetricDefinition.create!(code: :review_coverage, explanation: 'Measures the percentage of files in a pull request that have received review comments.', name: 'Review Coverage')
 end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -128,7 +128,8 @@ CREATE TYPE public.metric_name AS ENUM (
     'defect_escape_rate',
     'pull_request_size',
     'development_cycle',
-    'planned_to_done'
+    'planned_to_done',
+    'review_coverage'
 );
 
 
@@ -1295,6 +1296,41 @@ ALTER SEQUENCE public.repositories_id_seq OWNED BY public.repositories.id;
 
 
 --
+-- Name: review_coverages; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.review_coverages (
+    id bigint NOT NULL,
+    pull_request_id bigint NOT NULL,
+    total_files_changed integer NOT NULL,
+    files_with_comments_count integer NOT NULL,
+    coverage_percentage numeric NOT NULL,
+    deleted_at timestamp(6) without time zone,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: review_coverages_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.review_coverages_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: review_coverages_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.review_coverages_id_seq OWNED BY public.review_coverages.id;
+
+
+--
 -- Name: review_requests; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -1712,6 +1748,13 @@ ALTER TABLE ONLY public.repositories ALTER COLUMN id SET DEFAULT nextval('public
 
 
 --
+-- Name: review_coverages id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.review_coverages ALTER COLUMN id SET DEFAULT nextval('public.review_coverages_id_seq'::regclass);
+
+
+--
 -- Name: review_requests id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -1999,6 +2042,14 @@ ALTER TABLE ONLY public.products
 
 ALTER TABLE ONLY public.repositories
     ADD CONSTRAINT repositories_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: review_coverages review_coverages_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.review_coverages
+    ADD CONSTRAINT review_coverages_pkey PRIMARY KEY (id);
 
 
 --
@@ -2464,6 +2515,13 @@ CREATE INDEX index_repositories_on_product_id ON public.repositories USING btree
 
 
 --
+-- Name: index_review_coverages_on_pull_request_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_review_coverages_on_pull_request_id ON public.review_coverages USING btree (pull_request_id);
+
+
+--
 -- Name: index_review_requests_on_owner_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -2659,6 +2717,13 @@ ALTER TABLE ONLY public.events_pull_requests
 ALTER TABLE ONLY public.events_pushes
     ADD CONSTRAINT fk_rails_3f633d82fd FOREIGN KEY (repository_id) REFERENCES public.repositories(id);
 
+
+--
+-- Name: review_coverages fk_rails_40af85f049; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.review_coverages
+    ADD CONSTRAINT fk_rails_40af85f049 FOREIGN KEY (pull_request_id) REFERENCES public.events_pull_requests(id);
 
 
 --
@@ -2936,6 +3001,8 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20250430195700'),
 ('20250430195657'),
 ('20250430195652'),
+('20250430151601'),
+('20250429002929'),
 ('20240829142623'),
 ('20240627133952'),
 ('20221228121949'),

--- a/lib/tasks/review_coverage_backfill.rake
+++ b/lib/tasks/review_coverage_backfill.rake
@@ -2,23 +2,22 @@ namespace :review_coverage do
   desc 'Backfill review coverage for merged pull requests'
   task backfill: :environment do
     puts 'Starting review coverage backfill...'
-    
+
     pull_requests = Events::PullRequest
-        .where.not(merged_at: nil)
-        .where.not(id: ReviewCoverage.select(:pull_request_id))
-        .where(created_at: Time.current.beginning_of_year..Time.current)
-    
+                    .where.not(merged_at: nil)
+                    .where.not(id: ReviewCoverage.select(:pull_request_id))
+                    .where(created_at: Time.current.beginning_of_year..Time.current)
+
     total = pull_requests.count
     puts "Found #{total} pull requests to process"
-    
+
     pull_requests.find_each do |pull_request|
-      begin
-        Builders::ReviewCoverage.call(pull_request)
-      rescue => e
-        puts "Error processing PR ##{pull_request.number} in repository #{pull_request.repository.id}: #{e.message}"
-      end
+      Builders::ReviewCoverage.call(pull_request)
+    rescue StandardError => exception
+      puts "Error processing PR ##{pull_request.number}
+            in repository #{pull_request.repository.id}: #{exception.message}"
     end
-    
+
     puts 'Review coverage backfill completed!'
   end
-end 
+end

--- a/lib/tasks/review_coverage_backfill.rake
+++ b/lib/tasks/review_coverage_backfill.rake
@@ -1,0 +1,24 @@
+namespace :review_coverage do
+  desc 'Backfill review coverage for merged pull requests'
+  task backfill: :environment do
+    puts 'Starting review coverage backfill...'
+    
+    pull_requests = Events::PullRequest
+        .where.not(merged_at: nil)
+        .where.not(id: ReviewCoverage.select(:pull_request_id))
+        .where(created_at: Time.current.beginning_of_year..Time.current)
+    
+    total = pull_requests.count
+    puts "Found #{total} pull requests to process"
+    
+    pull_requests.find_each do |pull_request|
+      begin
+        Builders::ReviewCoverage.call(pull_request)
+      rescue => e
+        puts "Error processing PR ##{pull_request.number} in repository #{pull_request.repository.id}: #{e.message}"
+      end
+    end
+    
+    puts 'Review coverage backfill completed!'
+  end
+end 

--- a/spec/factories/events/pull_requests.rb
+++ b/spec/factories/events/pull_requests.rb
@@ -53,5 +53,26 @@ FactoryBot.define do
     repository
 
     association :owner, factory: :user
+
+    trait :merged do
+      state { 'closed' }
+      merged_at { Time.current }
+
+      transient do
+        merge_time { (merged_at - opened_at).to_i }
+      end
+
+      after(:create) do |pull_request, evaluator|
+        create(
+          :merge_time,
+          pull_request: pull_request,
+          value: evaluator.merge_time
+        )
+        create(
+          :review_coverage,
+          pull_request: pull_request
+        )
+      end
+    end
   end
 end

--- a/spec/factories/review_coverages.rb
+++ b/spec/factories/review_coverages.rb
@@ -1,0 +1,29 @@
+# == Schema Information
+#
+# Table name: review_coverages
+#
+#  id                        :bigint           not null, primary key
+#  coverage_percentage       :decimal(, )      not null
+#  deleted_at                :datetime
+#  files_with_comments_count :integer          not null
+#  total_files_changed       :integer          not null
+#  created_at                :datetime         not null
+#  updated_at                :datetime         not null
+#  pull_request_id           :bigint           not null
+#
+# Indexes
+#
+#  index_review_coverages_on_pull_request_id  (pull_request_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (pull_request_id => events_pull_requests.id)
+#
+
+FactoryBot.define do
+  factory :review_coverage do
+    total_files_changed { Faker::Number.between(from: 1, to: 100) }
+    files_with_comments_count { Faker::Number.between(from: 0, to: total_files_changed) }
+    pull_request
+  end
+end 

--- a/spec/factories/review_coverages.rb
+++ b/spec/factories/review_coverages.rb
@@ -24,6 +24,7 @@ FactoryBot.define do
   factory :review_coverage do
     total_files_changed { Faker::Number.between(from: 1, to: 100) }
     files_with_comments_count { Faker::Number.between(from: 0, to: total_files_changed) }
+    coverage_percentage { (files_with_comments_count.to_f / total_files_changed).round(2) }
     pull_request
   end
 end

--- a/spec/factories/review_coverages.rb
+++ b/spec/factories/review_coverages.rb
@@ -26,4 +26,4 @@ FactoryBot.define do
     files_with_comments_count { Faker::Number.between(from: 0, to: total_files_changed) }
     pull_request
   end
-end 
+end

--- a/spec/models/events/pull_request_spec.rb
+++ b/spec/models/events/pull_request_spec.rb
@@ -77,24 +77,4 @@ RSpec.describe Events::PullRequest, type: :model do
       end
     end
   end
-
-  describe 'callbacks' do
-    context 'when a pull request is merged' do
-      before { travel_to(Time.zone.today.beginning_of_day) }
-      let!(:pull_request) { create(:pull_request, opened_at: Time.current) }
-
-      it 'creates a merge time with the correct values' do
-        pull_request.update!(merged_at: Time.current + 1.hour)
-        merge_time = MergeTime.last
-        expect(merge_time[:value].seconds).to eq(1.hour)
-        expect(merge_time[:pull_request_id]).to eq(pull_request.id)
-      end
-
-      it 'creates a merge time' do
-        expect {
-          pull_request.update!(merged_at: Time.current)
-        }.to change { MergeTime.count }.from(0).to(1)
-      end
-    end
-  end
 end

--- a/spec/models/review_coverage_spec.rb
+++ b/spec/models/review_coverage_spec.rb
@@ -48,19 +48,19 @@ RSpec.describe ReviewCoverage, type: :model do
 
   describe 'callbacks' do
     describe '#calculate_coverage_percentage' do
-        let(:total_files) { 10 }
-        let(:files_with_comments) { 5 }
-        let(:expected_percentage) { 0.5 }
+      let(:total_files) { 10 }
+      let(:files_with_comments) { 5 }
+      let(:expected_percentage) { 0.5 }
 
-        before do
+      before do
         subject.total_files_changed = total_files
         subject.files_with_comments_count = files_with_comments
-        end
+      end
 
-        it 'calculates the coverage percentage correctly' do
-            subject.save!
-            expect(subject.coverage_percentage).to eq(expected_percentage)
-        end
+      it 'calculates the coverage percentage correctly' do
+        subject.save!
+        expect(subject.coverage_percentage).to eq(expected_percentage)
+      end
     end
   end
-end 
+end

--- a/spec/models/review_coverage_spec.rb
+++ b/spec/models/review_coverage_spec.rb
@@ -45,22 +45,4 @@ RSpec.describe ReviewCoverage, type: :model do
       expect(subject).not_to be_valid
     end
   end
-
-  describe 'callbacks' do
-    describe '#calculate_coverage_percentage' do
-      let(:total_files) { 10 }
-      let(:files_with_comments) { 5 }
-      let(:expected_percentage) { 0.5 }
-
-      before do
-        subject.total_files_changed = total_files
-        subject.files_with_comments_count = files_with_comments
-      end
-
-      it 'calculates the coverage percentage correctly' do
-        subject.save!
-        expect(subject.coverage_percentage).to eq(expected_percentage)
-      end
-    end
-  end
 end

--- a/spec/models/review_coverage_spec.rb
+++ b/spec/models/review_coverage_spec.rb
@@ -1,0 +1,66 @@
+# == Schema Information
+#
+# Table name: review_coverages
+#
+#  id                        :bigint           not null, primary key
+#  coverage_percentage       :decimal(, )      not null
+#  deleted_at                :datetime
+#  files_with_comments_count :integer          not null
+#  total_files_changed       :integer          not null
+#  created_at                :datetime         not null
+#  updated_at                :datetime         not null
+#  pull_request_id           :bigint           not null
+#
+# Indexes
+#
+#  index_review_coverages_on_pull_request_id  (pull_request_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (pull_request_id => events_pull_requests.id)
+#
+
+require 'rails_helper'
+
+RSpec.describe ReviewCoverage, type: :model do
+  subject { build :review_coverage }
+
+  context 'validations' do
+    it 'is valid with valid attributes' do
+      expect(subject).to be_valid
+    end
+
+    it { is_expected.to validate_presence_of(:total_files_changed) }
+    it { is_expected.to validate_presence_of(:files_with_comments_count) }
+    it { is_expected.to validate_uniqueness_of(:pull_request_id) }
+    it { is_expected.to belong_to(:pull_request) }
+
+    it 'total_files_changed is not valid with negative value' do
+      subject.total_files_changed = -1
+      expect(subject).not_to be_valid
+    end
+
+    it 'files_with_comments_count is not valid with negative value' do
+      subject.files_with_comments_count = -1
+      expect(subject).not_to be_valid
+    end
+  end
+
+  describe 'callbacks' do
+    describe '#calculate_coverage_percentage' do
+        let(:total_files) { 10 }
+        let(:files_with_comments) { 5 }
+        let(:expected_percentage) { 0.5 }
+
+        before do
+        subject.total_files_changed = total_files
+        subject.files_with_comments_count = files_with_comments
+        end
+
+        it 'calculates the coverage percentage correctly' do
+            subject.save!
+            expect(subject.coverage_percentage).to eq(expected_percentage)
+        end
+    end
+  end
+end 

--- a/spec/requests/pull_requests/pull_request_size_prs_repository/index_spec.rb
+++ b/spec/requests/pull_requests/pull_request_size_prs_repository/index_spec.rb
@@ -4,7 +4,6 @@ RSpec.describe 'PullRequests::PullRequestSizePrsRepositoryController' do
   let(:repository) { create(:repository) }
   let(:from) { 4.weeks.ago }
   let(:to) { Time.zone.now }
-  let(:wednesday) { Time.zone.today.last_week(:thursday) }
   let(:subject) do
     get repository_pull_request_size_prs_repository_index_path(
       repository_name: repository.name
@@ -12,51 +11,43 @@ RSpec.describe 'PullRequests::PullRequestSizePrsRepositoryController' do
   end
 
   let!(:first_pull_request) do
-    create(:pull_request,
+    create(:pull_request, :merged,
            repository: repository,
            html_url: 'test_pr_url_one',
            size: Faker::Number.within(range: 1000..5000),
-           opened_at: wednesday - 6.hours)
+           opened_at: 6.hours.ago)
   end
 
   let!(:second_pull_request) do
-    create(:pull_request,
+    create(:pull_request, :merged,
            repository: repository,
            html_url: 'test_pr_url_two',
            size: Faker::Number.within(range: 1000..5000),
-           opened_at: wednesday - 14.hours)
+           opened_at: 14.hours.ago)
   end
 
   let!(:third_pull_request) do
-    create(:pull_request,
+    create(:pull_request, :merged,
            repository: repository,
            html_url: 'test_pr_url_three',
            size: Faker::Number.within(range: 1000..5000),
-           opened_at: wednesday - 26.hours)
+           opened_at: 26.hours.ago)
   end
 
   let!(:fourth_pull_request) do
-    create(:pull_request,
+    create(:pull_request, :merged,
            repository: repository,
            size: Faker::Number.within(range: 100..200),
            html_url: 'test_pr_url_four',
-           opened_at: wednesday - 14.hours)
+           opened_at: 14.hours.ago)
   end
 
   let!(:fifth_pull_request) do
-    create(:pull_request,
+    create(:pull_request, :merged,
            repository: repository,
            size: Faker::Number.within(range: 500..600),
            html_url: 'test_pr_url_five',
-           opened_at: wednesday - 26.hours)
-  end
-
-  before do
-    first_pull_request.update!(merged_at: wednesday)
-    second_pull_request.update!(merged_at: wednesday)
-    third_pull_request.update!(merged_at: wednesday)
-    fourth_pull_request.update!(merged_at: wednesday)
-    fifth_pull_request.update!(merged_at: wednesday)
+           opened_at: 26.hours.ago)
   end
 
   context 'With correct params' do

--- a/spec/requests/pull_requests/time_to_merge_prs/index_spec.rb
+++ b/spec/requests/pull_requests/time_to_merge_prs/index_spec.rb
@@ -8,30 +8,24 @@ RSpec.describe 'PullRequests::TimeToMergePrsController' do
   end
 
   let!(:first_ruby_pull_request) do
-    create(:pull_request,
+    create(:pull_request, :merged,
            repository: ruby_repository,
            html_url: 'ruby_pr_url',
            opened_at: Time.zone.now - 6.hours)
   end
 
   let!(:node_pull_request) do
-    create(:pull_request,
+    create(:pull_request, :merged,
            repository: node_repository,
            html_url: 'node_pr_url',
            opened_at: Time.zone.now - 14.hours)
   end
 
   let!(:second_ruby_pull_request) do
-    create(:pull_request,
+    create(:pull_request, :merged,
            repository: ruby_repository,
            html_url: 'ruby_pr_url',
            opened_at: Time.zone.now - 26.hours)
-  end
-
-  before do
-    first_ruby_pull_request.update!(merged_at: Time.zone.now)
-    node_pull_request.update!(merged_at: Time.zone.now)
-    second_ruby_pull_request.update!(merged_at: Time.zone.now)
   end
 
   context 'when lang param is present' do

--- a/spec/requests/pull_requests/time_to_merge_prs_repository/index_spec.rb
+++ b/spec/requests/pull_requests/time_to_merge_prs_repository/index_spec.rb
@@ -4,7 +4,6 @@ RSpec.describe 'PullRequests::TimeToMergePrsRepositoryController' do
   let(:repository) { create(:repository) }
   let(:from) { 4.weeks.ago }
   let(:to) { Time.zone.now }
-  let(:wednesday) { Time.zone.today.last_week(:thursday) }
   let(:subject) do
     get repository_time_to_merge_prs_repository_index_path(
       repository_name: repository.name
@@ -12,30 +11,24 @@ RSpec.describe 'PullRequests::TimeToMergePrsRepositoryController' do
   end
 
   let!(:first_pull_request) do
-    create(:pull_request,
+    create(:pull_request, :merged,
            repository: repository,
            html_url: 'test_pr_url_one',
-           opened_at: wednesday - 6.hours)
+           opened_at: 6.hours.ago)
   end
 
   let!(:second_pull_request) do
-    create(:pull_request,
+    create(:pull_request, :merged,
            repository: repository,
            html_url: 'test_pr_url_two',
-           opened_at: wednesday - 14.hours)
+           opened_at: 14.hours.ago)
   end
 
   let!(:third_pull_request) do
-    create(:pull_request,
+    create(:pull_request, :merged,
            repository: repository,
            html_url: 'test_pr_url_three',
-           opened_at: wednesday - 26.hours)
-  end
-
-  before do
-    first_pull_request.update!(merged_at: wednesday)
-    second_pull_request.update!(merged_at: wednesday)
-    third_pull_request.update!(merged_at: wednesday)
+           opened_at: 26.hours.ago)
   end
 
   context 'With correct params' do

--- a/spec/services/builders/distribution/pull_requests/pull_request_size_repository_spec.rb
+++ b/spec/services/builders/distribution/pull_requests/pull_request_size_repository_spec.rb
@@ -9,28 +9,28 @@ RSpec.describe Builders::Distribution::PullRequests::PullRequestSizeRepository d
     let(:repository_two) { create(:repository) }
 
     let!(:first_pull_request) do
-      create(:pull_request,
+      create(:pull_request, :merged,
              repository: repository_one,
              html_url: 'test_pr_url_one',
              opened_at: 6.hours.ago)
     end
 
     let!(:second_pull_request) do
-      create(:pull_request,
+      create(:pull_request, :merged,
              repository: repository_two,
              html_url: 'test_pr_url_two',
              opened_at: 14.hours.ago)
     end
 
     let!(:third_pull_request) do
-      create(:pull_request,
+      create(:pull_request, :merged,
              repository: repository_one,
              html_url: 'test_pr_url_three',
              opened_at: 26.hours.ago)
     end
 
     let!(:fourth_pull_request) do
-      create(:pull_request,
+      create(:pull_request, :merged,
              repository: repository_one,
              size: Faker::Number.within(range: 0..100),
              html_url: 'test_pr_url_four',
@@ -38,19 +38,11 @@ RSpec.describe Builders::Distribution::PullRequests::PullRequestSizeRepository d
     end
 
     let!(:fifth_pull_request) do
-      create(:pull_request,
+      create(:pull_request, :merged,
              repository: repository_two,
              size: Faker::Number.within(range: 100..200),
              html_url: 'test_pr_url_five',
              opened_at: 15.hours.ago)
-    end
-
-    before do
-      first_pull_request.update!(merged_at: Time.zone.now)
-      second_pull_request.update!(merged_at: Time.zone.now)
-      third_pull_request.update!(merged_at: Time.zone.now)
-      fourth_pull_request.update!(merged_at: Time.zone.now)
-      fifth_pull_request.update!(merged_at: Time.zone.now)
     end
 
     context 'with correct params' do
@@ -95,12 +87,11 @@ RSpec.describe Builders::Distribution::PullRequests::PullRequestSizeRepository d
 
     context 'when pull request has html_url attribute nil' do
       let!(:pull_request_html_url_nil) do
-        create(:pull_request,
+        create(:pull_request, :merged,
                repository: repository_one,
                size: Faker::Number.within(range: 700..800),
                html_url: nil,
-               opened_at: 40.hours.ago,
-               merged_at: Time.zone.now)
+               opened_at: 40.hours.ago)
       end
 
       subject do
@@ -118,11 +109,10 @@ RSpec.describe Builders::Distribution::PullRequests::PullRequestSizeRepository d
 
     context 'when pull request has size attribute nil' do
       let!(:pull_request_html_url_nil) do
-        create(:pull_request,
+        create(:pull_request, :merged,
                repository: repository_one,
                size: nil,
-               opened_at: 40.hours.ago,
-               merged_at: Time.zone.now)
+               opened_at: 40.hours.ago)
       end
 
       subject do

--- a/spec/services/builders/distribution/pull_requests/time_to_merge_repository_spec.rb
+++ b/spec/services/builders/distribution/pull_requests/time_to_merge_repository_spec.rb
@@ -9,30 +9,24 @@ RSpec.describe Builders::Distribution::PullRequests::TimeToMergeRepository do
     let(:repository_two) { create(:repository) }
 
     let!(:first_pull_request) do
-      create(:pull_request,
+      create(:pull_request, :merged,
              repository: repository_one,
              html_url: 'test_pr_url_one',
              opened_at: 6.hours.ago)
     end
 
     let!(:second_pull_request) do
-      create(:pull_request,
+      create(:pull_request, :merged,
              repository: repository_two,
              html_url: 'test_pr_url_two',
              opened_at: 14.hours.ago)
     end
 
     let!(:third_pull_request) do
-      create(:pull_request,
+      create(:pull_request, :merged,
              repository: repository_one,
              html_url: 'test_pr_url_three',
              opened_at: 26.hours.ago)
-    end
-
-    before do
-      first_pull_request.update!(merged_at: Time.zone.now)
-      second_pull_request.update!(merged_at: Time.zone.now)
-      third_pull_request.update!(merged_at: Time.zone.now)
     end
 
     context 'with correct params' do
@@ -59,11 +53,10 @@ RSpec.describe Builders::Distribution::PullRequests::TimeToMergeRepository do
 
     context 'when pull request has html_url attribute nil' do
       let!(:pull_request_html_url_nil) do
-        create(:pull_request,
+        create(:pull_request, :merged,
                repository: repository_one,
                html_url: nil,
-               opened_at: 40.hours.ago,
-               merged_at: Time.zone.now)
+               opened_at: 40.hours.ago)
       end
 
       subject do

--- a/spec/services/builders/distribution/pull_requests/time_to_merge_spec.rb
+++ b/spec/services/builders/distribution/pull_requests/time_to_merge_spec.rb
@@ -8,19 +8,19 @@ RSpec.describe Builders::Distribution::PullRequests::TimeToMerge do
     let(:node_repository) { create(:repository, language: Language.find_by(name: 'nodejs')) }
 
     let!(:first_ruby_pull_request) do
-      create(:pull_request,
+      create(:pull_request, :merged,
              repository: ruby_repository,
              opened_at: 6.hours.ago)
     end
 
     let!(:node_pull_request) do
-      create(:pull_request,
+      create(:pull_request, :merged,
              repository: node_repository,
              opened_at: 14.hours.ago)
     end
 
     let!(:second_ruby_pull_request) do
-      create(:pull_request,
+      create(:pull_request, :merged,
              repository: ruby_repository,
              opened_at: 26.hours.ago)
     end
@@ -32,12 +32,6 @@ RSpec.describe Builders::Distribution::PullRequests::TimeToMerge do
           from: 4,
           languages: []
         )
-      end
-
-      before do
-        first_ruby_pull_request.update!(merged_at: Time.zone.now)
-        node_pull_request.update!(merged_at: Time.zone.now)
-        second_ruby_pull_request.update!(merged_at: Time.zone.now)
       end
 
       it 'returns data for 1-12 hours' do
@@ -60,12 +54,6 @@ RSpec.describe Builders::Distribution::PullRequests::TimeToMerge do
         )
       end
 
-      before do
-        first_ruby_pull_request.update!(merged_at: Time.zone.now)
-        node_pull_request.update!(merged_at: Time.zone.now)
-        second_ruby_pull_request.update!(merged_at: Time.zone.now)
-      end
-
       it 'returns data for 1-12 hours' do
         expect(subject).to have_key('1-12')
       end
@@ -81,17 +69,10 @@ RSpec.describe Builders::Distribution::PullRequests::TimeToMerge do
 
     context 'when pull request has html_url attribute nil' do
       let!(:third_ruby_pull_request_html_url_nil) do
-        create(:pull_request,
+        create(:pull_request, :merged,
                repository: ruby_repository,
                html_url: nil,
                opened_at: 40.hours.ago)
-      end
-
-      before do
-        first_ruby_pull_request.update!(merged_at: Time.zone.now)
-        node_pull_request.update!(merged_at: Time.zone.now)
-        second_ruby_pull_request.update!(merged_at: Time.zone.now)
-        third_ruby_pull_request_html_url_nil.update!(merged_at: Time.zone.now)
       end
 
       subject do

--- a/spec/services/builders/review_coverage_spec.rb
+++ b/spec/services/builders/review_coverage_spec.rb
@@ -9,9 +9,9 @@ RSpec.describe Builders::ReviewCoverage do
 
     before do
       allow(GithubClient::PullRequest).to receive(:new).with(pull_request).and_return(github_client)
-      allow(github_client).to receive(:files).and_return(Array.new(total_files))
-      allow(github_client).to receive(:comments).and_return(
-        Array.new(files_with_comments) { { path: "file#{_1}.rb" } }
+      allow(github_client).to receive_messages(
+        files: Array.new(total_files),
+        comments: Array.new(files_with_comments) { { path: "file#{_1}.rb" } }
       )
     end
 
@@ -39,4 +39,4 @@ RSpec.describe Builders::ReviewCoverage do
       end
     end
   end
-end 
+end

--- a/spec/services/builders/review_coverage_spec.rb
+++ b/spec/services/builders/review_coverage_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.describe Builders::ReviewCoverage do
+  describe '.call' do
+    let(:pull_request) { create(:pull_request) }
+    let(:total_files) { 10 }
+    let(:files_with_comments) { 5 }
+    let(:github_client) { instance_double(GithubClient::PullRequest) }
+
+    before do
+      allow(GithubClient::PullRequest).to receive(:new).with(pull_request).and_return(github_client)
+      allow(github_client).to receive(:files).and_return(Array.new(total_files))
+      allow(github_client).to receive(:comments).and_return(
+        Array.new(files_with_comments) { { path: "file#{_1}.rb" } }
+      )
+    end
+
+    subject { described_class.call(pull_request) }
+
+    it 'creates a new review coverage' do
+      expect { subject }.to change(ReviewCoverage, :count).by(1)
+    end
+
+    it 'creates it with the correct attributes' do
+      review_coverage = subject
+      expect(review_coverage.pull_request).to eq(pull_request)
+      expect(review_coverage.total_files_changed).to eq(total_files)
+      expect(review_coverage.files_with_comments_count).to eq(files_with_comments)
+      expect(review_coverage.coverage_percentage).to eq(0.5)
+    end
+
+    context 'when the pull request has no comments' do
+      let(:files_with_comments) { 0 }
+
+      it 'creates a review coverage with zero coverage' do
+        review_coverage = subject
+        expect(review_coverage.files_with_comments_count).to eq(0)
+        expect(review_coverage.coverage_percentage).to eq(0)
+      end
+    end
+  end
+end 

--- a/spec/services/github_service_spec.rb
+++ b/spec/services/github_service_spec.rb
@@ -48,8 +48,16 @@ RSpec.describe GithubService do
         context 'and the pull request is merged' do
           let(:merged) { true }
 
+          before do
+            allow_any_instance_of(GithubClient::PullRequest).to receive(:comments).and_return([])
+          end
+
           it 'sets state merged' do
             expect { subject }.to change { pull_request.reload.merged_at }.from(nil).to(Time)
+          end
+
+          it 'creates a review coverage' do
+            expect { subject }.to change { pull_request.reload.review_coverage }.to be_present
           end
         end
 

--- a/spec/support/shared_examples/merge_time_distribution_data.rb
+++ b/spec/support/shared_examples/merge_time_distribution_data.rb
@@ -8,8 +8,7 @@ RSpec.shared_examples 'merge time data distribution' do
   context 'when name is merge time' do
     before do
       values_in_seconds.each do |value|
-        pull_request = create(:pull_request, repository: repository, merged_at: Time.zone.now)
-        create(:merge_time, pull_request: pull_request, value: value)
+        create(:pull_request, :merged, repository: repository, merge_time: value)
       end
       query.merge!(name: :merge_time)
     end
@@ -39,8 +38,8 @@ RSpec.shared_examples 'merge time data distribution' do
     context 'when there are pull requests merged outside of the requested period' do
       before do
         old_timestamp = range.first.yesterday
-        pull_request = create(:pull_request, repository: repository, merged_at: old_timestamp)
-        create(:merge_time, pull_request: pull_request, value: 90_000)
+        create(:pull_request, :merged, repository: repository, merged_at: old_timestamp,
+                                       merge_time: 90_000)
       end
 
       it 'does not count them' do

--- a/spec/tasks/review_coverage_backfill_spec.rb
+++ b/spec/tasks/review_coverage_backfill_spec.rb
@@ -14,8 +14,7 @@ RSpec.describe 'review_coverage:backfill' do
     load 'lib/tasks/review_coverage_backfill.rake'
 
     allow(GithubClient::PullRequest).to receive(:new).with(merged_pr).and_return(github_client)
-    allow(github_client).to receive(:files).and_return(["file1.rb"])
-    allow(github_client).to receive(:comments).and_return([{ path: "file1.rb" }])
+    allow(github_client).to receive_messages(files: ['file1.rb'], comments: [{ path: 'file1.rb' }])
   end
 
   it 'processes merged pull requests' do
@@ -29,4 +28,4 @@ RSpec.describe 'review_coverage:backfill' do
       expect { subject }.to change { ReviewCoverage.count }.by(1)
     end
   end
-end 
+end

--- a/spec/tasks/review_coverage_backfill_spec.rb
+++ b/spec/tasks/review_coverage_backfill_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+require 'rake'
+
+RSpec.describe 'review_coverage:backfill' do
+  subject { rake['review_coverage:backfill'].invoke }
+
+  let(:rake) { Rake::Application.new }
+  let!(:merged_pr) { create(:pull_request, merged_at: Time.current) }
+  let(:github_client) { instance_double(GithubClient::PullRequest) }
+
+  before do
+    Rake.application = rake
+    Rake::Task.define_task(:environment)
+    load 'lib/tasks/review_coverage_backfill.rake'
+
+    allow(GithubClient::PullRequest).to receive(:new).with(merged_pr).and_return(github_client)
+    allow(github_client).to receive(:files).and_return(["file1.rb"])
+    allow(github_client).to receive(:comments).and_return([{ path: "file1.rb" }])
+  end
+
+  it 'processes merged pull requests' do
+    expect { subject }.to change { ReviewCoverage.count }.by(1)
+  end
+
+  context 'when there is a not merged pull request' do
+    let!(:unmerged_pr) { create(:pull_request, merged_at: nil) }
+
+    it 'does not process unmerged pull requests' do
+      expect { subject }.to change { ReviewCoverage.count }.by(1)
+    end
+  end
+end 

--- a/spec/tasks/review_coverage_backfill_spec.rb
+++ b/spec/tasks/review_coverage_backfill_spec.rb
@@ -1,6 +1,7 @@
 require 'rails_helper'
 require 'rake'
 
+# rubocop:disable RSpec/DescribeClass
 RSpec.describe 'review_coverage:backfill' do
   subject { rake['review_coverage:backfill'].invoke }
 
@@ -29,3 +30,4 @@ RSpec.describe 'review_coverage:backfill' do
     end
   end
 end
+# rubocop:enable RSpec/DescribeClass


### PR DESCRIPTION
## What does this PR do?
This PR introduces a new code review metric that measures the percentage of files in a pull request that have received comments during the review process.

#### Changes

- Add ReviewCoverage model with associations and validations
- Create necessary database migrations and schema updates
- Extend GithubClient to fetch PR comments
- Modify PullRequest model to build review coverage metrics upon merge
- Add new tests and adjust existent ones.
- Implement backfill rake task for existing merged PRs
