### PR TITLE
Review coverage dashboard

### DIFF
--- a/app/controllers/development_metrics_controller.rb
+++ b/app/controllers/development_metrics_controller.rb
@@ -52,6 +52,7 @@ class DevelopmentMetricsController < ApplicationController
     @merge_time_success_rate = merge_time[:success_rate]
     @merge_time_avg = merge_time[:avg]
     @pull_request_size_avg = @pull_request_size[key].first[:avg]
+    @review_coverage_avg = @review_coverage[key].first[:avg]
   end
 
   def build_metrics(entity_id, entity_name)
@@ -60,6 +61,7 @@ class DevelopmentMetricsController < ApplicationController
                                                      .call(entity_id, @from, @to)
     @merge_time = metrics[:merge_time]
     @pull_request_size = metrics[:pull_request_size]
+    @review_coverage = metrics[:review_coverage]
   end
 
   def build_product_metrics(entity_id, entity_name)
@@ -84,6 +86,7 @@ class DevelopmentMetricsController < ApplicationController
     @review_turnaround_definition = MetricDefinition.find_by(code: :review_turnaround)
     @merge_time_definition = MetricDefinition.find_by(code: :merge_time)
     @pull_request_size_definition = MetricDefinition.find_by(code: :pull_request_size)
+    @review_coverage_definition = MetricDefinition.find_by(code: :review_coverage)
   end
 
   def set_metrics_to_show

--- a/app/controllers/development_metrics_controller.rb
+++ b/app/controllers/development_metrics_controller.rb
@@ -52,7 +52,7 @@ class DevelopmentMetricsController < ApplicationController
     @merge_time_success_rate = merge_time[:success_rate]
     @merge_time_avg = merge_time[:avg]
     @pull_request_size_avg = @pull_request_size[key].first[:avg]
-    @review_coverage_avg = @review_coverage[key].first[:avg]
+    @review_coverage_avg = @review_coverage[key].first[:avg] if @review_coverage.present?
   end
 
   def build_metrics(entity_id, entity_name)

--- a/app/controllers/pull_requests/review_coverage_prs_repository_controller.rb
+++ b/app/controllers/pull_requests/review_coverage_prs_repository_controller.rb
@@ -1,0 +1,7 @@
+module PullRequests
+  class ReviewCoveragePrsRepositoryController < PullRequestsController
+    def repository
+      Builders::Distribution::PullRequests::ReviewCoverageRepository
+    end
+  end
+end

--- a/app/helpers/modal_see_detail_helper.rb
+++ b/app/helpers/modal_see_detail_helper.rb
@@ -14,6 +14,10 @@ module ModalSeeDetailHelper
       'pull-request-size': {
         url: repository_pull_request_size_prs_repository_index_path(repository_name, metrics),
         metric: 'lines'
+      },
+      'review-coverage': {
+        url: repository_review_coverage_prs_repository_index_path(repository_name, metrics),
+        metric: '%'
       }
     }
 

--- a/app/services/builders/chartkick/development_metrics.rb
+++ b/app/services/builders/chartkick/development_metrics.rb
@@ -71,7 +71,8 @@ module Builders
           metrics = {
             review_turnaround: %w[repository users_repository repository_distribution],
             merge_time: %w[repository users_repository repository_distribution],
-            pull_request_size: %w[repository_distribution]
+            pull_request_size: %w[repository_distribution],
+            review_coverage: %w[repository repository_distribution]
           }
           metrics
         end

--- a/app/services/builders/chartkick/repository_distribution_data_metrics/review_coverage.rb
+++ b/app/services/builders/chartkick/repository_distribution_data_metrics/review_coverage.rb
@@ -1,0 +1,23 @@
+module Builders
+  module Chartkick
+    module RepositoryDistributionDataMetrics
+      class ReviewCoverage
+        def retrieve_records(entity_id:, time_range:)
+          ::ReviewCoverage
+            .joins(pull_request: :repository)
+            .where(repositories: { id: entity_id })
+            .where(events_pull_requests: { merged_at: time_range })
+            .where.not(events_pull_requests: { owner: User.ignored_users })
+        end
+
+        def resolve_interval(entity)
+          Metrics::IntervalResolver::Percentage.call(entity.coverage_percentage * 100)
+        end
+
+        def value_for_average(entity)
+          entity.coverage_percentage * 100
+        end
+      end
+    end
+  end
+end

--- a/app/services/builders/distribution/pull_requests/pull_request_size_repository.rb
+++ b/app/services/builders/distribution/pull_requests/pull_request_size_repository.rb
@@ -26,6 +26,7 @@ module Builders
                                              .where.not(
                                                events_pull_requests: { html_url: nil }
                                              )
+                                             .where.not(owner: User.ignored_users)
                                              .where.not(size: nil)
                                              .order(:size)
         end

--- a/app/services/builders/distribution/pull_requests/review_coverage_repository.rb
+++ b/app/services/builders/distribution/pull_requests/review_coverage_repository.rb
@@ -24,6 +24,7 @@ module Builders
                                 .joins(pull_request: :repository)
                                 .where(repositories: { name: @repository_name })
                                 .where(pull_request: { merged_at: @from..@to })
+                                .where.not(pull_request: { owner: User.ignored_users })
                                 .order(:coverage_percentage)
         end
 

--- a/app/services/builders/distribution/pull_requests/review_coverage_repository.rb
+++ b/app/services/builders/distribution/pull_requests/review_coverage_repository.rb
@@ -1,0 +1,36 @@
+module Builders
+  module Distribution
+    module PullRequests
+      class ReviewCoverageRepository < BaseService
+        def initialize(repository_name:, from:, to:)
+          @repository_name = repository_name
+          @from = from.to_datetime.beginning_of_day
+          @to = to.to_datetime.end_of_day
+        end
+
+        def call
+          review_coverages.each_with_object(hash_of_arrays) { |review_coverage, hash|
+            coverage = review_coverage.coverage_percentage * 100
+            interval = Metrics::IntervalResolver::Percentage.call(coverage)
+            pr_values = { html_url: review_coverage.pull_request.html_url, value: coverage }
+            hash[interval] << pr_values
+          }.sort.to_h
+        end
+
+        private
+
+        def review_coverages
+          @review_coverages ||= ::ReviewCoverage
+                                .joins(pull_request: :repository)
+                                .where(repositories: { name: @repository_name })
+                                .where(pull_request: { merged_at: @from..@to })
+                                .order(:coverage_percentage)
+        end
+
+        def hash_of_arrays
+          Hash.new { |hash, key| hash[key] = [] }
+        end
+      end
+    end
+  end
+end

--- a/app/services/builders/distribution/pull_requests/time_to_merge_repository.rb
+++ b/app/services/builders/distribution/pull_requests/time_to_merge_repository.rb
@@ -24,6 +24,9 @@ module Builders
                                       .joins(pull_request: :repository)
                                       .where(repositories: { name: @repository_name })
                                       .where.not(events_pull_requests: { html_url: nil })
+                                      .where.not(
+                                        events_pull_requests: { owner: User.ignored_users }
+                                      )
                                       .includes(:pull_request)
                                       .order(:value)
         end

--- a/app/services/metrics/interval_resolver/percentage.rb
+++ b/app/services/metrics/interval_resolver/percentage.rb
@@ -1,0 +1,9 @@
+module Metrics
+  module IntervalResolver
+    class Percentage < Metrics::IntervalResolver::Base
+      def ranges
+        { '0-10': 10, '10-20': 20, '20-40': 40, '40-60': 60, '60-80': 80 }
+      end
+    end
+  end
+end

--- a/app/services/metrics/review_coverage/per_repository.rb
+++ b/app/services/metrics/review_coverage/per_repository.rb
@@ -13,7 +13,7 @@ module Metrics
       end
 
       def query(interval)
-        Repository.joins(pull_requests: :review_requests)
+        Repository.joins(pull_requests: :review_coverage)
                   .where(events_pull_requests: { merged_at: interval })
                   .where(id: @entity_id)
                   .group(:id)

--- a/app/services/metrics/review_coverage/per_repository.rb
+++ b/app/services/metrics/review_coverage/per_repository.rb
@@ -1,0 +1,24 @@
+module Metrics
+  module ReviewCoverage
+    class PerRepository < Metrics::Base
+      private
+
+      def process
+        week_intervals.flat_map do |week|
+          interval = build_interval(week)
+          query(interval).map do |repository_id, metric_value|
+            Metric.new(repository_id, interval.first, metric_value)
+          end
+        end
+      end
+
+      def query(interval)
+        Repository.joins(pull_requests: :review_requests)
+                  .where(events_pull_requests: { merged_at: interval })
+                  .where(id: @entity_id)
+                  .group(:id)
+                  .pluck(:id, Arel.sql('AVG(review_coverages.coverage_percentage)'))
+      end
+    end
+  end
+end

--- a/app/views/development_metrics/repositories.erb
+++ b/app/views/development_metrics/repositories.erb
@@ -3,6 +3,7 @@
     review_turnaround_presenter = RepositoryMetricPresenter.new(@review_turnaround, @review_turnaround_definition)
     merge_time_presenter = RepositoryMetricPresenter.new(@merge_time, @merge_time_definition)
     pull_request_size_presenter = RepositoryMetricPresenter.new(@pull_request_size, @pull_request_size_definition)
+    review_coverage_presenter = RepositoryMetricPresenter.new(@review_coverage, @review_coverage_definition)
   %>
 
   <div class="metrics-container">
@@ -103,13 +104,51 @@
               <% end %>
             </div>
           </div>
-        <div class="col-md-1">
-          <div class="distribution-report-button mr-5">
-            <%= link_to 'See details',
+          <div class="col-md-1">
+            <div class="distribution-report-button mr-5">
+              <%= link_to 'See details',
                         repository_pull_request_size_prs_repository_index_path(@repository.name, { metric: { from: params&.dig(:metric, :from), to: params&.dig(:metric, :to) }}),
                         class: 'btn btn-detail' if pull_request_size_presenter.per_repository_distribution_has_data_to_display?
-            %>
+              %>
             </div>
+          </div>
+        </div>
+      </div>
+      <div class="metrics">
+        <div class='row'>
+          <div class="col-md-11">
+            <div class="box-title" >
+              <%= review_coverage_presenter.metric_name %>
+              <span data-placement='right' class='metric_tooltip' aria-hidden='true' data-toggle='tooltip' title='<%= review_coverage_presenter.metric_explanation %>'>¡</span>
+            </div>
+            <div class="box-title" >
+              <% if @review_coverage_avg.present? %>
+                <span class="badge badge-info success_rate_btn">
+                  Average: <%= @review_coverage_avg[:avg_number] %>%
+                </span>
+                <span class="badge badge-info success_rate_btn">
+                  Total: <%= @review_coverage_avg[:total] %> PRs (bots excluded)
+                </span>
+              <% end %>
+            </div>
+            <div class="graph">
+              <% if review_coverage_presenter.per_repository_distribution_has_data_to_display? %>
+                <%= render 'development_metrics/review_coverage/main_metric', review_coverage: review_coverage_presenter.metric %>
+              <% else %>
+                <div class="p-3 text-center">
+                  <span class="text-danger extra-padding"><h5>No data to display for the selected period</h5></span>
+                </div>
+              <% end %>
+            </div>
+          </div>
+          <div class="col-md-1">
+            <div class="distribution-report-button mr-5">
+              <%= link_to 'See details',
+                          repository_review_coverage_prs_repository_index_path(@repository.name, { metric: { from: params&.dig(:metric, :from), to: params&.dig(:metric, :to) }}),
+                          class: 'btn btn-detail' if review_coverage_presenter.per_repository_distribution_has_data_to_display?
+              %>
+            </div>
+          </div>
         </div>
       </div>
     <% else %>

--- a/app/views/development_metrics/review_coverage/_main_metric.erb
+++ b/app/views/development_metrics/review_coverage/_main_metric.erb
@@ -1,0 +1,7 @@
+<%= render partial: 'shared/column-chart',
+           locals: {
+             chart_id: 'review-coverage',
+             metric_name: 'Distribution',
+             suffix: " pull requests",
+             metric: review_coverage[:per_repository_distribution]
+           } if review_coverage && review_coverage[:per_repository_distribution] %> 

--- a/app/views/development_metrics/review_coverage/_main_metric.erb
+++ b/app/views/development_metrics/review_coverage/_main_metric.erb
@@ -4,4 +4,4 @@
              metric_name: 'Distribution',
              suffix: " pull requests",
              metric: review_coverage[:per_repository_distribution]
-           } if review_coverage && review_coverage[:per_repository_distribution] %> 
+           } if review_coverage && review_coverage[:per_repository_distribution] %>

--- a/app/views/pull_requests/review_coverage_prs_repository/index.erb
+++ b/app/views/pull_requests/review_coverage_prs_repository/index.erb
@@ -14,4 +14,4 @@
     </div>
   </div>
   <%= render partial: 'shared/pull_request_list' , locals: { pull_requests: @pull_requests, kpi_label: '%' } %>
-</div> 
+</div>

--- a/app/views/pull_requests/review_coverage_prs_repository/index.erb
+++ b/app/views/pull_requests/review_coverage_prs_repository/index.erb
@@ -1,0 +1,17 @@
+<%= render 'development_metrics/development_metrics_sidebar', enabled_users_section: @enabled_users_section %>
+<div class="metrics-container">
+  <div class="row title_sidebar">
+    <div class="col-md-6">
+      <b class="rute_title_grey"><%= @repository_name %>/</b>
+      <b class="rute_title">Review Coverage</b>
+    </div>
+    <div class="col-md-6 interval d-flex flex-row-reverse">
+      <%= simple_form_for :metric, url: repository_review_coverage_prs_repository_index_path, method: 'GET', html: {
+                                                      id: 'nav-filter-form', style:"display: flex;"} do |f|%>
+          <%= hidden_field_tag 'repository_name', @repository_name %>
+          <%= render 'shared/interval-filter', form: f %>
+        <% end %>
+    </div>
+  </div>
+  <%= render partial: 'shared/pull_request_list' , locals: { pull_requests: @pull_requests, kpi_label: '%' } %>
+</div> 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,7 @@ Rails.application.routes.draw do
         resources :time_to_merge_prs_repository, only: :index, module: :pull_requests
         resources :time_to_second_review_prs_repository, only: :index, module: :pull_requests
         resources :pull_request_size_prs_repository, only: :index, module: :pull_requests
+        resources :review_coverage_prs_repository, only: :index, module: :pull_requests
       end
       resources :users, only: [] do
         resources :repositories, only: :index, controller: 'users/repositories'

--- a/spec/controllers/development_metrics_controller_spec.rb
+++ b/spec/controllers/development_metrics_controller_spec.rb
@@ -229,6 +229,17 @@ describe DevelopmentMetricsController, type: :controller do
           end
         end
       end
+
+      context '#departments' do
+        before { params[:department_name] = repository.language.department.name }
+
+        it 'calls CodeClimate summary retriever class' do
+          expect(CodeClimate::RepositoriesSummaryService)
+            .to receive(:call).and_return(code_climate_metric)
+
+          get :departments, params: params
+        end
+      end
     end
   end
 end

--- a/spec/controllers/development_metrics_controller_spec.rb
+++ b/spec/controllers/development_metrics_controller_spec.rb
@@ -18,6 +18,9 @@ describe DevelopmentMetricsController, type: :controller do
   let!(:pull_request_size_metric_definition) do
     create(:metric_definition, code: :pull_request_size)
   end
+  let!(:review_coverage_metric_definition) do
+    create(:metric_definition, code: :review_coverage)
+  end
 
   describe '#index' do
     context 'when metric params are empty' do
@@ -219,17 +222,11 @@ describe DevelopmentMetricsController, type: :controller do
             subject
             expect(response.body).to include(pull_request_size_metric_definition.explanation)
           end
-        end
-      end
 
-      context '#departments' do
-        before { params[:department_name] = repository.language.department.name }
-
-        it 'calls CodeClimate summary retriever class' do
-          expect(CodeClimate::RepositoriesSummaryService)
-            .to receive(:call).and_return(code_climate_metric)
-
-          get :departments, params: params
+          it 'render review coverage metric tooltip' do
+            subject
+            expect(response.body).to include(review_coverage_metric_definition.explanation)
+          end
         end
       end
     end

--- a/spec/factories/events/pull_requests.rb
+++ b/spec/factories/events/pull_requests.rb
@@ -47,7 +47,7 @@ FactoryBot.define do
     size { Faker::Number.within(range: 0..10_000) }
     state { 'open' }
     html_url { 'https://github.com/Codertocat/Hello-World/pull/2' }
-    opened_at { Faker::Date.between(from: 1.month.ago, to: Time.zone.now) }
+    opened_at { Faker::Time.between(from: 1.month.ago, to: Time.zone.now) }
     locked { false }
     draft { false }
     repository

--- a/spec/services/builders/distribution/pull_requests/review_coverage_repository_spec.rb
+++ b/spec/services/builders/distribution/pull_requests/review_coverage_repository_spec.rb
@@ -1,0 +1,114 @@
+require 'rails_helper'
+
+RSpec.describe Builders::Distribution::PullRequests::ReviewCoverageRepository do
+  describe '.call' do
+    let(:from) { 4.weeks.ago }
+    let(:to) { Time.zone.now }
+    let(:repository_one) { create(:repository) }
+    let(:repository_two) { create(:repository) }
+
+    let!(:first_pull_request) do
+      create(:pull_request, :merged,
+             repository: repository_one,
+             html_url: 'test_pr_url_one',
+             merged_at: 6.hours.ago)
+    end
+
+    let!(:second_pull_request) do
+      create(:pull_request, :merged,
+             repository: repository_two,
+             html_url: 'test_pr_url_two',
+             merged_at: 14.hours.ago)
+    end
+
+    let!(:third_pull_request) do
+      create(:pull_request, :merged,
+             repository: repository_one,
+             html_url: 'test_pr_url_three',
+             merged_at: 26.hours.ago)
+    end
+
+    before do
+      first_pull_request.review_coverage.update!(coverage_percentage: 0.25)
+      second_pull_request.review_coverage.update!(coverage_percentage: 0.75)
+      third_pull_request.review_coverage.update!(coverage_percentage: 0.50)
+    end
+
+    context 'with correct params' do
+      subject do
+        described_class.call(
+          repository_name: repository_one.name,
+          from: from,
+          to: to
+        )
+      end
+
+      it 'returns data for 0-25% coverage' do
+        expect(subject).to have_key('20-40')
+        expect(subject['20-40'].first[:value]).to eq(25.0)
+      end
+
+      it 'returns data for 50-75% coverage' do
+        expect(subject).to have_key('40-60')
+        expect(subject['40-60'].first[:value]).to eq(50.0)
+      end
+
+      it 'does not return data for 25-50% coverage' do
+        expect(subject).not_to have_key('10-20')
+      end
+    end
+
+    context 'when pull request has html_url attribute nil' do
+      let!(:pull_request_html_url_nil) do
+        create(:pull_request, :merged,
+               repository: repository_one,
+               html_url: nil,
+               merged_at: 40.hours.ago)
+      end
+
+      before do
+        pull_request_html_url_nil.review_coverage.update!(coverage_percentage: 0.90)
+      end
+
+      subject do
+        described_class.call(
+          repository_name: repository_one.name,
+          from: from,
+          to: to
+        )
+      end
+
+      it 'does not add the pull request to the data' do
+        expect(subject).not_to have_key('60-80')
+      end
+    end
+
+    context 'when pull request belongs to ignored user' do
+      let(:ignored_user) { create(:user, login: 'ignored_user') }
+      let!(:setting) { create(:setting, key: 'ignored_users', value: ignored_user.login) }
+
+      let!(:ignored_pull_request) do
+        create(:pull_request, :merged,
+               repository: repository_one,
+               merged_at: 6.hours.ago,
+               owner: ignored_user)
+      end
+
+      before do
+        ignored_pull_request.review_coverage.update!(coverage_percentage: 0.25)
+      end
+
+      subject do
+        described_class.call(
+          repository_name: repository_one.name,
+          from: from,
+          to: to
+        )
+      end
+
+      it 'does not include pull requests from ignored users' do
+        expect(subject['20-40'].pluck(:html_url)).not_to include('ignored_pr_url')
+      end
+    end
+  end
+end

--- a/spec/services/builders/distribution/pull_requests/review_coverage_repository_spec.rb
+++ b/spec/services/builders/distribution/pull_requests/review_coverage_repository_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe Builders::Distribution::PullRequests::ReviewCoverageRepository do
       end
 
       it 'does not include pull requests from ignored users' do
-        expect(subject['20-40'].pluck(:html_url)).not_to include('ignored_pr_url')
+        expect(subject['20-40'].pluck(:html_url)).not_to include(ignored_pull_request.html_url)
       end
     end
   end

--- a/spec/services/metrics/review_coverage/per_repository_spec.rb
+++ b/spec/services/metrics/review_coverage/per_repository_spec.rb
@@ -1,0 +1,66 @@
+require 'rails_helper'
+
+RSpec.describe Metrics::ReviewCoverage::PerRepository do
+  describe '.call' do
+    let(:subject) { described_class.call(repository.id) }
+    let(:repository) { create(:repository) }
+    let(:beginning_of_day) { Time.zone.today.beginning_of_day }
+    let(:entity_type) { 'Repository' }
+    let(:metric_name) { :review_coverage }
+
+    context 'when there is available data' do
+      before do
+        pull_request1 = create(
+          :pull_request,
+          :merged,
+          repository: repository,
+          merged_at: beginning_of_day + 1.hour
+        )
+        pull_request2 = create(
+          :pull_request,
+          :merged,
+          repository: repository,
+          merged_at: beginning_of_day + 3.hours
+        )
+        pull_request1.review_coverage.update!(coverage_percentage: 80.0)
+        pull_request2.review_coverage.update!(coverage_percentage: 90.0)
+      end
+
+      it 'returns the metric' do
+        metrics = subject
+        expect(metrics.count).to eq 1
+      end
+
+      it 'returns the average value' do
+        metric = subject.first
+        expect(metric.value).to eq 85.0
+      end
+
+      context 'when interval is set' do
+        let(:interval) { 4.weeks.ago.beginning_of_week..Time.current.end_of_week }
+        let(:subject) { described_class.call(repository.id, interval) }
+
+        before do
+          pull_request = create(
+            :pull_request,
+            :merged,
+            repository: repository,
+            merged_at: 5.weeks.ago
+          )
+          pull_request.review_coverage.update!(coverage_percentage: 85.0)
+        end
+
+        it 'does not change metric value' do
+          metric = subject.first
+          expect(metric.value).to eq 85.0
+        end
+      end
+    end
+
+    context 'when no data is available' do
+      it 'returns no metrics' do
+        expect(subject).to be_empty
+      end
+    end
+  end
+end

--- a/spec/services/metrics/review_coverage/per_repository_spec.rb
+++ b/spec/services/metrics/review_coverage/per_repository_spec.rb
@@ -2,7 +2,8 @@ require 'rails_helper'
 
 RSpec.describe Metrics::ReviewCoverage::PerRepository do
   describe '.call' do
-    let(:subject) { described_class.call(repository.id) }
+    subject { described_class.call(repository.id) }
+
     let(:repository) { create(:repository) }
     let(:beginning_of_day) { Time.zone.today.beginning_of_day }
     let(:entity_type) { 'Repository' }
@@ -37,8 +38,9 @@ RSpec.describe Metrics::ReviewCoverage::PerRepository do
       end
 
       context 'when interval is set' do
+        subject { described_class.call(repository.id, interval) }
+
         let(:interval) { 4.weeks.ago.beginning_of_week..Time.current.end_of_week }
-        let(:subject) { described_class.call(repository.id, interval) }
 
         before do
           pull_request = create(
@@ -50,7 +52,7 @@ RSpec.describe Metrics::ReviewCoverage::PerRepository do
           pull_request.review_coverage.update!(coverage_percentage: 85.0)
         end
 
-        it 'does not change metric value' do
+        it 'returns the average value correctly' do
           metric = subject.first
           expect(metric.value).to eq 85.0
         end


### PR DESCRIPTION
## Add Review Coverage Metric to Dashboard

This PR introduces a new metric to the development dashboard: Review Coverage. This feature follows the existing pattern and architecture used for other metrics in the system (review turnaround, merge time, pull request size).

### Changes include:

- Added Review Coverage metric to repository dashboard
- Created review coverage controllers, services, and views following the same patterns used by existing metrics
- Implemented percentage interval resolver for displaying coverage data in appropriate ranges
- Added repository distribution visualization for the new metric
- Extended modal helpers and routes configuration to support the new metric details view
- Built repository-specific PR list view for detailed analysis

The implementation leverages the existing metrics infrastructure, maintaining consistency in how metrics are collected, calculated, and displayed throughout the application.

![Screenshot 2025-05-21 at 6 31 25 PM](https://github.com/user-attachments/assets/ef0e6a74-904d-4f12-bfd6-78c308ee1789)
![Screenshot 2025-05-21 at 6 31 35 PM](https://github.com/user-attachments/assets/b897c779-7799-457b-86fb-6ba0c6426951)


