### PR TITLE
Fix Review Coverage when the PR has no files

### DIFF
--- a/app/services/builders/review_coverage.rb
+++ b/app/services/builders/review_coverage.rb
@@ -25,6 +25,8 @@ module Builders
     end
 
     def coverage_percentage
+      return 0 if total_files.zero?
+      
       (files_with_comments_count.to_f / total_files).round(2)
     end
 

--- a/app/services/builders/review_coverage.rb
+++ b/app/services/builders/review_coverage.rb
@@ -26,7 +26,7 @@ module Builders
 
     def coverage_percentage
       return 0 if total_files.zero?
-      
+
       (files_with_comments_count.to_f / total_files).round(2)
     end
 

--- a/spec/services/builders/review_coverage_spec.rb
+++ b/spec/services/builders/review_coverage_spec.rb
@@ -38,5 +38,15 @@ RSpec.describe Builders::ReviewCoverage do
         expect(review_coverage.coverage_percentage).to eq(0)
       end
     end
+
+    context 'when the pull request has no files' do
+      let(:total_files) { 0 }
+
+      it 'creates a review coverage with zero coverage' do
+        review_coverage = subject
+        expect(review_coverage.total_files_changed).to eq(0)
+        expect(review_coverage.coverage_percentage).to eq(0)
+      end
+    end
   end
 end


### PR DESCRIPTION
# Fix Review Coverage when the PR has no files

## Problem
When a pull request has no files changed, the review coverage calculation was causing a division by zero error, resulting in an undefined coverage percentage.

## Solution
Return 0 when `total_files` is zero, preventing the division by zero error.

## Changes
- **File**: `app/services/builders/review_coverage.rb`
  - Added early return with 0 when `total_files.zero?` in the `coverage_percentage` method

## Testing
- **File**: `spec/services/builders/review_coverage_spec.rb`
  - Added test case for when pull request has no files
  - Verifies that coverage percentage returns 0 and total files changed is 0

## Impact
- Prevents application errors when processing pull requests with no file changes
- Ensures consistent behavior for edge cases in review coverage calculations
- Maintains data integrity in metrics reporting