### PR TITLE
[FIX] Public endpoints being indexed

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -131,21 +131,20 @@ jobs:
       - name: Run tests
         run: |
           bundle exec rspec
-      - name: Setup sonar scanner
-        uses: warchant/setup-sonar-scanner@v3
       - name: Run Sonarqube analysis
-        run: |
-          sonar-scanner \
-            -Dsonar.qualitygate.wait=true \
-            -Dsonar.host.url=$SONAR_URL \
-            -Dsonar.login=$SONAR_TOKEN \
-            -Dsonar.projectKey=$SONAR_PROJECT_KEY \
-            -Dsonar.scm.provider=git \
-            -Dsonar.nodejs.executable=$(which node) \
-            -Dsonar.projectVersion=$(echo $GITHUB_SHA | cut -c1-8) \
-            -Dsonar.sources=app/controllers,app/jobs,app/mailers,app/models,app/views \
-            -Dsonar.tests=spec \
-            -Dsonar.test.inclusions=**/*_spec.rb \
-            -Dsonar.test.exclusions=bin,config,db,app/javascript,app/assets \
-            -Dsonar.projectBaseDir=. \
-            -Dsonar.ruby.coverage.reportPaths=coverage/coverage.json \
+        uses: SonarSource/sonarqube-scan-action@v4
+        env:
+          SONAR_HOST_URL: ${{ secrets.SONAR_URL }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        with:
+          args: >
+            -Dsonar.qualitygate.wait=true
+            -Dsonar.projectKey=${{ secrets.SONAR_PROJECT_KEY }}
+            -Dsonar.scm.provider=git
+            -Dsonar.projectVersion=${{ github.sha }}
+            -Dsonar.sources=app/controllers,app/jobs,app/mailers,app/models,app/views
+            -Dsonar.tests=spec
+            -Dsonar.test.inclusions=**/*_spec.rb
+            -Dsonar.test.exclusions=bin,config,db,app/javascript,app/assets
+            -Dsonar.projectBaseDir=.
+            -Dsonar.ruby.coverage.reportPaths=coverage/coverage.json

--- a/app/admin/file_ignoring_rules.rb
+++ b/app/admin/file_ignoring_rules.rb
@@ -38,7 +38,7 @@ ActiveAdmin.register FileIgnoringRule do
     end
 
     def create_rule_for_all_languages(regex)
-      Language.where.not(name: 'unassigned').each do |language|
+      Language.where.not(name: 'unassigned').find_each do |language|
         FileIgnoringRule.create!(
           language: language,
           regex: regex

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -76,9 +76,12 @@ canvas[style] {
   float:left;
   height: 100vh;
   overflow-y: auto;
+  display: flex;
+  flex-direction: column;
   padding-left: 50px;
   padding-right: 50px;
   padding-top: 53px;
+  padding-bottom: 2rem;
 
 }
 

--- a/app/assets/stylesheets/layout/_login.scss
+++ b/app/assets/stylesheets/layout/_login.scss
@@ -1,0 +1,31 @@
+.login-page {
+  align-items: center;
+  background-color: $primary-color;
+  display: flex;
+  justify-content: center;
+  min-height: 100vh;
+  padding: 1rem;
+}
+
+.login-card {
+  background-color: $white;
+  border-radius: 10px;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.2);
+  max-width: 400px;
+  padding: 2.5rem 2rem;
+  width: 100%;
+
+  .login-logo {
+    display: block;
+    height: 48px;
+    margin: 0 auto 1rem;
+  }
+
+  .login-title {
+    color: $primary-color;
+    font-size: 1.25rem;
+    font-weight: 600;
+    margin-bottom: 1.5rem;
+    text-align: center;
+  }
+}

--- a/app/assets/stylesheets/shared/_sidebar.scss
+++ b/app/assets/stylesheets/shared/_sidebar.scss
@@ -51,6 +51,23 @@
   line-height: 19px;
 }
 
+.sidebar-admin-link {
+  margin-top: 2rem;
+
+  a {
+    color: $white;
+    font-size: 14px;
+    line-height: 21px;
+    text-decoration: none;
+
+    &:hover,
+    &:focus {
+      color: $white;
+      text-decoration: underline;
+    }
+  }
+}
+
 .sidebar-logout {
   border-top: 1px solid rgba($white, 0.15);
   margin-top: auto;

--- a/app/assets/stylesheets/shared/_sidebar.scss
+++ b/app/assets/stylesheets/shared/_sidebar.scss
@@ -50,3 +50,9 @@
   font-size: 16px;
   line-height: 19px;
 }
+
+.sidebar-logout {
+  border-top: 1px solid rgba($white, 0.15);
+  margin-top: auto;
+  padding-top: 1.5rem;
+}

--- a/app/controllers/admin_users/sessions_controller.rb
+++ b/app/controllers/admin_users/sessions_controller.rb
@@ -1,0 +1,7 @@
+module AdminUsers
+  # Serves the sign-in page with the Engineering Metrics styling instead of the
+  # default Active Admin login screen. All other Devise behaviour is inherited.
+  class SessionsController < ActiveAdmin::Devise::SessionsController
+    layout 'devise'
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,4 @@
 class ApplicationController < ActionController::Base
+  before_action :authenticate_admin_user!, unless: :devise_controller?
   before_action { Rack::MiniProfiler.authorize_request if current_admin_user.present? }
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,13 @@
 class ApplicationController < ActionController::Base
+  before_action :set_robots_noindex_header
   before_action :authenticate_admin_user!, unless: :devise_controller?
   before_action { Rack::MiniProfiler.authorize_request if current_admin_user.present? }
+
+  private
+
+  # Keep every response out of search engines. This is an internal, admin-only
+  # tool, so we never want its pages (including the login screen) indexed.
+  def set_robots_noindex_header
+    response.set_header('X-Robots-Tag', 'noindex, nofollow, noarchive')
+  end
 end

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -1,5 +1,6 @@
 class WebhookController < ApplicationController
   skip_before_action :verify_authenticity_token
+  skip_before_action :authenticate_admin_user!
   before_action :set_params
 
   def handle

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -120,7 +120,7 @@ class Repository < ApplicationRecord
   }
 
   scope :without_cc, lambda {
-    left_joins(:code_climate_repository_metric).where(code_climate_repository_metrics: { id: nil })
+    where.missing(:code_climate_repository_metric)
   }
 
   scope :without_cc_rate, lambda {

--- a/app/services/builders/chartkick/helpers/success_rate.rb
+++ b/app/services/builders/chartkick/helpers/success_rate.rb
@@ -26,7 +26,7 @@ module Builders
         end
 
         def total
-          @total ||= intervals.map { |interval| interval[1] }.sum
+          @total ||= intervals.pluck(1).sum
         end
 
         def successful
@@ -36,7 +36,7 @@ module Builders
         end
 
         def time_interval_range
-          intervals.map { |tuple| tuple[0] }
+          intervals.pluck(0)
                    .reject { |range| range.include?('+') }
                    .select { |range| range.split('-')[1].to_i <= metric_setting }
         end

--- a/app/services/code_climate/api/snapshot.rb
+++ b/app/services/code_climate/api/snapshot.rb
@@ -8,7 +8,7 @@ module CodeClimate
 
       def ratings
         ratings_json = @json.dig('attributes', 'ratings')
-        ratings_json ? ratings_json.map { |json| json['letter'] } : []
+        ratings_json ? ratings_json.pluck('letter') : []
       end
 
       def snapshot_time

--- a/app/services/github_client/base.rb
+++ b/app/services/github_client/base.rb
@@ -41,7 +41,7 @@ module GithubClient
         request.params = request_params
       end
 
-      new_users = JSON.parse(response.body).map { |user| user['login'] }
+      new_users = JSON.parse(response.body).pluck('login')
 
       return accumulated_users if new_users.empty?
 

--- a/app/views/admin_users/sessions/new.html.erb
+++ b/app/views/admin_users/sessions/new.html.erb
@@ -1,0 +1,27 @@
+<%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
+  <div class="mb-3">
+    <%= f.label :email, class: 'form-label' %>
+    <%= f.email_field :email,
+                      autofocus: true,
+                      autocomplete: 'email',
+                      class: 'form-control input-height' %>
+  </div>
+
+  <div class="mb-3">
+    <%= f.label :password, class: 'form-label' %>
+    <%= f.password_field :password,
+                        autocomplete: 'current-password',
+                        class: 'form-control input-height' %>
+  </div>
+
+  <% if devise_mapping.rememberable? %>
+    <div class="form-check mb-3">
+      <%= f.check_box :remember_me, class: 'form-check-input' %>
+      <%= f.label :remember_me, class: 'form-check-label' %>
+    </div>
+  <% end %>
+
+  <div class="d-grid">
+    <%= f.submit 'Sign in', class: 'btn btn-primary input-height' %>
+  </div>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>Engineering Metrics</title>
+    <meta name="robots" content="noindex, nofollow, noarchive" />
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
     <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <title>Engineering Metrics</title>
     <meta name="robots" content="noindex, nofollow, noarchive" />

--- a/app/views/layouts/devise.html.erb
+++ b/app/views/layouts/devise.html.erb
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Engineering Metrics</title>
+    <%= csrf_meta_tags %>
+    <%= csp_meta_tag %>
+
+    <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
+    <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
+  </head>
+
+  <body>
+    <div class="login-page">
+      <div class="login-card">
+        <%= image_tag('logo-nav.svg', class: 'login-logo', alt: 'Rootstrap') %>
+        <h1 class="login-title">Engineering Metrics</h1>
+
+        <% if notice.present? %>
+          <div class="alert alert-success" role="alert"><%= notice %></div>
+        <% end %>
+        <% if alert.present? %>
+          <div class="alert alert-danger" role="alert"><%= alert %></div>
+        <% end %>
+
+        <%= yield %>
+      </div>
+    </div>
+  </body>
+</html>

--- a/app/views/layouts/devise.html.erb
+++ b/app/views/layouts/devise.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <title>Engineering Metrics</title>
+    <title><%= t('admin_panel.title') %></title>
     <meta name="robots" content="noindex, nofollow, noarchive" />
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
@@ -14,7 +14,7 @@
     <div class="login-page">
       <div class="login-card">
         <%= image_tag('logo-nav.svg', class: 'login-logo', alt: 'Rootstrap') %>
-        <h1 class="login-title">Engineering Metrics</h1>
+        <h1 class="login-title"><%= t('admin_panel.title') %></h1>
 
         <% if notice.present? %>
           <div class="alert alert-success" role="alert"><%= notice %></div>

--- a/app/views/layouts/devise.html.erb
+++ b/app/views/layouts/devise.html.erb
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>Engineering Metrics</title>
+    <meta name="robots" content="noindex, nofollow, noarchive" />
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 

--- a/app/views/layouts/devise.html.erb
+++ b/app/views/layouts/devise.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <title>Engineering Metrics</title>
     <meta name="robots" content="noindex, nofollow, noarchive" />

--- a/app/views/layouts/sidebar_metrics.html.erb
+++ b/app/views/layouts/sidebar_metrics.html.erb
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>Engineering Metrics</title>
+    <meta name="robots" content="noindex, nofollow, noarchive" />
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 

--- a/app/views/layouts/sidebar_metrics.html.erb
+++ b/app/views/layouts/sidebar_metrics.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <title>Engineering Metrics</title>
     <meta name="robots" content="noindex, nofollow, noarchive" />

--- a/app/views/shared/_sidebar.html.erb
+++ b/app/views/shared/_sidebar.html.erb
@@ -7,6 +7,12 @@
   </div>
 
 
+  <% if admin_user_signed_in? %>
+    <div class="sidebar-admin-link">
+      <%= link_to 'Admin Panel', admin_root_path %>
+    </div>
+  <% end %>
+
   <%= yield(:development_metrics_sidebar) %>
   <% # yield(:open_source_sidebar) %>
 

--- a/app/views/shared/_sidebar.html.erb
+++ b/app/views/shared/_sidebar.html.erb
@@ -9,3 +9,12 @@
 
   <%= yield(:development_metrics_sidebar) %>
   <% # yield(:open_source_sidebar) %>
+
+  <% if admin_user_signed_in? %>
+    <div class="sidebar-logout">
+      <%= link_to 'Log out',
+                  destroy_admin_user_session_path,
+                  method: :delete,
+                  class: 'btn btn-primary w-100' %>
+    </div>
+  <% end %>

--- a/config/initializers/active_admin.rb
+++ b/config/initializers/active_admin.rb
@@ -46,6 +46,14 @@ ActiveAdmin.setup do |config|
   # This will ONLY change the title for the admin section. Other
   # namespaces will continue to use the main "site_title" configuration.
 
+  # Add a top-bar menu item so admins can navigate from the admin panel back to
+  # the (now authenticated) Engineering Metrics dashboard.
+  config.namespace :admin do |admin|
+    admin.build_menu :default do |menu|
+      menu.add label: 'Engineering Metrics', url: '/', priority: 0
+    end
+  end
+
   # == User Authentication
   #
   # Active Admin will automatically call an authentication

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -49,6 +49,8 @@ en:
         see_settings: For more information about the success rate of the metric 
         see_alert: To change alert settings 
       subject: Engineering Metrics - Alert metric below threshold
+  admin_panel:
+    title: 'Engineering Metrics'
   alerts:
     department_or_repository_presence: 'Repository or department must be selected'
     emails_not_an_array: 'is not an array of emails'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,9 @@ require 'sidekiq/cron/web'
 
 Rails.application.routes.draw do
   root to: 'development_metrics#index'
-  devise_for :admin_users, ActiveAdmin::Devise.config
+  devise_for :admin_users, ActiveAdmin::Devise.config.deep_merge(
+    controllers: { sessions: 'admin_users/sessions' }
+  )
   # TODO: Remove or update ExceptionHunter
   # authenticate :admin_user do
   #   ExceptionHunter.routes(self)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,9 @@ Rails.application.routes.draw do
   #   ExceptionHunter.routes(self)
   # end
   ActiveAdmin.routes(self)
-  mount Sidekiq::Web => '/sidekiq'
+  authenticate :admin_user do
+    mount Sidekiq::Web => '/sidekiq'
+  end
   post '/github_event_handler', to: 'webhook#handle'
   resources :development_metrics, only: [] do
     collection do

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -42,9 +42,9 @@ if Rails.env.development?
       FactoryBot.create(:user, login: name)
     end
 
-    User.all.each { |user| UsersRepository.create!(user: user, repository: repository) }
+    User.find_each { |user| UsersRepository.create!(user: user, repository: repository) }
 
-    UsersRepository.all.each do |uspr|
+    UsersRepository.find_each do |uspr|
       20.times do |v|
         FactoryBot.create(:metric, ownable: uspr, value_timestamp: Time.zone.now - v.days)
       end
@@ -59,7 +59,7 @@ if Rails.env.development?
       end
     end
 
-    Repository.all.each do |uspr|
+    Repository.find_each do |uspr|
       20.times do |v|
         FactoryBot.create(:metric, ownable: uspr, value_timestamp: Time.zone.now - v.days)
       end
@@ -90,7 +90,7 @@ if Rails.env.development?
       FactoryBot.create(:user, login: name)
     end
 
-    User.all.each { |user| UsersRepository.create!(user: user, repository: second_repository) }
+    User.find_each { |user| UsersRepository.create!(user: user, repository: second_repository) }
 
     Technology.create_with(keyword_string: 'ruby,rails').find_or_create_by!(name: 'ruby')
     Technology.create_with(keyword_string: 'python,django').find_or_create_by!(name: 'python')

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,10 +1,5 @@
 # See https://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
 #
-# This is an internal, admin-only application. We want every page removed from
-# search engines. Removal is driven by the `noindex` directive sent on every
-# response (the `X-Robots-Tag` header in ApplicationController and the
-# `<meta name="robots">` tag in the layouts).
-#
 # We deliberately DO NOT `Disallow: /` here: blocking crawling would stop
 # search engines from re-fetching the pages and seeing the `noindex`, so any
 # already-indexed URLs would linger in results. Once the pages have dropped

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,1 +1,13 @@
 # See https://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
+#
+# This is an internal, admin-only application. We want every page removed from
+# search engines. Removal is driven by the `noindex` directive sent on every
+# response (the `X-Robots-Tag` header in ApplicationController and the
+# `<meta name="robots">` tag in the layouts).
+#
+# We deliberately DO NOT `Disallow: /` here: blocking crawling would stop
+# search engines from re-fetching the pages and seeing the `noindex`, so any
+# already-indexed URLs would linger in results. Once the pages have dropped
+# out of the index, this can be tightened to `Disallow: /`.
+User-agent: *
+Allow: /

--- a/spec/controllers/admin_users/sessions_controller_spec.rb
+++ b/spec/controllers/admin_users/sessions_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe AdminUsers::SessionsController, :unauthenticated, type: :controller do
-  before { @request.env['devise.mapping'] = Devise.mappings[:admin_user] }
+  before { request.env['devise.mapping'] = Devise.mappings[:admin_user] }
 
   describe 'GET #new' do
     it 'is reachable without authentication so logged-out users can sign in' do

--- a/spec/controllers/admin_users/sessions_controller_spec.rb
+++ b/spec/controllers/admin_users/sessions_controller_spec.rb
@@ -9,5 +9,11 @@ RSpec.describe AdminUsers::SessionsController, :unauthenticated, type: :controll
 
       expect(response).to have_http_status(:ok)
     end
+
+    it 'tells crawlers not to index the login page' do
+      get :new
+
+      expect(response.headers['X-Robots-Tag']).to eq('noindex, nofollow, noarchive')
+    end
   end
 end

--- a/spec/controllers/admin_users/sessions_controller_spec.rb
+++ b/spec/controllers/admin_users/sessions_controller_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe AdminUsers::SessionsController, :unauthenticated, type: :controller do
+  before { @request.env['devise.mapping'] = Devise.mappings[:admin_user] }
+
+  describe 'GET #new' do
+    it 'is reachable without authentication so logged-out users can sign in' do
+      get :new
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
+end

--- a/spec/controllers/webhook_controller_spec.rb
+++ b/spec/controllers/webhook_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe WebhookController, type: :controller do
+RSpec.describe WebhookController, :unauthenticated, type: :controller do
   subject { post :handle, params: params }
   let(:headers) { { 'X-GitHub-Event': 'pull_request', 'X-Hub-Signature': '' } }
   let(:params) { { payload: (create :pull_request_payload).to_json } }

--- a/spec/factories/admin_users.rb
+++ b/spec/factories/admin_users.rb
@@ -19,7 +19,7 @@
 
 FactoryBot.define do
   factory :admin_user do
-    email { 'admin@example.com' }
+    sequence(:email) { |n| "admin#{n}@example.com" }
     password { 'password' }
     password_confirmation { 'password' }
   end

--- a/spec/requests/authentication_spec.rb
+++ b/spec/requests/authentication_spec.rb
@@ -15,6 +15,14 @@ describe 'Endpoint authentication', :unauthenticated, type: :request do
 
       expect(response).to have_http_status(:ok)
     end
+
+    it 'tells crawlers not to index served pages' do
+      sign_in create(:admin_user)
+
+      get root_path
+
+      expect(response.headers['X-Robots-Tag']).to eq('noindex, nofollow, noarchive')
+    end
   end
 
   describe 'the GitHub webhook endpoint' do

--- a/spec/requests/authentication_spec.rb
+++ b/spec/requests/authentication_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+describe 'Endpoint authentication', :unauthenticated, type: :request do
+  describe 'a protected browser-facing endpoint' do
+    it 'redirects anonymous visitors to the login page' do
+      get root_path
+
+      expect(response).to redirect_to(new_admin_user_session_path)
+    end
+
+    it 'grants access once an admin is signed in' do
+      sign_in create(:admin_user)
+
+      get root_path
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe 'the GitHub webhook endpoint' do
+    before do
+      allow(OpenSSL::HMAC).to receive(:hexdigest).and_return(true)
+      allow(ActiveSupport::SecurityUtils).to receive(:secure_compare).and_return(true)
+      allow_any_instance_of(GithubService).to receive(:call).and_return(true)
+    end
+
+    it 'stays public and is not redirected to the login page' do
+      post '/github_event_handler',
+           params: { payload: { action: 'opened' }.to_json },
+           headers: { 'X-GitHub-Event' => 'pull_request' }
+
+      expect(response).to have_http_status(:ok)
+      expect(response).not_to redirect_to(new_admin_user_session_path)
+    end
+  end
+end

--- a/spec/requests/code_owner_repositories_spec.rb
+++ b/spec/requests/code_owner_repositories_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'CodeOwnersRepositoriesController' do
     context 'when user has repositories as code owner' do
       before do
         create_list(:repository, repositories_count)
-        Repository.all.each { |repository| repository.code_owners << user }
+        Repository.find_each { |repository| repository.code_owners << user }
         subject
       end
 

--- a/spec/requests/pull_requests/pull_request_size_prs_repository/index_spec.rb
+++ b/spec/requests/pull_requests/pull_request_size_prs_repository/index_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe 'PullRequests::PullRequestSizePrsRepositoryController' do
     end
 
     it 'returns data with the correct keys' do
-      data = JSON.parse(response.body)
+      data = response.parsed_body
 
       expect(data.keys).to match_array(['100-199', '1000+', '500-599'])
     end

--- a/spec/services/github_client/organization_spec.rb
+++ b/spec/services/github_client/organization_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe GithubClient::Organization do
       end
 
       it 'returns the members from all pages' do
-        expect(subject.members).to match_array(members_payloads.map { |user| user['login'] })
+        expect(subject.members).to match_array(members_payloads.pluck('login'))
       end
     end
   end

--- a/spec/support/helpers/authentication.rb
+++ b/spec/support/helpers/authentication.rb
@@ -1,0 +1,20 @@
+module AuthenticationHelper
+  def sign_in_admin_user
+    sign_in(create(:admin_user))
+  end
+end
+
+# Every browser-facing endpoint now sits behind `authenticate_admin_user!`
+# (see ApplicationController). Sign a default admin in for request and controller
+# specs so they exercise the protected behaviour. Tag an example or group with
+# `unauthenticated: true` to opt out (e.g. the public webhook, or specs that
+# assert the redirect to the login page).
+RSpec.configure do |config|
+  config.include AuthenticationHelper
+
+  %i[request controller].each do |spec_type|
+    config.before(:each, type: spec_type) do |example|
+      sign_in_admin_user unless example.metadata[:unauthenticated]
+    end
+  end
+end


### PR DESCRIPTION
## What does this PR do?

This PR fixes these critical issues:
- All pages were being indexed by Search Engines.
- All engineering metric pages and data were publicly available, so anyone could access them with a simple Google search.

**Note:** Only webhook endpoints are kept with no admin auth, so GitHub metric reports continue to work.

### Resolves
- All engineering metric pages are now behind authentication. We are reusing Devise auth, so Admin Users are the ones authorized to see the information.
- Added robots.txt and header instructions to avoid further indexing.
- Correct several linter issues.


### Preview


https://github.com/user-attachments/assets/6f40bdeb-911f-4d2a-b1e8-34dbbf3a16ee

